### PR TITLE
fix: per-bar OHLC 상태 스레드-로컬 격리로 Source 무한 재귀(RecursionError) 제거

### DIFF
--- a/pynecore/core/script_runner.py
+++ b/pynecore/core/script_runner.py
@@ -11,7 +11,6 @@ from pynecore.types.ohlcv import OHLCV
 from pynecore.core.syminfo import SymInfo
 from pynecore.core.csv_file import CSVWriter
 from pynecore.core.strategy_stats import calculate_strategy_statistics, write_strategy_statistics_csv
-from pynecore.types.source import Source
 
 from pynecore.types import script_type
 
@@ -24,8 +23,6 @@ __all__ = [
     'import_script',
     'ScriptRunner',
 ]
-
-_LAST_LIB_RESET_CONTEXT: dict[str, Any] | None = None
 
 
 def import_script(script_path: Path) -> ModuleType:
@@ -165,15 +162,6 @@ def _reset_lib_vars(lib: ModuleType):
     if TYPE_CHECKING:  # This is needed for the type checker to work
         from .. import lib
     from ..types.source import Source
-    import threading
-    import traceback
-
-    global _LAST_LIB_RESET_CONTEXT
-    _LAST_LIB_RESET_CONTEXT = {
-        "time": datetime.now(UTC).isoformat(),
-        "thread": threading.current_thread().name,
-        "stack": "".join(traceback.format_stack(limit=8)),
-    }
 
     lib.open = Source("open")
     lib.high = Source("high")
@@ -387,47 +375,6 @@ class ScriptRunner:
                 for library_title, main_func in script._registered_libraries:
                     main_func()
                 lib._lib_semaphore = False
-
-                # In long-running step mode, another runner cleanup can reset global lib
-                # OHLC sources back to Source placeholders. Restore the current candle
-                # only when that corrupted state is observed.
-                source_fields = [
-                    name
-                    for name in ("open", "high", "low", "close", "volume")
-                    if isinstance(getattr(lib, name), Source)
-                ]
-                if source_fields:
-                    import threading
-                    import traceback
-
-                    last_reset_time = None
-                    last_reset_thread = None
-                    last_reset_stack = None
-                    if _LAST_LIB_RESET_CONTEXT is not None:
-                        last_reset_time = _LAST_LIB_RESET_CONTEXT.get("time")
-                        last_reset_thread = _LAST_LIB_RESET_CONTEXT.get("thread")
-                        last_reset_stack = _LAST_LIB_RESET_CONTEXT.get("stack")
-                    print(
-                        "[script_runner] Source placeholder detected before script main; "
-                        "restoring current candle. "
-                        f"fields={source_fields}, "
-                        f"script={getattr(self.script, 'title', None)}, "
-                        f"module={getattr(self.script_module, '__name__', None)}, "
-                        f"bar_index={self.bar_index}, "
-                        f"last_bar_index={self.last_bar_index}, "
-                        f"candle_ts={candle.timestamp}, "
-                        f"ohlcv=({candle.open}, {candle.high}, {candle.low}, {candle.close}, {candle.volume}), "
-                        f"thread={threading.current_thread().name}, "
-                        f"last_reset_time={last_reset_time}, "
-                        f"last_reset_thread={last_reset_thread}"
-                    )
-                    if last_reset_stack:
-                        print("[script_runner] Last _reset_lib_vars stack:\n" + last_reset_stack.rstrip())
-                    print(
-                        "[script_runner] Current detection stack:\n"
-                        + "".join(traceback.format_stack(limit=8)).rstrip()
-                    )
-                    _set_lib_properties(candle, self.bar_index, self.tz, lib)
 
                 # Run the script
                 res = self.script_module.main()

--- a/pynecore/lib/__init__.py
+++ b/pynecore/lib/__init__.py
@@ -129,7 +129,7 @@ def max_bars_back(var: Any, num: int) -> None:
 # noinspection PyShadowingNames
 def _get_dt(time: int | None = None, timezone: str | None = None) -> datetime:
     """ Get datetime object from time and timezone """
