### PR TITLE
feat(data_service): add SQLite OHLCV cache for faster data_service startup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,8 @@ test2.py
 .env
 workdir/scripts/*.toml
 
-# Ignore OHLCV Cache file
-!workdir/data/cache/*
+# Ignore SQLite cache files but keep the directory
+workdir/data/cache/*.sqlite
 
 # Ignore OHLCV and TOML files in workdir/data/
 workdir/data/ccxt*.ohlcv

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,9 @@ test2.py
 .env
 workdir/scripts/*.toml
 
+# Ignore OHLCV Cache file
+!workdir/data/cache/*
+
 # Ignore OHLCV and TOML files in workdir/data/
 workdir/data/ccxt*.ohlcv
 workdir/data/ccxt*.toml

--- a/data_service/collector_loop.py
+++ b/data_service/collector_loop.py
@@ -7,7 +7,7 @@ from typing import Callable, Optional, Awaitable
 import ccxt.pro as ccxt
 
 from state import DataState
-from ohlcv_io import parse_timeframe_to_ms
+from ohlcv_io import convert_timeframe
 
 
 async def watch_trades_loop(
@@ -68,7 +68,7 @@ async def fix_missing_bars_loop(
     state: DataState,
     check_interval_sec: float = 0.1,
 ) -> None:
-    tf_ms = parse_timeframe_to_ms(timeframe)
+    tf_ms = convert_timeframe(timeframe, to_ms=True)
     grace_ms = 0.2 * 1000
     ex = getattr(ccxt, exchange_name)(config={})
 

--- a/data_service/file_update_loop.py
+++ b/data_service/file_update_loop.py
@@ -1,20 +1,35 @@
 from __future__ import annotations
 
 import asyncio
-import os
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, UTC
+from dateutil.relativedelta import relativedelta
 from pathlib import Path
 from typing import Awaitable, Callable, Optional
 
 from config import DataServiceConfig
+from pynecore.cli.commands.data import parse_date_or_days
+from pynecore.core.ohlcv_file import OHLCVReader
+from pynecore.cli.app import app_state
 from ohlcv_io import (
-    parse_timeframe_to_ms,
+    convert_timeframe,
     download_history,
     fix_last_open_if_needed,
     fetch_and_update_ohlcv_data,
+    download_history_range_into_cache,
     update_ohlcv_data,
 )
+from ohlcv_cache import (
+    init_cache,
+    cache_has_data,
+    get_last_ts,
+    get_min_ts,
+    import_from_ohlcv,
+    export_to_ohlcv,
+    upsert_bars,
+    export_to_ohlcv_since,
+)
+from ohlcv_paths import make_cache_path
 from state import DataState
 
 
@@ -31,25 +46,143 @@ async def file_update_loop(
     exchange = config.exchange
     symbol = config.symbol
     timeframe = config.timeframe
+    cache_path = make_cache_path()
+    init_cache(cache_path)
+    # print(f"[data_service] sqlite cache path: {cache_path}")
 
     # Get history_since from the config
     realtime_section: dict = config.realtime_section
     history_since = realtime_section.get("history_since", "")
 
     start_timestamp: Optional[int] = None
+    cache_ready = cache_has_data(cache_path, provider, exchange, symbol, timeframe)
+    history_download_complete: bool = False
+    desired_dt: Optional[datetime] = None
+    export_start_ts: Optional[int] = None
+    # Resolve desired start time from history_since or default window.
+    if history_since:
+        try:
+            desired_dt = parse_date_or_days(history_since)
+            if desired_dt.tzinfo is None:
+                desired_dt = desired_dt.replace(tzinfo=UTC)
+        except Exception:
+            desired_dt = None
+    else:
+        tf_modifier = timeframe[-1]
+        tf_value = int(timeframe[:-1])
+        month_ago = 1 if tf_modifier == "m" and tf_value == 1 else 2
+        desired_dt = (datetime.now(UTC) - relativedelta(months=month_ago)).replace(second=0, microsecond=0)
 
-    if ohlcv_path.exists() and history_since == "":
-        from pynecore.core.ohlcv_file import OHLCVReader
+    if ohlcv_path.exists() and desired_dt is not None:
         with OHLCVReader(ohlcv_path) as reader:
-            start_timestamp = reader.start_timestamp
+            start_ts = reader.start_timestamp
             reader.close()
+        if start_ts is not None and int(start_ts) != int(desired_dt.timestamp()):
+            export_start_ts = int(desired_dt.timestamp())
+            print("[data_service] history_since changed; ohlcv will be regenerated from cache")
 
-    # Remove all the data file
-    for file_path in [ohlcv_path, toml_path]:
-        if file_path.exists():
-            os.remove(file_path)
+    if cache_ready:
+        # Ensure toml exists before using cached data.
+        if not toml_path.exists():
+            try:
+                provider_module = __import__(f"pynecore.providers.{provider}", fromlist=[""])
+                provider_class = getattr(
+                    provider_module,
+                    [p for p in dir(provider_module) if p.endswith("Provider")][0],
+                )
+                provider_instance = provider_class(
+                    symbol=f"{exchange}:{symbol}".upper(),
+                    timeframe=convert_timeframe(timeframe),
+                    ohlv_dir=ohlcv_path.parent,
+                    config_dir=app_state.config_dir,
+                )
+                sym_info = provider_instance.get_symbol_info(force_update=False)
+                sym_info.save_toml(toml_path)
+                print("[data_service] toml regenerated from provider symbol info")
+            except Exception as e:
+                import traceback
+                print(f"[data_service] toml regeneration failed: {e!r}")
+                print(traceback.format_exc())
+                cache_ready = False
+        else:
+            print("[data_service] sqlite cache found; syncing from last_ts")
+        # Backfill cache if desired history is older than cached min_ts.
+        if cache_ready and desired_dt is not None:
+            try:
+                desired_ts = int(desired_dt.timestamp())
+                min_ts = get_min_ts(cache_path, provider, exchange, symbol, timeframe)
+                if min_ts is not None and desired_ts < min_ts:
+                    print(f"[data_service] backfilling cache: {desired_ts} -> {min_ts}")
+                    with ThreadPoolExecutor() as ex:
+                        ok = ex.submit(
+                            download_history_range_into_cache,
+                            cache_path=cache_path,
+                            provider=provider,
+                            exchange=exchange,
+                            symbol=symbol,
+                            timeframe=timeframe,
+                            time_from=desired_dt,
+                            time_to=datetime.fromtimestamp(min_ts, UTC),
+                        ).result()
+                    if ok:
+                        print("[data_service] backfill updated cache via download_history")
+                else:
+                    print(f"[data_service] backfill not needed (desired_ts={desired_ts}, min_ts={min_ts})")
+            except Exception as e:
+                print(f"[data_service] history_since backfill skipped: {e}")
+        # Refresh cache from last_ts (include last bar to finalize).
+        last_ts = get_last_ts(cache_path, provider, exchange, symbol, timeframe)
+        if last_ts is not None:
+            with ThreadPoolExecutor() as ex:
+                ok = ex.submit(
+                    download_history_range_into_cache,
+                    cache_path=cache_path,
+                    provider=provider,
+                    exchange=exchange,
+                    symbol=symbol,
+                    timeframe=timeframe,
+                    time_from=datetime.fromtimestamp(
+                        int(last_ts) - int(convert_timeframe(timeframe, to_ms=True) / 1000),
+                        UTC,
+                    ),
+                    time_to=datetime.now(UTC),
+                ).result()
+            if ok:
+                print("[data_service] sqlite cache updated via download_history")
+        # Export cache into ohlcv for runner consumption.
+        if export_start_ts is not None:
+            export_to_ohlcv_since(
+                cache_path,
+                provider,
+                exchange,
+                symbol,
+                timeframe,
+                ohlcv_path,
+                export_start_ts,
+            )
+        else:
+            export_to_ohlcv(cache_path, provider, exchange, symbol, timeframe, ohlcv_path)
+        if ohlcv_path.exists():
+            print("[data_service] ohlcv regenerated from sqlite cache")
+            history_download_complete = True
+            state.pending_prerun_event = {
+                "type": "prerun_ready_after_history_download",
+                "ohlcv_path": str(ohlcv_path),
+                "toml_path": str(toml_path),
+                "confirmed_bar_and_new_bar": None
+            }
+    if not cache_ready:
+        # No cache: start history download flow.
+        print("[data_service] sqlite cache missing; starting history download")
+        if ohlcv_path.exists() and history_since == "":
+            with OHLCVReader(ohlcv_path) as reader:
+                start_timestamp = reader.start_timestamp
+                reader.close()
+        for file_path in (ohlcv_path, toml_path):
+            if file_path.exists():
+                file_path.unlink()
 
-    timeframe_ms = parse_timeframe_to_ms(timeframe)
+    timeframe_ms = convert_timeframe(timeframe, to_ms=True)
     pre_run_script_time = timeframe_ms / 2
     fixed_open_price: float = 0.0
     open_fix_done = False
@@ -57,7 +190,6 @@ async def file_update_loop(
     # Flag to prevent duplicate prerun_ready events
     prerun_sent_for_bar_ts: Optional[int] = None
 
-    history_download_complete: bool = False
     first_fetch_after_download_done: bool = False
 
     while True:
@@ -68,6 +200,7 @@ async def file_update_loop(
 
             # 1) file missing -> download history
             if not ohlcv_path.exists():
+                # Compute since date for history download.
                 since = None
                 if start_timestamp is not None:
                     since = datetime.fromtimestamp(start_timestamp).strftime("%Y-%m-%d")
@@ -87,11 +220,13 @@ async def file_update_loop(
                 if not ok:
                     for fp in (ohlcv_path, toml_path):
                         if fp.exists():
-                            os.remove(fp)
+                            fp.unlink()
                     continue
                 else:
                     history_download_complete = True
                     first_fetch_after_download_done = False
+                    import_from_ohlcv(cache_path, provider, exchange, symbol, timeframe, ohlcv_path)
+                    # print("[data_service] sqlite cache populated from downloaded ohlcv")
 
                     # Store pending event instead of emitting immediately
                     # This will be sent when runner_service connects
@@ -114,15 +249,35 @@ async def file_update_loop(
                 and (not open_fix_done)
                 and (datetime.now().timestamp() * 1000 >= bars[1][0] + pre_run_script_time)
             ):
+                # Wait for history download and fix last open if needed.
                 if not history_download_complete:
                     continue
 
                 # Fetch candles via fetch_ohlcv at the first pre_run after history download
                 if not first_fetch_after_download_done:
-                    fetch_and_update_ohlcv_data(exchange, symbol, timeframe, str(ohlcv_path))
+                    res = fetch_and_update_ohlcv_data(exchange, symbol, timeframe, str(ohlcv_path))
+                    if res:
+                        # print(f"[data_service] pre_run fetch updated {len(res)} bars")
+                        cache_rows = []
+                        with OHLCVReader(ohlcv_path) as reader:
+                            for i in range(len(res)):
+                                bar = reader.read(reader.size - (len(res) - i))
+                                cache_rows.append(bar)
+                            reader.close()
+                        upsert_bars(cache_path, provider, exchange, symbol, timeframe, cache_rows)
+                        last_ts = get_last_ts(cache_path, provider, exchange, symbol, timeframe)
+                        # print(f"[data_service] sqlite cache updated from pre_run fetch (last_ts={last_ts})")
                     first_fetch_after_download_done = True
                 else:
                     fixed_open_price = fix_last_open_if_needed(str(ohlcv_path))
+                    if fixed_open_price > 0.0:
+                        # Fix the last bar stored in the ohlcv cache
+                        cache_rows = []
+                        with OHLCVReader(ohlcv_path) as reader:
+                            last_bar = reader.read(reader.size - 1)
+                            cache_rows.append(last_bar)
+                            upsert_bars(cache_path, provider, exchange, symbol, timeframe, cache_rows)
+                            reader.close()
 
                 open_fix_done = True
 
@@ -145,6 +300,7 @@ async def file_update_loop(
 
             # 3) bars>=3 -> keep 2 and update file
             if len(bars) >= 3 and ohlcv_path.exists():
+                # Apply live bars and emit run_ready if ohlcv is updated.
                 confirmed_bar_and_new_bar = bars[1:]  # confirmed, new
                 state.live_bars = confirmed_bar_and_new_bar
 
@@ -156,6 +312,7 @@ async def file_update_loop(
 
                 incremented_size = update_ohlcv_data(str(ohlcv_path), confirmed_bar_and_new_bar)
                 if incremented_size > 0:
+                    # Emit run_ready signal to runner_service
                     await emit_event(
                         {
                             "type": "run_ready",
@@ -164,6 +321,17 @@ async def file_update_loop(
                             "confirmed_bar_and_new_bar": confirmed_bar_and_new_bar,  # confirmed/new
                         }
                     )
+                    # SQLite cache sync
+                    # print(f"[data_service] ohlcv updated from live bars; syncing sqlite cache, {confirmed_bar_and_new_bar}")
+                    with OHLCVReader(ohlcv_path) as reader:
+                        last_confirmed_bar = reader.read(reader.size - 2)
+                        last_new_bar = reader.read(reader.size - 1)
+                        cache_rows = []
+                        for cd in [last_confirmed_bar, last_new_bar]:
+                            cache_rows.append([cd.timestamp, cd.open, cd.high, cd.low, cd.close, cd.volume])
+                        upsert_bars(cache_path, provider, exchange, symbol, timeframe, cache_rows)
+                        # print("[data_service] sqlite cache synced")
+                        reader.close()
                 else:
                     print(f"Failed to update OHLCV file with bars: {confirmed_bar_and_new_bar}")
 

--- a/data_service/ohlcv_cache.py
+++ b/data_service/ohlcv_cache.py
@@ -1,0 +1,228 @@
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from typing import Iterable, Sequence
+
+from pynecore.core.ohlcv_file import OHLCVReader, OHLCVWriter
+from pynecore.types.ohlcv import OHLCV
+
+
+def init_cache(db_path: Path) -> None:
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(db_path) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS bars (
+                provider TEXT NOT NULL,
+                exchange TEXT NOT NULL,
+                symbol TEXT NOT NULL,
+                timeframe TEXT NOT NULL,
+                ts INTEGER NOT NULL,
+                open REAL NOT NULL,
+                high REAL NOT NULL,
+                low REAL NOT NULL,
+                close REAL NOT NULL,
+                volume REAL NOT NULL,
+                PRIMARY KEY (provider, exchange, symbol, timeframe, ts)
+            )
+            """
+        )
+
+
+def cache_has_data(
+    db_path: Path,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+) -> bool:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT 1 FROM bars
+            WHERE provider = ? AND exchange = ? AND symbol = ? AND timeframe = ?
+            LIMIT 1
+            """,
+            (provider, exchange, symbol, timeframe),
+        ).fetchone()
+        return row is not None
+
+
+def get_last_ts(
+    db_path: Path,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+) -> int | None:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT MAX(ts) FROM bars
+            WHERE provider = ? AND exchange = ? AND symbol = ? AND timeframe = ?
+            """,
+            (provider, exchange, symbol, timeframe),
+        ).fetchone()
+        return row[0] if row and row[0] is not None else None
+
+
+def get_min_ts(
+    db_path: Path,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+) -> int | None:
+    with sqlite3.connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT MIN(ts) FROM bars
+            WHERE provider = ? AND exchange = ? AND symbol = ? AND timeframe = ?
+            """,
+            (provider, exchange, symbol, timeframe),
+        ).fetchone()
+        return row[0] if row and row[0] is not None else None
+
+
+def upsert_bars(
+    db_path: Path,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    bars: Iterable[Sequence[float]],
+) -> None:
+    rows = [
+        (
+            provider,
+            exchange,
+            symbol,
+            timeframe,
+            int(bar[0]),
+            float(bar[1]),
+            float(bar[2]),
+            float(bar[3]),
+            float(bar[4]),
+            float(bar[5]),
+        )
+        for bar in bars
+    ]
+    if not rows:
+        return
+    with sqlite3.connect(db_path) as conn:
+        conn.executemany(
+            """
+            INSERT INTO bars (provider, exchange, symbol, timeframe, ts, open, high, low, close, volume)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(provider, exchange, symbol, timeframe, ts)
+            DO UPDATE SET
+                open = excluded.open,
+                high = excluded.high,
+                low = excluded.low,
+                close = excluded.close,
+                volume = excluded.volume
+            """,
+            rows,
+        )
+
+
+def import_from_ohlcv(
+    db_path: Path,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    ohlcv_path: Path,
+    batch_size: int = 2000,
+) -> None:
+    if not ohlcv_path.exists():
+        return
+    with OHLCVReader(ohlcv_path) as reader:
+        size = reader.size
+        batch = []
+        for idx in range(size):
+            bar = reader.read(idx)
+            batch.append(
+                (
+                    bar.timestamp,
+                    bar.open,
+                    bar.high,
+                    bar.low,
+                    bar.close,
+                    bar.volume,
+                )
+            )
+            if len(batch) >= batch_size:
+                upsert_bars(db_path, provider, exchange, symbol, timeframe, batch)
+                batch.clear()
+        if batch:
+            upsert_bars(db_path, provider, exchange, symbol, timeframe, batch)
+        reader.close()
+
+
+def export_to_ohlcv(
+    db_path: Path,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    ohlcv_path: Path,
+) -> None:
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT ts, open, high, low, close, volume
+            FROM bars
+            WHERE provider = ? AND exchange = ? AND symbol = ? AND timeframe = ?
+            ORDER BY ts
+            """,
+            (provider, exchange, symbol, timeframe),
+        )
+        with OHLCVWriter(ohlcv_path, truncate=True) as writer:
+            for ts, open_p, high, low, close, volume in rows:
+                writer.write(
+                    OHLCV(
+                        timestamp=int(ts),
+                        open=float(open_p),
+                        high=float(high),
+                        low=float(low),
+                        close=float(close),
+                        volume=float(volume),
+                    )
+                )
+            writer.close()
+
+
+def export_to_ohlcv_since(
+    db_path: Path,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    ohlcv_path: Path,
+    start_ts: int,
+) -> None:
+    with sqlite3.connect(db_path) as conn:
+        rows = conn.execute(
+            """
+            SELECT ts, open, high, low, close, volume
+            FROM bars
+            WHERE provider = ? AND exchange = ? AND symbol = ? AND timeframe = ? AND ts >= ?
+            ORDER BY ts
+            """,
+            (provider, exchange, symbol, timeframe, start_ts),
+        )
+        with OHLCVWriter(ohlcv_path, truncate=True) as writer:
+            for ts, open_p, high, low, close, volume in rows:
+                writer.write(
+                    OHLCV(
+                        timestamp=int(ts),
+                        open=float(open_p),
+                        high=float(high),
+                        low=float(low),
+                        close=float(close),
+                        volume=float(volume),
+                    )
+                )
+            writer.close()

--- a/data_service/ohlcv_paths.py
+++ b/data_service/ohlcv_paths.py
@@ -27,3 +27,7 @@ def make_plot_path(cfg: DataServiceConfig) -> Path:
     script_stem = Path(script_name).stem
     plot_path = app_state.output_dir / f"{script_stem}.csv"
     return plot_path
+
+
+def make_cache_path() -> Path:
+    return app_state.data_dir / "cache" / "ohlcv_cache.sqlite"

--- a/data_service/templates/chart.js
+++ b/data_service/templates/chart.js
@@ -189,12 +189,12 @@ App.chart = {
       if (state.lastFrameTs != null) {
         const delta = ts - state.lastFrameTs;
         state.jankFrames.push(delta);
-        if (state.jankFrames.length > 60) {
+        if (state.jankFrames.length > 120) {
           state.jankFrames.shift();
         }
-        if (!state.jankReloaded && state.jankFrames.length === 60) {
+        if (!state.jankReloaded && state.jankFrames.length === 120) {
           const avg = state.jankFrames.reduce((a, b) => a + b, 0) / state.jankFrames.length;
-          if (avg >= 60) {
+          if (avg >= 80) {
             state.jankReloaded = true;
             try {
               const range = this.chart.timeScale().getVisibleRange();


### PR DESCRIPTION
- Add SQLite-based OHLCV caching to avoid re-downloading history on restart                                                                                                                                                           
- Cache bars locally and sync incrementally from last timestamp                                                                                                                                                                       
- Support backfill when history_since is older than cached data                                                                                                                                                                       
- Export cache to .ohlcv file for runner consumption                                                                                                                                                                                  
- Optimize convert_timeframe function and chart.js jank detection 