### PR TITLE
fix: OKX hidden-bar 실시간 alert/marker 처리 및 cold-start seed

### DIFF
--- a/data_service/collector_loop.py
+++ b/data_service/collector_loop.py
@@ -89,7 +89,8 @@ async def fix_missing_bars_loop(
 
         async with state.lock:
             bars = state.live_bars
-            if len(bars) < 2:
+            # print(f"[collector_loop] bars: {bars}")
+            if len(bars) < 1:
                 continue
 
             last_open_ts = bars[-1][0]
@@ -108,4 +109,5 @@ async def fix_missing_bars_loop(
             # OKX policy will hide it; BITGET/Hyperliquid policy will still treat it as a visible bar.
             fake = [missing_ts, prev_close, prev_close, prev_close, prev_close, 0.0]
             bars.append(fake)
+            # print(f"[collector_loop] fake bars appended: {fake}")
             state.last_fix_bar_ts = missing_ts

--- a/data_service/file_update_loop.py
+++ b/data_service/file_update_loop.py
@@ -202,6 +202,24 @@ async def file_update_loop(
         async with state.lock:
             bars = state.live_bars
 
+            # 0) cold-start seed: 히스토리 준비 후에도 라이브 거래가 한 건도 없어
+            # live_bars 가 비어 있으면 파일 마지막 바로 1개 seed 한다. 그래야
+            # fix_missing_bars_loop 가 prev_close 를 얻어 no-trade 구간에도 fake bar
+            # 를 만들고 파일/전략 시계가 전진한다 (steady-state 와 동일 동작).
+            # seed 가 없으면 첫 거래 전까지 live_bars 가 [] 라 file_update 가 멈춘다.
+            if history_download_complete and ohlcv_path.exists() and len(bars) == 0:
+                try:
+                    with OHLCVReader(ohlcv_path) as reader:
+                        last = reader.read(reader.size - 1)
+                        reader.close()
+                    bars.append([
+                        int(last.timestamp) * 1000,
+                        float(last.open), float(last.high), float(last.low),
+                        float(last.close), float(last.volume),
+                    ])
+                except Exception as e:
+                    print(f"[data_service] cold-start live_bars seed skipped: {e}")
+
             # 1) file missing -> download history
             if not ohlcv_path.exists():
                 # Compute since date for history download.

--- a/pynecore/lib/strategy/__init__.py
+++ b/pynecore/lib/strategy/__init__.py
@@ -828,7 +828,7 @@ class Position:
 
         if not realtime_trade() and order.alert_message:
             alert(order.alert_message)
-        elif realtime_trade() and order.alert_message:
+        elif realtime_trade() and not pre_run() and order.alert_message:
             # print(f"order.bar_index: {order.bar_index}, last_bar_index: {last_bar_index()}")
             # Real time trade 에서는 최종 봉이 확정되고 새로운 봉이 생길때에만 alert 이 울리도록 함
             if order.bar_index == last_bar_index() - 1:

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -101,8 +101,18 @@ def clear_local_state() -> None:
     plot_options.clear()
 
 
-def on_entry_event(trade):
-    """Callback for entry events"""
+def on_entry_event(trade, runner=None):
+    """Callback for entry events.
+
+    pre_run-gated: the runner is destroyed and rebuilt every cycle, and prerun
+    replays the whole history re-filling every order. Emitting markers during that
+    replay would duplicate them (and, on OKX, a hidden-bar fill replays onto a
+    different visible bar than the real-time fake-bar fill, so dedup-by-time fails).
+    We emit only on real-time fills (run_ready, pre_run=False) and on the one-time
+    full-history pre-run after a history download (also pre_run=False).
+    """
+    if runner is not None and getattr(runner.script, "pre_run", False):
+        return
     event = {
         "type": "trade_entry",
         "time": int(trade.entry_time / 1000),
@@ -114,8 +124,10 @@ def on_entry_event(trade):
     trade_event_queue.append(event)
 
 
-def on_close_event(trade):
-    """Callback for close events"""
+def on_close_event(trade, runner=None):
+    """Callback for close events. pre_run-gated; see on_entry_event."""
+    if runner is not None and getattr(runner.script, "pre_run", False):
+        return
     event = {
         "type": "trade_close",
         "time": int(trade.exit_time / 1000),
@@ -275,8 +287,8 @@ AppendableIterable[OHLCV], OHLCVReader] | None:
                 runner.init_step()
 
                 # Register trade event callbacks
-                runner.script.position.on_entry_callback = on_entry_event
-                runner.script.position.on_close_callback = on_close_event
+                runner.script.position.on_entry_callback = partial(on_entry_event, runner=runner)
+                runner.script.position.on_close_callback = partial(on_close_event, runner=runner)
                 runner.script.position.on_alert_callback = partial(on_alert_event, runner=runner)
                 # Register plot event callback
                 runner.script.on_plot_callback = on_plot_event
@@ -434,8 +446,19 @@ async def main():
     DATA_WS = f"ws://127.0.0.1:{data_service_port}/ws"
 
     ctx: Optional[RunnerCtx] = None
+    last_ws = None
+    # Re-emit all trade markers on the next prerun when the connection is fresh
+    # (runner restart/reconnect) or the script was edited mid-run. Trade-event
+    # callbacks are pre_run-gated, so a cleared trades_history (reset_history on
+    # reconnect, or script_modified on edit) would otherwise not be re-populated
+    # until a full restart. A redundant re-emit (reconnect without change) is
+    # harmless: data_service dedupes by exact event.
+    pending_full_reemit = False
 
     async for ws, raw in ws_loop():
+        if ws is not last_ws:
+            last_ws = ws
+            pending_full_reemit = True
         try:
             msg = json.loads(raw)
         except Exception:
@@ -469,6 +492,7 @@ async def main():
                 current_hashes = compute_script_hashes(SCRIPT_PATH)
                 previous_hashes = load_script_hashes(SCRIPT_HASH_PATH)
                 if current_hashes != previous_hashes:
+                    pending_full_reemit = True
                     await ws.send(json.dumps({"type": "script_modified"}))
                     clear_local_state()
                     write_script_hashes(SCRIPT_HASH_PATH, current_hashes)
@@ -502,7 +526,17 @@ async def main():
             if mtype == "prerun_ready_after_history_download":
                 prerun_range = size
                 runner.script.pre_run = False
+            elif pending_full_reemit:
+                # Fresh connection (runner restart/reconnect) or mid-run script edit:
+                # trades_history was (or may have been) cleared, and trade-event callbacks
+                # are pre_run-gated, so a normal (pre_run=True) prerun would NOT re-emit
+                # the historical markers, leaving the chart empty until a restart. Run this
+                # one prerun with pre_run=False so the gated callbacks re-emit all historical
+                # markers. prerun_range stays size-1: the last open bar is still left for
+                # run_ready, so no spurious last-bar alert fires (its fill bar isn't stepped).
+                runner.script.pre_run = False
             await asyncio.to_thread(run_prerun_steps, runner, prerun_range)
+            pending_full_reemit = False
             # print("=== Pre-run finished ===")
 
             try:
@@ -673,6 +707,28 @@ async def main():
                     step_res = ctx.runner.step()
                     if step_res is None:
                         break
+
+                # OKX hidden-bar fix:
+                # 새로 열린 봉이 volume 0 hidden bar 면 new_ohlcv 가 stream 에 append 되지
+                # 않아(line 619-620) confirmed bar 의 main() 에서 접수된 주문을 체결할
+                # process_orders() 패스가 없어 webhook alert 이 나가지 않는다. fake bar 의
+                # open(=직전 종가)으로 대기 주문만 체결시켜 alert 을 발생시킨다. main() 은
+                # 호출하지 않는다 (hidden bar 는 전략 로직/visible bar_index 에 들어가면 안 됨).
+                # script.last_bar_index 는 위에서 confirmed_bar_index + 1 로 맞춰져 있어
+                # realtime alert 게이트(order.bar_index == last_bar_index() - 1)가 성립한다.
+                # BITGET/Hyperliquid 는 new_visible=True 라 기존 new bar step 경로를 그대로 탄다.
+                if not new_visible and ctx.runner.script.position is not None:
+                    from pynecore import lib
+                    from pynecore.core.script_runner import _set_lib_properties
+                    _set_lib_properties(new_ohlcv, confirmed_bar_index + 1,
+                                        ctx.runner.tz, lib)
+                    # Fill the pending order on the fake bar so the webhook alert fires
+                    # AND the chart trade marker is emitted in real time (pre_run is False
+                    # here). The duplicate that prerun replay would otherwise create (it
+                    # re-fills on the next visible bar) is prevented by pre_run-gating the
+                    # trade-event callbacks (see on_entry_event/on_close_event): only this
+                    # real-time fill emits a marker, prerun replay does not re-emit.
+                    ctx.runner.script.position.process_orders()
 
                 # Send trade events to data_service
                 if trade_event_queue:


### PR DESCRIPTION
## 배경
OKX는 거래량 0인 봉을 hidden 처리한다(차트 미표시 + 전략 계산 제외). data_service는 무거래 구간에 volume 0.0인 fake new bar를 생성하는데, 이로 인해 실시간 alert·마커·파일 갱신에서 여러 문제가 발생했다.

## 변경 사항

### 1. OKX hidden-bar alert 누락 해결 (`runner_service/main.py`)
confirmed 봉에 시그널이 발생했는데 new bar가 fake(volume 0)면 `process_orders`가 진행되지 않아 webhook alert이 누락됨 → fake bar의 open(=직전 종가)으로 대기 주문을 체결시켜 alert 발사.

### 2. 마커 중복/분리/지연 해결 (`runner_service/main.py`)
runner는 매 cycle 재구축되며 prerun이 전체 히스토리를 재체결·재emit한다. OKX hidden-bar에선 실시간 fill과 prerun fill이 서로 다른 봉에 떨어져 dedup이 실패 → 마커 중복.
- `on_entry_event`/`on_close_event`를 `pre_run` 게이팅 → 실시간 fill과 1회 full prerun에서만 마커 emit, prerun 재생은 재emit 안 함.
- `pending_full_reemit`: 새 연결(runner 재시작/재접속) 또는 스크립트 mid-run 편집 시 해당 prerun을 `pre_run=False`로 돌려 과거 마커 재populate.

### 3. cold-start seed (`data_service/file_update_loop.py`)
무거래 기동 시 `live_bars`가 빈 채로 유지되면 file_update가 멈춰 파일/전략 시계가 정지함 → 히스토리 준비 후 파일 마지막 봉으로 `live_bars`를 1개 seed.

### 4. 의존 변경
- `collector_loop.py`: `fix_missing_bars_loop` 임계값 `len(bars) < 2` → `< 1` (단일 seed 봉만으로도 fake bar 생성 — cold-start seed의 필수 의존성). 임시 디버그 print 주석 처리.
- `strategy/__init__.py`: realtime alert 게이트에 `not pre_run()` 추가 (prerun 재생 시 alert 중복/스팸 방지).

## 검증
- 변경 Python 파일 `py_compile` 통과.
- BITGET/Hyperliquid 등 non-OKX는 `new_visible=True`라 기존 경로를 그대로 타므로 영향 없음.

## 알려진 trade-off
- OKX 진짜 무거래봉(해당 간격 전 구간 volume 0): 마커가 hidden 슬롯에 잠깐 표시될 수 있음(드묾, cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)