-    dt = _datetime if time is None else datetime.fromtimestamp(time / 1000, UTC)
+    dt = _bar_state._datetime if time is None else datetime.fromtimestamp(time / 1000, UTC)
     assert dt is not None
     return dt.astimezone(_parse_timezone(timezone))
 
@@ -261,7 +261,7 @@ def plotchar(series: Any, title: str | None = None, char: str = "•", text: str
         return
 
     # Only allow calling from main function
-    if bar_index == 0:
+    if _bar_state.bar_index == 0:
         if sys._getframe(1).f_code.co_name != 'main':
             raise RuntimeError("The plotchar function can only be called from the main function!")
 
@@ -270,7 +270,7 @@ def plotchar(series: Any, title: str | None = None, char: str = "•", text: str
         title = 'PlotChar'
 
     # No plotchar callback if the bar is progressing
-    if bar_index == _script.last_bar_index:
+    if _bar_state.bar_index == _script.last_bar_index:
         return
 
     # Call plotchar callback if exists
@@ -311,7 +311,7 @@ def plotchar(series: Any, title: str | None = None, char: str = "•", text: str
                     size_val = size
 
             # Get current timestamp
-            timestamp = _time
+            timestamp = _bar_state._time
 
             _script.on_plotchar_callback({
                 'title': title,
@@ -637,7 +637,7 @@ def time(timeframe: str | None = None, session: str | None = None, timezone: str
     :return: UNIX time in milliseconds or NA if bar is outside session or invalid parameters
     """
     if timeframe is None:
-        return _time
+        return _bar_state._time
 
     # Get resampler for the requested timeframe
     try:
@@ -647,7 +647,7 @@ def time(timeframe: str | None = None, session: str | None = None, timezone: str
         return NA(int)
 
     # Get the current bar time for the requested timeframe
-    current_time_ms = _time
+    current_time_ms = _bar_state._time
     bar_time = resampler.get_bar_time(current_time_ms)
 
     if session is None:
@@ -704,7 +704,7 @@ def time_close(timeframe: str | None = None, session: str | None = None, timezon
     :return: UNIX time in milliseconds of bar close or NA if bar is outside session or invalid parameters
     """
     if timeframe is None:
-        return _time
+        return _bar_state._time
 
     # Get resampler for the requested timeframe
     try:
@@ -714,7 +714,7 @@ def time_close(timeframe: str | None = None, session: str | None = None, timezon
         return NA(int)
 
     # Get the current bar time for the requested timeframe
-    current_time_ms = _time
+    current_time_ms = _bar_state._time
     bar_start_time = resampler.get_bar_time(current_time_ms)
 
     # Calculate bar close time by adding timeframe duration
@@ -770,3 +770,85 @@ def year(time: int | None = None, timezone: str | None = None) -> int:
     :return: The year
     """
     return _get_dt(time, timezone).year
+
+
+#
+# Per-runner (thread-local) bar-state isolation
+# =============================================
+# OHLC and the per-bar time/index values are mutated every bar by the
+# ScriptRunner (see core.script_runner._set_lib_properties) and reset to Source
+# placeholders on teardown (_reset_lib_vars). Because `lib` is a process-global
+# singleton shared by every ScriptRunner, a runner finishing/teardown on one
+# thread used to blank these globals while another runner (e.g. a background
+# prerun running via asyncio.to_thread) was mid-bar — leaving `lib.open` etc. as
+# Source placeholders. Source arithmetic then recursed without bound
+# (Source.__sub__ -> _get_value -> still a Source -> __sub__ -> ...) and blew up
+# with RecursionError.
+#
+# We remove the shared mutable state by backing every per-bar field with a
+# thread-local store and exposing it through module-level property descriptors,
+# so each runner thread sees only its own bar state and another thread's
+# teardown can never corrupt an in-flight runner. request.security's same-thread
+# save/restore (lib/request.py) and the AST-injected `x = getattr(lib, "x", na)`
+# resolution keep working unchanged, since both run on the runner's own thread.
+#
+import threading as _threading
+from types import ModuleType as _ModuleType
+
+#: Names whose values change per bar and must be isolated per runner thread.
+_BAR_STATE_FIELDS = (
+    "open", "high", "low", "close", "volume",
+    "hl2", "hlc3", "ohlc4", "hlcc4",
+    "bar_index", "last_bar_index",
+    "_time", "last_bar_time", "_datetime",
+)
+
+
+class _BarState(_threading.local):
+    """Per-thread bar state.
+
+    ``threading.local.__init__`` runs once per thread on first access, so every
+    runner thread starts from the same placeholder defaults (matching the
+    module-level annotations above) before its first ``_set_lib_properties``.
+    """
+
+    def __init__(self):
+        self.open = Source("open")
+        self.high = Source("high")
+        self.low = Source("low")
+        self.close = Source("close")
+        self.volume = Source("volume")
+        self.hl2 = Source("hl2")
+        self.hlc3 = Source("hlc3")
+        self.ohlc4 = Source("ohlc4")
+        self.hlcc4 = Source("hlcc4")
+        self.bar_index = 0
+        self.last_bar_index = 0
+        self._time = 0
+        self.last_bar_time = 0
+        self._datetime = datetime.fromtimestamp(0, UTC)
+
+
+_bar_state = _BarState()
+
+
+class _LibModule(_ModuleType):
+    """Module type for ``pynecore.lib`` whose per-bar fields resolve to the
+    calling thread's :data:`_bar_state`. The ``property`` data descriptors
+    transparently intercept both ``lib.open`` reads and ``lib.open = ...``
+    writes (data descriptors take precedence over the module ``__dict__``)."""
+
+
+def _make_bar_property(_name):
+    return property(lambda _self: getattr(_bar_state, _name),
+                    lambda _self, _value: setattr(_bar_state, _name, _value))
+
+
+for _field in _BAR_STATE_FIELDS:
+    setattr(_LibModule, _field, _make_bar_property(_field))
+
+# Swap the live module object's type so the descriptors take effect. The plain
+# module-level assignments above (e.g. `open = Source("open")`) stay in the
+# module __dict__ as type-hint anchors but are shadowed by these descriptors for
+# every attribute access.
+sys.modules[__name__].__class__ = _LibModule

--- a/pynecore/types/source.py
+++ b/pynecore/types/source.py
@@ -39,9 +39,29 @@ class Source(Series[float]):
         return getattr(self, 'name')
 
     def _get_value(self):
-        """Get actual value from lib module"""
+        """Get actual value from lib module.
+
+        During normal bar processing ``lib.<name>`` holds a concrete numeric
+        value (set per bar by the ScriptRunner). If it is still a ``Source``
+        placeholder here, the per-bar state was never populated for this
+        thread/run — fail loudly instead of returning the placeholder (which
+        previously recursed forever) or a fabricated ``na`` (which would let the
+        strategy keep computing on wrong values). A clear error surfaces the
+        real problem instead of producing silently incorrect trades.
+        """
         from pynecore import lib
-        return getattr(lib, getattr(self, 'name'), self)
+        name = getattr(self, 'name')
+        value = getattr(lib, name, None)
+        if value is None or isinstance(value, Source):
+            raise RuntimeError(
+                f"lib.{name} is still a Source placeholder when its value was "
+                f"needed. The per-bar OHLC/time state was not populated for the "
+                f"current run (it must be set via "
+                f"script_runner._set_lib_properties before the script main() "
+                f"runs). This usually means the bar state was reset/corrupted "
+                f"mid-run."
+            )
+        return value
 
     def _resolve(self, other):
         """Resolve self and other to actual values"""


### PR DESCRIPTION
## 문제

러너 구동 중 다음 traceback으로 죽는 현상 (`gcat_alpha_stock.py` panicDump의 `(open - low) / open`):

```
File "pynecore/types/source.py", line 88, in __sub__
    return a - b
  [Previous line repeated 985 more times]
RecursionError: maximum recursion depth exceeded
```

수천 봉(예: ~5015)을 멀쩡히 처리하다가 특정 타이밍에만 터지는, 재현 어려운 경합성 버그였습니다.

## 원인

`pynecore.lib`는 **프로세스 전역 싱글톤**이고 OHLC(`open/high/low/close/...`)는 모든 `ScriptRunner`가 공유하는 모듈 속성입니다.

- 정상: 매 봉 `_set_lib_properties()`가 `lib.open` 등을 float으로 채움
- 정리: 러너 종료 시 `_reset_lib_vars()`가 `lib.open = Source(...)` placeholder로 되돌림

prerun이 백그라운드 스레드(`asyncio.to_thread`)에서 도는 동안, **다른 스레드(이벤트 루프/GC)에서 다른 러너의 `_reset_lib_vars`가 공유 OHLC를 placeholder로 blank**시키는 cross-thread 오염이 발생합니다. 이 상태에서 `open - low`가 `Source.__sub__ → _get_value → 여전히 Source → __sub__ …`로 무한 재귀합니다. (`_get_value`의 `getattr(lib, name, self)` 기본값이 `self`라 "값 없음"이 명확한 에러가 아니라 무한 재귀로 변질되던 것도 한몫)

## 변경 사항

**1. per-bar 상태를 스레드-로컬로 격리 (`pynecore/lib/__init__.py`)** — 근본 해결
- per-bar 가변 필드 14개(OHLC, `hl2/hlc3/ohlc4/hlcc4`, `bar_index/last_bar_index`, `_time/last_bar_time/_datetime`)를 `threading.local` 스토어(`_bar_state`)에 담고, `lib` 모듈의 `__class__`를 프로퍼티 디스크립터를 가진 `_LibModule`로 치환
- → `lib.open` 읽기/`lib.open = ...` 쓰기가 모두 **호출 스레드 자기 슬롯**으로 라우팅 → 다른 스레드의 reset이 진행 중 러너에 구조적으로 닿을 수 없음. 락 불필요
- 모듈 내부 bare-name 참조 8곳(`_time`×5, `bar_index`×2, `_datetime`×1)을 `_bar_state` 경유로 변경해 프로퍼티와의 값 어긋남(누수) 제거
- `request.security`의 same-thread save/restore, AST 주입 `getattr(lib, "x", na)` 경로는 무수정으로 그대로 동작

**2. `Source._get_value` fail-loud (`pynecore/types/source.py`)**
- placeholder를 만나면 `self` 반환(무한 재귀)도, `na` 반환(조용한 오계산)도 아닌 **명확한 `RuntimeError`로 즉시 실패**. 트레이딩 전략 특성상 잘못된 값으로 진행하는 것보다 시끄럽게 죽는 게 안전
- 합법적 `na` 값은 `Source`가 아니므로 정상 통과

**3. 불필요해진 감지/복구 dead code 제거 (`pynecore/core/script_runner.py`)**
- 격리로 발동 불가능해진 "Source placeholder detected … restoring" 블록 제거. 이 블록의 "조용히 복원 후 계속 진행"은 위 fail-loud와 상충(버그 은폐 가능)
- 함께 고아가 된 `_LAST_LIB_RESET_CONTEXT` 전역 + 진단 로직, 그 용도뿐이던 `threading`/`traceback` import, 모듈 스코프 `Source` import 정리

## 검증

- 단위: 모듈 클래스 치환 / get·set / `getattr` 경로 정상, **스레드 격리 확인**(워커=999, 메인=5.0 독립), placeholder 산술 시 `RecursionError`가 아닌 `RuntimeError`
- end-to-end: `gcat_alpha_stock.py`를 NVDA 5m 데이터로 **43,189봉 완주(크래시 지점의 8배+), RecursionError/Traceback 0**, placeholder 감지 로그 0
- 단일 스레드에선 thread-local과 공유 전역이 동일 값 → **수치 결과 변화 없음**

## 호환성

- `develop` 대비 충돌 없음(clean merge). 공통 수정 파일은 `script_runner.py`뿐이며, develop의 `bf02901`(`_set_lib_properties` OHLC 라운딩 제거)과는 서로 다른 함수라 자동 병합됨
- 머지 후 `_set_lib_properties`는 develop 버전(raw OHLC) 유지 — 격리 로직은 저장값의 라운딩 여부와 무관하게 동작

🤖 Generated with [Claude Code](https://claude.com/claude-code)
