### PR TITLE
OKX 거래소 지원 변경사항 병합

### DIFF
--- a/data_service/api.py
+++ b/data_service/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from config import DataServiceConfig
 from fastapi import APIRouter, Body
 from fastapi.responses import JSONResponse
+from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any, Dict, List
 from tomlkit import parse, dumps
@@ -67,6 +68,24 @@ def build_api_router(plot_path: Path, ohlcv_path: Path, trades_history: List[Dic
         if not plot_path.exists():
             return JSONResponse([])
 
+        current_open_ts = None
+        if ohlcv_path.exists():
+            try:
+                with OHLCVReader(ohlcv_path) as ohlcv_reader:
+                    end_ts = ohlcv_reader.end_timestamp
+                    interval = ohlcv_reader.interval
+                    if end_ts is not None and interval is not None:
+                        now_ts = int(datetime.now(UTC).timestamp())
+                        # Exclude only the actual in-progress open bar. The plot CSV usually
+                        # ends at the latest confirmed bar, especially when OKX hides the
+                        # zero-volume current bar, so dropping the last CSV row unconditionally
+                        # hides one valid confirmed plot point on initial chart load.
+                        if int(end_ts) <= now_ts < int(end_ts) + int(interval):
+                            current_open_ts = int(end_ts)
+                    ohlcv_reader.close()
+            except Exception as e:
+                print(f"[api] Failed to read OHLCV end timestamp: {e}")
+
         # Read CSV file and build plot data
         result = []
         try:
@@ -74,11 +93,13 @@ def build_api_router(plot_path: Path, ohlcv_path: Path, trades_history: List[Dic
                 # Collect all candles
                 candles = []
                 for candle in reader:
+                    if current_open_ts is not None and int(candle.timestamp) >= current_open_ts:
+                        continue
                     candles.append(candle)
 
                 # Limit the number of candles
                 start_idx = max(0, len(candles) - limit)
-                candles = candles[start_idx:-1]
+                candles = candles[start_idx:]
 
                 # Build plot data for each title
                 for title, options in plot_options.items():

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -114,12 +114,21 @@ def build_api_router(plot_path: Path, ohlcv_path: Path, trades_history: List[Dic
         if not ohlcv_path.exists():
             return JSONResponse([])
 
+        # The chart must receive the same visible candle set as the runner.
+        # OKX hides zero-volume bars like TradingView; BITGET keeps them visible.
+        skip_zero_volume = cfg is not None and cfg.exchange.upper() == "OKX"
         out: List[Dict[str, Any]] = []
         with OHLCVReader(ohlcv_path) as reader:
-            size = reader.size
-            start = max(0, size - limit)
-            for i in range(start, size):
-                c = reader.read(i)
+            if reader.start_timestamp is None:
+                return JSONResponse([])
+            candles = list(
+                reader.read_from(
+                    reader.start_timestamp,
+                    reader.end_timestamp,
+                    skip_zero_volume=skip_zero_volume,
+                )
+            )
+            for c in candles[-limit:]:
                 out.append(
                     {
                         "time": int(c.timestamp),

--- a/data_service/collector_loop.py
+++ b/data_service/collector_loop.py
@@ -104,6 +104,8 @@ async def fix_missing_bars_loop(
                 continue
 
             prev_close = bars[-1][4]
-            fake = [missing_ts, prev_close, prev_close, prev_close, prev_close, 0.01]
+            # No trades occurred in this interval. Store the placeholder as true 0-volume.
+            # OKX policy will hide it; BITGET policy will still treat it as a visible bar.
+            fake = [missing_ts, prev_close, prev_close, prev_close, prev_close, 0.0]
             bars.append(fake)
             state.last_fix_bar_ts = missing_ts

--- a/data_service/file_update_loop.py
+++ b/data_service/file_update_loop.py
@@ -66,6 +66,10 @@ async def file_update_loop(
             desired_dt = parse_date_or_days(history_since)
             if desired_dt.tzinfo is None:
                 desired_dt = desired_dt.replace(tzinfo=UTC)
+            # Keep cache export stable across restarts. If this is set only
+            # when the existing .ohlcv start differs, export alternates between
+            # clipped history_since data and full cache data.
+            export_start_ts = int(desired_dt.timestamp())
         except Exception:
             desired_dt = None
     else:
@@ -79,7 +83,6 @@ async def file_update_loop(
             start_ts = reader.start_timestamp
             reader.close()
         if start_ts is not None and int(start_ts) != int(desired_dt.timestamp()):
-            export_start_ts = int(desired_dt.timestamp())
             print("[data_service] history_since changed; ohlcv will be regenerated from cache")
 
     if cache_ready:

--- a/data_service/file_update_loop.py
+++ b/data_service/file_update_loop.py
@@ -289,7 +289,12 @@ async def file_update_loop(
                         ]
                         upsert_bars(cache_path, provider, exchange, symbol, timeframe, cache_rows)
                     # Current candle open price fix if needed
-                    fixed_open_price = fix_last_open_if_needed(str(ohlcv_path))
+                    fixed_open_price = fix_last_open_if_needed(
+                        str(ohlcv_path),
+                        exchange=exchange,
+                        symbol=symbol,
+                        timeframe=timeframe,
+                    )
                     if fixed_open_price > 0.0:
                         # Fix the last bar stored in the ohlcv cache
                         cache_rows = []
@@ -304,7 +309,7 @@ async def file_update_loop(
                 # Send pre-run ready signal (confirmed bar and new bar)
                 confirmed_bar_and_new_bar = [bars[0], bars[1]]
                 if fixed_open_price > 0.0:
-                    confirmed_bar_and_new_bar[0][1] = fixed_open_price
+                    confirmed_bar_and_new_bar[1][1] = fixed_open_price
 
                 bar_ts = int(confirmed_bar_and_new_bar[1][0])  # new bar timestamp in ms
                 if prerun_sent_for_bar_ts != bar_ts:

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -86,7 +86,15 @@ async def main() -> None:
                                 await ws_manager.broadcast_json({"type": "runner_connected"})
                         elif msg_type == "last_bar_open_fix":
                             last_bar_index = event.get("last_bar_index", -1)
-                            if last_bar_index > 0:
+                            event_data = event.get("data")
+                            if isinstance(event_data, dict):
+                                # New runner sends the visible candle directly because visible indexes
+                                # can differ from raw file indexes when OKX hidden bars exist.
+                                await ws_manager.broadcast_json({
+                                    "type": "last_bar_open_fix",
+                                    "data": event_data,
+                                })
+                            elif last_bar_index > 0:
                                 try:
                                     from pynecore.core.ohlcv_file import OHLCVReader
                                     with OHLCVReader(ohlcv_path) as reader:

--- a/data_service/ohlcv_io.py
+++ b/data_service/ohlcv_io.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, UTC
+import struct
 from typing import Optional
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -112,33 +113,84 @@ def download_history_range_into_cache(
     return ok
 
 
-def fix_last_open_if_needed(ohlcv_path: str) -> float:
+def _ohlcv_float(value: float) -> float:
+    return struct.unpack("f", struct.pack("f", value))[0]
+
+
+def fetch_ohlcv_data(
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    since: int,
+    limit: int | None = None,
+) -> list | None:
+    import ccxt
+
+    client = getattr(ccxt, exchange)(config={})
+    return client.fetch_ohlcv(
+        symbol=symbol,
+        timeframe=timeframe,
+        since=since,
+        limit=limit,
+    )
+
+
+def fix_last_open_if_needed(
+    ohlcv_path: str,
+    exchange: str = "",
+    symbol: str = "",
+    timeframe: str = "",
+) -> float:
     fixed_candle_open_price = 0.0
-    need_fix = False
     open_price, high_price, low_price, close_price, vol, prev_close_price = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
+    last_timestamp, interval = 0, 0
     with OHLCVReader(ohlcv_path) as reader:
         size = reader.size
         last = reader.read(size - 1)
         prev = reader.read(size - 2)
+        interval = reader.interval
+        last_timestamp = last.timestamp
         open_price = last.open
         high_price = last.high
         low_price = last.low
         close_price = last.close
         vol = last.volume
         prev_close_price = prev.close
-        if open_price != prev_close_price:
-            # print(f"Open price is different from previous close price. Fixing...\n"
-            #       f"prev close: {prev_close_price}, open: {open_price}")
-            need_fix = True
         reader.close()
 
-    if need_fix:
+    if exchange.upper() == "OKX":
+        try:
+            res = fetch_ohlcv_data(
+                exchange=exchange,
+                symbol=symbol,
+                timeframe=timeframe,
+                since=(last_timestamp - interval) * 1000,
+                limit=3,
+            )
+        except Exception as e:
+            print(f"[fix_last_open_if_needed] Error fetching current open: {e}")
+            return fixed_candle_open_price
+
+        target_open_price = None
+        for bar in res or []:
+            if int(bar[0] / 1000) == last_timestamp:
+                # fetch 로 받은 bar open 데이터를 float32 타입으로 변경하여 저장
+                target_open_price = _ohlcv_float(bar[1])
+                break
+        if target_open_price is None:
+            return fixed_candle_open_price
+    else:
+        # BITGET-style continuity: the live-built current candle can start from the
+        # first trade, while the chart expects the previous close as the next open.
+        target_open_price = prev_close_price
+
+    if open_price != target_open_price:
         with OHLCVWriter(ohlcv_path) as writer:
             writer.overwrite(timestamp=writer.end_timestamp,
-                             candle=OHLCV(timestamp=writer.end_timestamp, open=prev_close_price,
+                             candle=OHLCV(timestamp=writer.end_timestamp, open=target_open_price,
                                           high=high_price,
                                           low=low_price, close=close_price, volume=vol))
-            fixed_candle_open_price = prev_close_price
+            fixed_candle_open_price = target_open_price
             # print("Candle open price fixing done")
             writer.close()
 
@@ -200,10 +252,6 @@ def fetch_and_update_ohlcv_data(
     :param ohlcv_path: Path to OHLCV file
     :return: Updated open price of the last candle
     """
-    import ccxt
-    # Create ccxt client
-    client = getattr(ccxt, exchange)(config={})
-
     # Read current last candle timestamp
     with OHLCVReader(ohlcv_path) as reader:
         size = reader.size
@@ -214,7 +262,8 @@ def fetch_and_update_ohlcv_data(
 
     # Fetch candles from exchange and update the ohlcv file
     try:
-        res = client.fetch_ohlcv(
+        res = fetch_ohlcv_data(
+            exchange=exchange,
             symbol=symbol,
             timeframe=timeframe,
             since=last_timestamp_sec * 1000 - interval * 1000,  # Convert to milliseconds
@@ -245,8 +294,6 @@ def fetch_and_update_recent_ohlcv_data(
     Fetch and update recently closed candles before the current live candle.
     The current candle is preserved from the local OHLCV file and is not updated from REST.
     """
-    import ccxt
-
     current_ts_sec = int(current_bar_ts_ms / 1000)
 
     with OHLCVReader(ohlcv_path) as reader:
@@ -273,11 +320,11 @@ def fetch_and_update_recent_ohlcv_data(
         last_bar.volume,
     ]
 
-    client = getattr(ccxt, exchange)(config={})
     since_ms = (current_ts_sec - interval * bar_count) * 1000
 
     try:
-        res = client.fetch_ohlcv(
+        res = fetch_ohlcv_data(
+            exchange=exchange,
             symbol=symbol,
             timeframe=timeframe,
             since=since_ms,

--- a/data_service/templates/chart.js
+++ b/data_service/templates/chart.js
@@ -28,7 +28,8 @@ App.chart = {
         wickUpColor: "#26a69a",
         wickDownColor: "#ef5350",
         lastValueVisible: false,
-        priceLineVisible: false
+        priceLineVisible: false,
+        priceFormat: { type: "price", precision: 2, minMove: 0.01 }
       }
     );
 
@@ -75,10 +76,10 @@ App.chart = {
           App.ui.setChartInfo();
           return;
         }
-        const ohlcvText = `O <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.open, 1)}</span>` +
-          ` H <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.high, 1)}</span>` +
-          ` L <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.low, 1)}</span>` +
-          ` C <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.close, 1)}</span>` +
+        const ohlcvText = `O <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.open, 2)}</span>` +
+          ` H <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.high, 2)}</span>` +
+          ` L <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.low, 2)}</span>` +
+          ` C <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.close, 2)}</span>` +
           ` Vol <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.volume, 2)}</span>`;
         App.ui.setChartInfo(ohlcvText);
         return;
@@ -90,10 +91,10 @@ App.chart = {
         return;
       }
       const volumeValue = volBar ? volBar.value : (state.lastOhlcv ? state.lastOhlcv.volume : null);
-      const ohlcvText = `O <span style="color:#d32f2f">${App.ui.formatNumber(bar.open, 1)}</span>` +
-        ` H <span style="color:#d32f2f">${App.ui.formatNumber(bar.high, 1)}</span>` +
-        ` L <span style="color:#d32f2f">${App.ui.formatNumber(bar.low, 1)}</span>` +
-        ` C <span style="color:#d32f2f">${App.ui.formatNumber(bar.close, 1)}</span>` +
+      const ohlcvText = `O <span style="color:#d32f2f">${App.ui.formatNumber(bar.open, 2)}</span>` +
+        ` H <span style="color:#d32f2f">${App.ui.formatNumber(bar.high, 2)}</span>` +
+        ` L <span style="color:#d32f2f">${App.ui.formatNumber(bar.low, 2)}</span>` +
+        ` C <span style="color:#d32f2f">${App.ui.formatNumber(bar.close, 2)}</span>` +
         ` Vol <span style="color:#d32f2f">${App.ui.formatNumber(volumeValue, 2)}</span>`;
       App.ui.setChartInfo(ohlcvText);
     });
@@ -155,7 +156,7 @@ App.chart = {
     if (this.currentPriceLine) {
       this.currentPriceLine.applyOptions({
         price: state.lastPrice,
-        title: `${timeText}`
+        title: `${state.lastPrice.toFixed(2)} | ${timeText}`
       });
     } else {
       this.currentPriceLine = this.candleSeries.createPriceLine({

--- a/data_service/templates/chart.js
+++ b/data_service/templates/chart.js
@@ -156,7 +156,7 @@ App.chart = {
     if (this.currentPriceLine) {
       this.currentPriceLine.applyOptions({
         price: state.lastPrice,
-        title: `${state.lastPrice.toFixed(2)} | ${timeText}`
+        title: `${timeText}`
       });
     } else {
       this.currentPriceLine = this.candleSeries.createPriceLine({

--- a/data_service/templates/ws.js
+++ b/data_service/templates/ws.js
@@ -59,6 +59,18 @@ App.ws = {
           state.lastOpenPrice.time = msg.data.time;
           state.lastOpenPrice.value = msg.data.open;
 
+          chart.candleSeries.update(msg.data);
+          chart.volumeSeries.update({
+            time: msg.data.time,
+            value: msg.data.volume,
+            color: msg.data.close >= msg.data.open ? "#26a69a" : "#ef5350"
+          });
+          state.lastBarTime = Math.max(state.lastBarTime, msg.data.time);
+          state.lastOhlcv = msg.data;
+          if (msg.data && msg.data.close !== undefined) {
+            state.lastPrice = msg.data.close;
+          }
+
           const entryIndex = collections.entryMarkerData.findIndex(m => m.time === msg.data.time);
           if (entryIndex !== -1) {
             const priceDiff = Math.abs(collections.entryMarkerData[entryIndex].value - msg.data.open);

--- a/pynecore/cli/commands/benchmark.py
+++ b/pynecore/cli/commands/benchmark.py
@@ -115,8 +115,12 @@ def benchmark(
             with OHLCVReader(data) as reader:
                 # Get only the requested number of candles
                 ohlcv_list = []
+                # Match realtime/CLI run behavior for exchange-specific hidden bars.
+                skip_zero_volume = syminfo.prefix.upper() == "OKX"
                 # Use read_from to get all data from the beginning
-                for idx, ohlcv in enumerate(reader.read_from(reader.start_timestamp, reader.end_timestamp)):
+                for idx, ohlcv in enumerate(
+                    reader.read_from(reader.start_timestamp, reader.end_timestamp, skip_zero_volume=skip_zero_volume)
+                ):
                     if idx >= candles:
                         break
                     ohlcv_list.append(ohlcv)

--- a/pynecore/cli/commands/run.py
+++ b/pynecore/cli/commands/run.py
@@ -293,13 +293,14 @@ def run(
 
         total_seconds = int((time_to - time_from).total_seconds())
 
-        # Get the iterator using the correct UTC timestamps
-        gaps = sum(1 for ohlcv in reader if ohlcv.volume < 0)
-        size = reader.get_size(time_from_ts, time_to_ts)
-        if gaps > 0:
-            size = size - gaps
-        # preload_list is used for request.security calculation
-        preload_list = list(reader.read_from(time_from_ts, time_to_ts))
+        # Use the same exchange-specific hidden-bar policy as realtime runner.
+        # OKX zero-volume bars are hidden; BITGET zero-volume bars are visible.
+        skip_zero_volume = syminfo.prefix.upper() == "OKX"
+        preload_list = list(reader.read_from(time_from_ts, time_to_ts, skip_zero_volume=skip_zero_volume))
+        size = len(preload_list)
+        if size == 0:
+            secho("No OHLCV candles found in the selected range after skipping gaps.", fg="red", err=True)
+            raise Exit(1)
         ohlcv_iter = iter(preload_list)
 
         # Add lib directory to Python path for library imports

--- a/pynecore/core/ohlcv_file.py
+++ b/pynecore/core/ohlcv_file.py
@@ -1513,7 +1513,8 @@ class OHLCVReader:
         data = struct.unpack(STRUCT_FORMAT, self._mmap[offset:offset + RECORD_SIZE])
         return OHLCV(*data, extra_fields={})
 
-    def read_from(self, start_timestamp: int, end_timestamp: int | None = None, skip_gaps: bool = True) \
+    def read_from(self, start_timestamp: int, end_timestamp: int | None = None, skip_gaps: bool = True,
+                  skip_zero_volume: bool = False) \
             -> Iterator[OHLCV]:
         """
         Read bars starting from timestamp, using direct position calculation.
@@ -1522,6 +1523,8 @@ class OHLCVReader:
         :param end_timestamp: End timestamp, if None, read until the end
         :param skip_gaps: Skip gaps in data, the writer fill gaps with the last value with -1 volume,
                           this will skip them (default)
+        :param skip_zero_volume: Also skip confirmed no-trade candles with zero volume. Enable this only for
+                                 exchanges whose TradingView chart hides zero-volume bars.
         :raises ValueError: If start_timestamp is after the last bar
         """
         if not self._size or not self._interval:
@@ -1534,8 +1537,10 @@ class OHLCVReader:
         for pos in range(start_pos, end_pos):
             ohlcv = self.read(pos)
             if ohlcv is not None:
-                # Skip gaps if needed
-                if skip_gaps and ohlcv.volume < 0:
+                # volume < 0: Pyne가 gap 보정용으로 만든 봉이므로 항상 제외.
+                # volume == 0: OKX처럼 TradingView가 hidden 처리하는 거래소에서만 제외.
+                # BITGET은 0-volume 봉도 TV 차트/계산에 포함되므로 skip_zero_volume=False로 읽어야 한다.
+                if skip_gaps and (ohlcv.volume < 0 or (skip_zero_volume and ohlcv.volume == 0)):
                     continue
                 yield ohlcv
 

--- a/pynecore/core/script_runner.py
+++ b/pynecore/core/script_runner.py
@@ -11,6 +11,7 @@ from pynecore.types.ohlcv import OHLCV
 from pynecore.core.syminfo import SymInfo
 from pynecore.core.csv_file import CSVWriter
 from pynecore.core.strategy_stats import calculate_strategy_statistics, write_strategy_statistics_csv
+from pynecore.types.source import Source
 
 from pynecore.types import script_type
 
@@ -23,6 +24,8 @@ __all__ = [
     'import_script',
     'ScriptRunner',
 ]
+
+_LAST_LIB_RESET_CONTEXT: dict[str, Any] | None = None
 
 
 def import_script(script_path: Path) -> ModuleType:
@@ -145,6 +148,15 @@ def _reset_lib_vars(lib: ModuleType):
     if TYPE_CHECKING:  # This is needed for the type checker to work
         from .. import lib
     from ..types.source import Source
+    import threading
+    import traceback
+
+    global _LAST_LIB_RESET_CONTEXT
+    _LAST_LIB_RESET_CONTEXT = {
+        "time": datetime.now(UTC).isoformat(),
+        "thread": threading.current_thread().name,
+        "stack": "".join(traceback.format_stack(limit=8)),
+    }
 
     lib.open = Source("open")
     lib.high = Source("high")
@@ -358,6 +370,47 @@ class ScriptRunner:
                 for library_title, main_func in script._registered_libraries:
                     main_func()
                 lib._lib_semaphore = False
+
+                # In long-running step mode, another runner cleanup can reset global lib
+                # OHLC sources back to Source placeholders. Restore the current candle
+                # only when that corrupted state is observed.
+                source_fields = [
+                    name
+                    for name in ("open", "high", "low", "close", "volume")
+                    if isinstance(getattr(lib, name), Source)
+                ]
+                if source_fields:
+                    import threading
+                    import traceback
+
+                    last_reset_time = None
+                    last_reset_thread = None
+                    last_reset_stack = None
+                    if _LAST_LIB_RESET_CONTEXT is not None:
+                        last_reset_time = _LAST_LIB_RESET_CONTEXT.get("time")
+                        last_reset_thread = _LAST_LIB_RESET_CONTEXT.get("thread")
+                        last_reset_stack = _LAST_LIB_RESET_CONTEXT.get("stack")
+                    print(
+                        "[script_runner] Source placeholder detected before script main; "
+                        "restoring current candle. "
+                        f"fields={source_fields}, "
+                        f"script={getattr(self.script, 'title', None)}, "
+                        f"module={getattr(self.script_module, '__name__', None)}, "
+                        f"bar_index={self.bar_index}, "
+                        f"last_bar_index={self.last_bar_index}, "
+                        f"candle_ts={candle.timestamp}, "
+                        f"ohlcv=({candle.open}, {candle.high}, {candle.low}, {candle.close}, {candle.volume}), "
+                        f"thread={threading.current_thread().name}, "
+                        f"last_reset_time={last_reset_time}, "
+                        f"last_reset_thread={last_reset_thread}"
+                    )
+                    if last_reset_stack:
+                        print("[script_runner] Last _reset_lib_vars stack:\n" + last_reset_stack.rstrip())
+                    print(
+                        "[script_runner] Current detection stack:\n"
+                        + "".join(traceback.format_stack(limit=8)).rstrip()
+                    )
+                    _set_lib_properties(candle, self.bar_index, self.tz, lib)
 
                 # Run the script
                 res = self.script_module.main()

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -609,20 +609,25 @@ async def main():
             # OKX fake/no-trade bars can stay in the raw file with volume 0, but they must not
             # enter the runner stream. BITGET leaves hide_zero_volume=False, so its 0-volume
             # bars still take this visible path.
+            confirmed_appended = False
             if confirmed_visible:
                 try:
                     ctx.stream.replace_last(confirmed_ohlcv)
                 except IndexError:
                     ctx.stream.append(confirmed_ohlcv)
+                    confirmed_appended = True
                 if new_visible:
                     ctx.stream.append(new_ohlcv)
             ctx.stream.finish()
 
-            # Check the interval is the same as the timeframe. If so, the incremented candle size is 1.
+            # Count only visible bars added to the runner's index space.
             timeframe_ms = parse_timeframe_to_ms(tf)
             interval_ms = (int(new_ohlcv.timestamp) - int(ctx.last_new_bar_ts_sec)) * 1000
-            # last_bar_index tracks visible bars. If the new bar is hidden, do not advance it.
-            incremented_size = 1 if interval_ms == timeframe_ms and new_visible else 0
+            # last_bar_index tracks visible bars. If pre_run skipped a hidden fake open bar,
+            # the confirmed bar may be appended as a new visible bar here.
+            confirmed_increment = 1 if confirmed_appended else 0
+            new_increment = 1 if interval_ms == timeframe_ms and new_visible else 0
+            incremented_size = confirmed_increment + new_increment
 
             if confirmed_visible:
                 # #################################### Module calculation ####################################
@@ -647,7 +652,12 @@ async def main():
 
                 # The confirmed bar index is the visible index just evaluated. When a visible
                 # new bar was appended, last_bar_index already points to that new open bar.
-                confirmed_bar_index = ctx.runner.last_bar_index - incremented_size
+                confirmed_bar_index = ctx.runner.last_bar_index - new_increment
+                # Strategy code uses strategy.last_bar_index() - 1 as the "last confirmed bar"
+                # check in realtime mode. If the next OKX open bar is hidden, it is not appended
+                # to the stream, but the confirmed bar should still satisfy that check.
+                if not new_visible:
+                    ctx.runner.script.last_bar_index = confirmed_bar_index + 1
 
                 # Ensure request.security can see the new bar during confirmed-bar evaluation.
                 from pynecore.lib.request import get_security_ctx

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -188,6 +188,22 @@ def on_alert_event(message: str, runner: ScriptRunner):
         )
 
 
+def hide_zero_volume_bars(exchange: str | None) -> bool:
+    # TradingView policy differs by exchange:
+    # - OKX: zero-volume candles are hidden and excluded from calculations.
+    # - BITGET: zero-volume candles remain visible and are included.
+    return (exchange or "").upper() == "OKX"
+
+
+def is_visible_ohlcv(ohlcv: OHLCV, *, hide_zero_volume: bool) -> bool:
+    # "visible" means the candle should advance bar_index and run strategy logic.
+    if ohlcv.volume < 0:
+        return False
+    if hide_zero_volume and ohlcv.volume == 0:
+        return False
+    return True
+
+
 def ready_scrip_runner(script_path: Path, data_path: Path, data_toml_path: Path) -> tuple[ScriptRunner,
 AppendableIterable[OHLCV], OHLCVReader] | None:
     """
@@ -202,13 +218,19 @@ AppendableIterable[OHLCV], OHLCVReader] | None:
     time_from = reader.start_datetime
     time_to = reader.end_datetime
 
-    # Get the iterator
-    gaps = sum(1 for ohlcv in reader if ohlcv.volume < 0)
-    size = reader.get_size(int(time_from.timestamp()), int(time_to.timestamp()))
-    if gaps > 0:
-        size = size - gaps
-    # preload_list is used for request.security calculation
-    preload_list = list(reader.read_from(int(time_from.timestamp()), int(time_to.timestamp())))
+    # Build the runner's candle list with the same hidden-bar policy used by TradingView.
+    # last_bar_index must be based on this visible list, not the raw file size.
+    preload_list = list(
+        reader.read_from(
+            int(time_from.timestamp()),
+            int(time_to.timestamp()),
+            skip_zero_volume=hide_zero_volume_bars(syminfo.prefix),
+        )
+    )
+    size = len(preload_list)
+    if size == 0:
+        reader.close()
+        return None
     ohlcv_iter: Iterator[OHLCV] = iter(preload_list)
     # Prepare a mutable iterator.
     if ohlcv_iter is not None:
@@ -267,6 +289,24 @@ AppendableIterable[OHLCV], OHLCVReader] | None:
 
         # return reader too. So we can close it later
         return runner, stream, reader
+
+
+def ohlcv_event_data(ohlcv: OHLCV) -> dict:
+    return {
+        "time": int(ohlcv.timestamp),
+        "open": float(ohlcv.open),
+        "high": float(ohlcv.high),
+        "low": float(ohlcv.low),
+        "close": float(ohlcv.close),
+        "volume": float(ohlcv.volume),
+    }
+
+
+def get_runner_candle(runner: ScriptRunner, index: int) -> OHLCV | None:
+    candles = getattr(runner, "_all_ohlcv", None)
+    if not candles or index < 0 or index >= len(candles):
+        return None
+    return candles[index]
 
 
 def bar_list_to_ohlcv(bar: list) -> OHLCV:
@@ -447,10 +487,20 @@ async def main():
 
             # print("=== Pre-run start (up to the last bar) ===")
             size = runner.last_bar_index + 1
-            prerun_range = size - 1
+            last_visible_bar = get_runner_candle(runner, runner.last_bar_index)
+            # In normal realtime pre-run, the file may already contain the open current bar.
+            # If that bar is visible, keep it in the stream for the next run_ready and
+            # pre-run only up to the last confirmed bar. If the raw last bar is hidden
+            # (OKX zero-volume), the visible list already ends at a confirmed bar.
+            has_unconfirmed_visible_bar = (
+                last_visible_bar is not None
+                and reader.end_timestamp is not None
+                and int(last_visible_bar.timestamp) == int(reader.end_timestamp)
+            )
+            prerun_range = size - 1 if has_unconfirmed_visible_bar else size
             runner.script.pre_run = True
             if mtype == "prerun_ready_after_history_download":
-                prerun_range = prerun_range + 1
+                prerun_range = size
                 runner.script.pre_run = False
             await asyncio.to_thread(run_prerun_steps, runner, prerun_range)
             # print("=== Pre-run finished ===")
@@ -464,12 +514,17 @@ async def main():
             except Exception as e:
                 print(f"[runner] Failed to send script_info: {e}")
 
-            # Send last bar index to data_service to fix open price
+            # Send the visible last candle itself. A visible index can differ from the
+            # raw file index when OKX hidden zero-volume bars exist.
             try:
-                await ws.send(json.dumps({
+                last_bar = get_runner_candle(runner, runner.last_bar_index)
+                event = {
                     "type": "last_bar_open_fix",
                     "last_bar_index": runner.last_bar_index,
-                }))
+                }
+                if last_bar is not None:
+                    event["data"] = ohlcv_event_data(last_bar)
+                await ws.send(json.dumps(event))
             except Exception as e:
                 print(f"[runner] Failed to send bar confirmation: {e}")
 
@@ -492,15 +547,15 @@ async def main():
             # Send plot options to data_service
             if plot_options:
                 try:
-                    confirmed_bar_time = None
-                    with OHLCVReader(ohlcv_path) as reader:
-                        confirmed_bar = reader.read(runner.last_bar_index - 1)
-                        confirmed_bar_time = int(confirmed_bar.timestamp)
-                        reader.close()
+                    # Plot CSV rows are keyed by candle timestamp. Timestamp lookup avoids
+                    # using a raw file index that may include hidden OKX bars.
+                    confirmed_bar_index = runner.last_bar_index - 1
+                    confirmed_bar = get_runner_candle(runner, confirmed_bar_index)
+                    confirmed_bar_time = int(confirmed_bar.timestamp) if confirmed_bar is not None else None
                     plot_options_event = {
                         "type": "plot_options",
                         "data": plot_options,
-                        "confirmed_bar_index": runner.last_bar_index - 1,
+                        "confirmed_bar_index": confirmed_bar_index,
                         "confirmed_bar_time": confirmed_bar_time,
                     }
                     await ws.send(json.dumps(plot_options_event))
@@ -545,18 +600,31 @@ async def main():
 
             confirmed_ohlcv = bar_list_to_ohlcv(confirmed_bar)
             new_ohlcv = bar_list_to_ohlcv(new_bar)
+            hide_zero_volume = hide_zero_volume_bars(getattr(ctx.runner.syminfo, "prefix", None))
+            # confirmed_visible decides whether this just-closed candle should run one strategy step.
+            # new_visible decides whether the newly opened candle should be kept as the next open bar.
+            confirmed_visible = is_visible_ohlcv(confirmed_ohlcv, hide_zero_volume=hide_zero_volume)
+            new_visible = is_visible_ohlcv(new_ohlcv, hide_zero_volume=hide_zero_volume)
 
-            # Replace the last uncompleted bar with the confirmed bar and append the new bar.
-            ctx.stream.replace_last(confirmed_ohlcv)
-            ctx.stream.append(new_ohlcv)
+            # OKX fake/no-trade bars can stay in the raw file with volume 0, but they must not
+            # enter the runner stream. BITGET leaves hide_zero_volume=False, so its 0-volume
+            # bars still take this visible path.
+            if confirmed_visible:
+                try:
+                    ctx.stream.replace_last(confirmed_ohlcv)
+                except IndexError:
+                    ctx.stream.append(confirmed_ohlcv)
+                if new_visible:
+                    ctx.stream.append(new_ohlcv)
             ctx.stream.finish()
 
             # Check the interval is the same as the timeframe. If so, the incremented candle size is 1.
             timeframe_ms = parse_timeframe_to_ms(tf)
             interval_ms = (int(new_ohlcv.timestamp) - int(ctx.last_new_bar_ts_sec)) * 1000
-            incremented_size = 1 if interval_ms == timeframe_ms else 0
+            # last_bar_index tracks visible bars. If the new bar is hidden, do not advance it.
+            incremented_size = 1 if interval_ms == timeframe_ms and new_visible else 0
 
-            if incremented_size > 0:
+            if confirmed_visible:
                 # #################################### Module calculation ####################################
                 # # bb1d / weekly high, low calculation
                 # from modules.bb1d_calc import get_bb1d_lower
@@ -573,15 +641,21 @@ async def main():
                     # "macro_low": macro_low
                 }
 
-                ctx.runner.last_bar_index += incremented_size
-                ctx.runner.script.last_bar_index += incremented_size
+                if incremented_size > 0:
+                    ctx.runner.last_bar_index += incremented_size
+                    ctx.runner.script.last_bar_index += incremented_size
+
+                # The confirmed bar index is the visible index just evaluated. When a visible
+                # new bar was appended, last_bar_index already points to that new open bar.
+                confirmed_bar_index = ctx.runner.last_bar_index - incremented_size
 
                 # Ensure request.security can see the new bar during confirmed-bar evaluation.
                 from pynecore.lib.request import get_security_ctx
                 security_ctx = get_security_ctx()
                 if security_ctx is not None:
-                    security_ctx.update_base_bar(confirmed_ohlcv, ctx.runner.last_bar_index - 1)
-                    security_ctx.update_base_bar(new_ohlcv, ctx.runner.last_bar_index)
+                    security_ctx.update_base_bar(confirmed_ohlcv, confirmed_bar_index)
+                    if new_visible:
+                        security_ctx.update_base_bar(new_ohlcv, ctx.runner.last_bar_index)
 
                 # Calculate the last confirmed bar
                 ctx.runner.script.pre_run = False
@@ -612,7 +686,7 @@ async def main():
                         plot_options_event = {
                             "type": "plot_options",
                             "data": plot_options,
-                            "confirmed_bar_index": ctx.runner.last_bar_index - 1,
+                            "confirmed_bar_index": confirmed_bar_index,
                             "confirmed_bar_time": int(confirmed_ohlcv.timestamp),
                         }
                         await ws.send(json.dumps(plot_options_event))


### PR DESCRIPTION
feature/add-support-okx 브랜치에서 작업한 OKX 거래소 지원 관련 변경사항을 develop 브랜치에 병합한다.

- OKX의 zero-volume 봉 처리 정책을 TradingView 기준에 맞춰 반영
- OKX hidden bar로 인해 raw index와 visible index가 달라지는 케이스 대응
- runner/UI에서 visible bar 기준으로 마지막 봉과 plot 데이터를 처리하도록 개선
- OKX 현재 진행 봉의 open은 거래소 fetch_ohlcv 값을 기준으로 보정
- BITGET 등 기존 거래소의 prev.close 기준 open 보정 동작은 유지
- SQLite cache, pre-run, run-ready 흐름에서 OKX/BITGET 차이를 반영