### PR TITLE
feat: OHLC 정밀도 보정 방식을 upstream 방식으로 조정

### DIFF
--- a/pynecore/core/script_runner.py
+++ b/pynecore/core/script_runner.py
@@ -94,10 +94,22 @@ def _set_lib_properties(ohlcv: OHLCV, bar_index: int, tz: 'ZoneInfo', lib: Modul
 
     lib.bar_index = lib.last_bar_index = bar_index
 
-    lib.open = _round_price(ohlcv.open, lib)
-    lib.high = _round_price(ohlcv.high, lib)
-    lib.low = _round_price(ohlcv.low, lib)
-    lib.close = _round_price(ohlcv.close, lib)
+    # Previous behavior kept for reference. It rounded all chart OHLC sources to
+    # syminfo.pricescale before indicator calculations, which can diverge from
+    # TradingView feed values for symbols whose metadata tick size is coarser than
+    # the actual chart data.
+    # lib.open = _round_price(ohlcv.open, lib)
+    # lib.high = _round_price(ohlcv.high, lib)
+    # lib.low = _round_price(ohlcv.low, lib)
+    # lib.close = _round_price(ohlcv.close, lib)
+
+    # TradingView indicator calculations use the chart feed OHLC values directly.
+    # Tick rounding belongs in explicit helpers such as math.round_to_mintick and
+    # in strategy order simulation, not in the global OHLC sources.
+    lib.open = ohlcv.open
+    lib.high = ohlcv.high
+    lib.low = ohlcv.low
+    lib.close = ohlcv.close
 
     lib.volume = ohlcv.volume
 

--- a/pynecore/core/script_runner.py
+++ b/pynecore/core/script_runner.py
@@ -73,15 +73,22 @@ def import_script(script_path: Path) -> ModuleType:
     return module
 
 
-def _round_price(price: float, lib: ModuleType):
+def _round_price(price: float):
     """
-    Round price to the nearest tick
+    Round price to 6 significant digits to clean float32 storage artifacts
+    without destroying sub-mintick precision.
+
+    TradingView does NOT round OHLC data to syminfo.mintick — scripts see
+    the raw data (e.g. close=4.125 even when mintick=0.01). The float32
+    OHLCV format introduces small errors (e.g. 4.12 → 4.1199998856) that
+    this function cleans by rounding to 6 significant digits (float32 has ~7).
     """
-    if TYPE_CHECKING:  # This is needed for the type checker to work
-        from .. import lib
-    syminfo = lib.syminfo
-    scaled = round(price * syminfo.pricescale)
-    return scaled / syminfo.pricescale
+    if price == 0.0:
+        return 0.0
+    from math import log10, floor
+    magnitude = floor(log10(abs(price)))
+    precision = 5 - magnitude  # 6 significant digits
+    return round(price, precision)
 
 
 # noinspection PyShadowingNames
@@ -94,22 +101,20 @@ def _set_lib_properties(ohlcv: OHLCV, bar_index: int, tz: 'ZoneInfo', lib: Modul
 
     lib.bar_index = lib.last_bar_index = bar_index
 
-    # Previous behavior kept for reference. It rounded all chart OHLC sources to
-    # syminfo.pricescale before indicator calculations, which can diverge from
-    # TradingView feed values for symbols whose metadata tick size is coarser than
-    # the actual chart data.
-    # lib.open = _round_price(ohlcv.open, lib)
-    # lib.high = _round_price(ohlcv.high, lib)
-    # lib.low = _round_price(ohlcv.low, lib)
-    # lib.close = _round_price(ohlcv.close, lib)
+    lib.open = _round_price(ohlcv.open)
+    lib.high = _round_price(ohlcv.high)
+    lib.low = _round_price(ohlcv.low)
+    lib.close = _round_price(ohlcv.close)
 
-    # TradingView indicator calculations use the chart feed OHLC values directly.
-    # Tick rounding belongs in explicit helpers such as math.round_to_mintick and
-    # in strategy order simulation, not in the global OHLC sources.
-    lib.open = ohlcv.open
-    lib.high = ohlcv.high
-    lib.low = ohlcv.low
-    lib.close = ohlcv.close
+    # If a symbol still shows TradingView calculation drift from the 6-significant
+    # digit cleanup above, consider bypassing _round_price and using the chart
+    # feed OHLC values directly. Tick rounding should stay in explicit helpers
+    # such as math.round_to_mintick and in strategy order simulation, not in the
+    # global OHLC sources.
+    # lib.open = ohlcv.open
+    # lib.high = ohlcv.high
+    # lib.low = ohlcv.low
+    # lib.close = ohlcv.close
 
     lib.volume = ohlcv.volume
 


### PR DESCRIPTION
- script_runner의 OHLC 입력값 라운딩을 syminfo.pricescale 기준에서 제거
- 최신 PyneCore upstream 방식에 맞춰 float32 저장 artifact만 6자리 유효숫자로 정리
- TradingView처럼 지표 계산 시 OHLC를 syminfo.mintick으로 강제 라운딩하지 않도록 변경
- chart feed OHLC 직접 사용 방식은 향후 계산 오차 발생 시 검토할 수 있도록 주석으로 보존