### PR TITLE
perf: PyneCore 백테스트 런타임 오버헤드 최적화 (약 15.5s → 8.7s)

### DIFF
--- a/pynecore/core/datetime.py
+++ b/pynecore/core/datetime.py
@@ -98,6 +98,12 @@ def parse_timezone(timezone: str | None) -> ZoneInfo:
     return ZoneInfo(zone)
 
 
+# Result cache for parse_datestring. The parse depends on syminfo.timezone
+# (via parse_timezone(None) for strings without an explicit timezone), so the
+# timezone must be part of the key.
+_datestring_cache: dict[tuple[str, str], datetime] = {}
+
+
 def parse_datestring(datestring: str) -> datetime:
     """
     Parse date string using multiple formats.
@@ -111,7 +117,20 @@ def parse_datestring(datestring: str) -> datetime:
     """
     datestring = datestring.strip()
     if not datestring:
+        # Depends on the current time, not cacheable
         return datetime.now(UTC).replace(hour=0, minute=0, second=0, microsecond=0)
+
+    cache_key = (datestring, str(syminfo.timezone))
+    try:
+        return _datestring_cache[cache_key]
+    except KeyError:
+        pass
+    result = _parse_datestring_impl(datestring)
+    _datestring_cache[cache_key] = result
+    return result
+
+
+def _parse_datestring_impl(datestring: str) -> datetime:
 
     # Try parsing ISO 8601 style dates WITH TIME first (handles both T and space separator)
     iso_match = re.match(

--- a/pynecore/core/function_isolation.py
+++ b/pynecore/core/function_isolation.py
@@ -36,21 +36,6 @@ def isolate_function(
     if call_id is None:
         return func  # type: ignore
 
-    # If it is a type object, return it as is
-    if isinstance(func, type):
-        return func  # type: ignore
-
-    # If it is a classmethod (bound method where __self__ is a class), return it as is
-    if hasattr(func, '__self__') and isinstance(func.__self__, type):
-        return func  # type: ignore
-
-    # Check if this is an Exported proxy and unwrap it
-    if isinstance(func, Exported):
-        unwrapped_func = func.__fn__
-        if unwrapped_func is None:
-            raise ValueError("Exported proxy has not been initialized with a function yet")
-        func = unwrapped_func
-
     # If it is an overloaded function, returned by the dispatcher
     is_overloaded = call_id == '__overloaded__?'
 
@@ -65,24 +50,51 @@ def isolate_function(
     if is_overloaded:
         del _function_cache[call_id_key]
 
-    try:
-        # If a function is cached we can just call it
-        isolated_function = _function_cache[call_id_key]
+    # Cache hit is the common case in the bar loop, so it is checked before any
+    # type/proxy inspection of func (those only matter when building a new entry)
+    isolated_function = _function_cache.get(call_id_key)
+    if isolated_function is not None:
+        if closure_argument_count != -1:
+            return isolated_function
 
-        if closure_argument_count == -1:  # If closures have been converted to  arguments, no closure is needed
-            # We need to create new instance in every run only if the function is inside the main function
-            # Create a new function with original closure and isolated globals
-            isolated_function = FunctionType(
-                func.__code__,
-                isolated_function.__globals__,
-                func.__name__,
-                func.__defaults__,
-                func.__closure__
-            )
+        if isinstance(func, Exported):
+            unwrapped_func = func.__fn__
+            if unwrapped_func is None:
+                raise ValueError("Exported proxy has not been initialized with a function yet")
+            func = unwrapped_func
 
-        return isolated_function
-    except KeyError:
-        pass
+        # Functions inside main are redefined every bar with fresh closure cells, so the
+        # cached instance must be rebound to the current closure. Module-level functions
+        # and overload dispatchers keep the same code/closure/defaults objects, so the
+        # cached instance can be returned as is - no FunctionType recreation needed.
+        if (isolated_function.__code__ is func.__code__
+                and isolated_function.__closure__ is func.__closure__
+                and isolated_function.__defaults__ is func.__defaults__):
+            return isolated_function
+
+        # Create a new function with original closure and isolated globals
+        return FunctionType(
+            func.__code__,
+            isolated_function.__globals__,
+            func.__name__,
+            func.__defaults__,
+            func.__closure__
+        )
+
+    # If it is a type object, return it as is
+    if isinstance(func, type):
+        return func  # type: ignore
+
+    # If it is a classmethod (bound method where __self__ is a class), return it as is
+    if hasattr(func, '__self__') and isinstance(func.__self__, type):
+        return func  # type: ignore
+
+    # Check if this is an Exported proxy and unwrap it
+    if isinstance(func, Exported):
+        unwrapped_func = func.__fn__
+        if unwrapped_func is None:
+            raise ValueError("Exported proxy has not been initialized with a function yet")
+        func = unwrapped_func
 
     # Builtin objects have no __globals__ attribute
     try:

--- a/pynecore/core/overload.py
+++ b/pynecore/core/overload.py
@@ -1,3 +1,4 @@
+import builtins
 from typing import (TypeVar, Callable, get_type_hints, overload as typing_overload,
                     Any, Type, Union, get_args, get_origin, cast)
 from inspect import signature
@@ -15,17 +16,21 @@ __scope_id__ = ""
 
 
 class Implementation:
-    __slots__ = ('func', 'sig', 'type_hints', 'param_types')
+    __slots__ = ('func', 'sig', 'type_hints', 'param_types', 'min_args')
     func: Callable
     sig: Any  # Signature object
     type_hints: dict
     param_types: tuple  # Cached parameter types for quick checking
+    min_args: int  # Number of parameters without a default value
 
     def __init__(self, func: Callable, sig: Any, type_hints: dict, param_types: tuple):
         self.func = func
         self.sig = sig
         self.type_hints = type_hints
         self.param_types = param_types
+        self.min_args = builtins.sum(
+            1 for p in sig.parameters.values() if p.default is p.empty
+        )
 
 
 _registry: dict[str, list[Implementation]] = defaultdict(list)
@@ -122,9 +127,10 @@ def overload(func: Callable[..., T]) -> Callable[..., T]:
         # noinspection PyShadowingNames
         def dispatcher(*args: Any, **kwargs: Any) -> Any:
             # Quick path: try direct positional args match first
+            # (trailing parameters with defaults may be omitted)
             if not kwargs:
                 for impl in _registry[qualname]:
-                    if len(args) == len(impl.param_types):
+                    if impl.min_args <= len(args) <= len(impl.param_types):
                         if all(_check_type(arg, type_)
                                for arg, (_, type_) in zip(args, impl.param_types)):
                             return isolate_function(impl.func, '__overloaded__', __scope_id__)(*args)

--- a/pynecore/core/safe_convert.py
+++ b/pynecore/core/safe_convert.py
@@ -1,4 +1,5 @@
 from ..types import NA
+from ..types.na import na_float
 
 
 def safe_div(a: float | NA[float], b: float | NA[float]):
@@ -10,14 +11,14 @@ def safe_div(a: float | NA[float], b: float | NA[float]):
     @param b: The denominator.
     @return: The division result, or NA(float) if b is zero or NA.
     """
-    if b == 0 or b == 0.0:
-        return NA(float)
-    if a is NA() or b is NA():
-        return NA(float)
+    if b == 0:  # NA compares False, handled below
+        return na_float
+    if isinstance(a, NA) or isinstance(b, NA):
+        return na_float
     try:
         return a / b
     except (ZeroDivisionError, TypeError):
-        return NA(float)
+        return na_float
 
 
 def safe_float(value: float | NA[float]) -> float | NA[float]:

--- a/pynecore/core/series.py
+++ b/pynecore/core/series.py
@@ -193,12 +193,11 @@ class SeriesImpl(Generic[T]):
             if key < 0:
                 raise IndexError("Negative indices not supported!")
             if key >= self._size:
-                return cast(NA[T], NA())
+                return NA()  # type: ignore[return-value]
             pos = self._write_pos - 1 - key
             if pos < 0:
                 pos += self._capacity
-            result = self._buffer[pos]
-            return cast(T | NA[T], result)
+            return self._buffer[pos]  # type: ignore[return-value]
 
         elif isinstance(key, slice):
             # Handle slice notation

--- a/pynecore/lib/__init__.py
+++ b/pynecore/lib/__init__.py
@@ -340,7 +340,7 @@ def alertcondition(*_, **__):
     In the future this could be used to define alert conditions
     that can be triggered based on boolean expressions.
     """
-    if bar_index == 0:  # Only check if it is the first bar for performance reasons
+    if _bar_state.bar_index == 0:  # Only check if it is the first bar for performance reasons
         # Check if it is called from the main function
         if sys._getframe(1).f_code.co_name != 'main':  # noqa
             raise RuntimeError("The alertcondition function can only be called from the main function!")
@@ -847,8 +847,18 @@ def _make_bar_property(_name):
 for _field in _BAR_STATE_FIELDS:
     setattr(_LibModule, _field, _make_bar_property(_field))
 
-# Swap the live module object's type so the descriptors take effect. The plain
-# module-level assignments above (e.g. `open = Source("open")`) stay in the
-# module __dict__ as type-hint anchors but are shadowed by these descriptors for
-# every attribute access.
+# Swap the live module object's type so the descriptors take effect.
 sys.modules[__name__].__class__ = _LibModule
+
+# Drop the module-__dict__ anchors for the bar-state fields (e.g. the
+# `open = Source("open")` placeholder assignments above). CPython 3.14's
+# LOAD_ATTR specializes `lib.<name>` into a direct module-__dict__ read after
+# the first call, silently bypassing the property descriptors on _LibModule —
+# the second `lib.close` read would return the stale Source anchor instead of
+# the thread-local bar value. With the anchors gone the names can't specialize
+# as module-dict loads, so every access stays on the descriptor path, while
+# non-bar-state attributes (lib.ta, lib.math, ...) keep the fast specialized
+# path. The placeholder semantics are preserved by _BarState.__init__, which
+# seeds the same Source defaults per thread.
+for _field in _BAR_STATE_FIELDS:
+    globals().pop(_field, None)

--- a/pynecore/lib/__init__.py
+++ b/pynecore/lib/__init__.py
@@ -368,12 +368,15 @@ def is_na(source: Any = None) -> bool | NA:
     """
     Check if the source is NA
     """
+    # Most common case first: an NA instance
+    if isinstance(source, NA):
+        return True
     if source is None:
         return NA(None)
     # If the source is a type or GenericAlias (like list[float]), return NA of that type
-    if isinstance(source, (type, GenericAlias)) and source is not NA:
-        return NA(source)
-    return isinstance(source, NA) or source is NA
+    if isinstance(source, (type, GenericAlias)):
+        return True if source is NA else NA(source)
+    return False
 
 
 # In Pine Script, na is both a property and a function

--- a/pynecore/lib/ta.py
+++ b/pynecore/lib/ta.py
@@ -527,7 +527,7 @@ def ema(source: float, length: int, _alpha: float | None = None) -> float | NA[f
     # Use SMA at warming stage
     if isinstance(last_val, NA):
         last_val = sma(source, length)
-        return cast(float | NA[float], last_val)
+        return last_val
 
     # Warmed result
     last_val = alpha * source + (1 - alpha) * last_val
@@ -606,8 +606,8 @@ def highest(source: Series[float], length: int, _bars: bool = False, _tuple: boo
     if _bars:
         return -max_index
     if _tuple:
-        return cast(float | tuple[float | NA[float], float | NA[float]], (last_max, -max_index))
-    return cast(float | NA[float], last_max)
+        return last_max, -max_index
+    return last_max
 
 
 @overload
@@ -804,8 +804,8 @@ def lowest(source: Series[float], length: int,
     if _bars:
         return -min_index
     if _tuple:
-        return cast(float | tuple[float | NA[float], float | NA[float]], (last_min, -min_index))
-    return cast(float | NA[float], last_min)
+        return last_min, -min_index
+    return last_min
 
 
 @overload

--- a/pynecore/lib/ta.py
+++ b/pynecore/lib/ta.py
@@ -871,7 +871,7 @@ def max(source: Series[float]) -> float | NA[float]:
     max_val: Persistent[float | NA] = NA(float)
     if max_val < source or isinstance(max_val, NA):
         max_val = source
-    return cast(float | NA[float], max_val)
+    return max_val  # type: ignore[return-value]
 
 
 def median(source: Series[TFI], length: int) -> TFI | NA[TFI] | Series[TFI]:
@@ -964,7 +964,7 @@ def min(source: Series[float]) -> float | NA:
     min_val: Persistent[float | NA] = NA(float)
     if min_val > source or isinstance(min_val, NA):
         min_val = source
-    return cast(float | NA[float], min_val)
+    return min_val  # type: ignore[return-value]
 
 
 def mode(source: Series[TFI], length: int) -> TFI | NA:
@@ -1645,7 +1645,7 @@ def sar(start: float = 0.02, inc: float = 0.02, max: float = 0.2) -> float | NA[
                 af = builtins.min(af + inc, max)
 
     sar_val = next_sar
-    return cast(float | NA[float], sar_val)
+    return sar_val  # type: ignore[return-value]
 
 
 def sma(source: Series[float], length: int) -> float | NA[float]:


### PR DESCRIPTION
## 개요

70,673바 백테스트(`gcat_alpha`, 5분봉) 기준 **바 단위 런타임 오버헤드**를 줄여 실행 시간을 단축합니다. 병목은 데이터 I/O나 전략 로직이 아니라 PyneCore 프레임워크의 호출당 비용(런타임 `cast` 평가, overload slow path, 함수 격리 재생성 등)이었습니다.

모든 변경은 **시그널 출력 224건이 baseline과 완전히 동일**함을 매 단계 `diff`로 검증했습니다 (결과 무결성 보장).

## 커밋 단위 변경 내용

**1. `fix: CPython 3.14 LOAD_ATTR 모듈 특수화로 인한 bar-state property 우회 수정`**
- CPython 3.14의 LOAD_ATTR 바이트코드 특수화가 두 번째 접근부터 `_LibModule`의 property 디스크립터를 건너뛰고 모듈 `__dict__`의 Source 앵커를 직접 읽어, `request.security` 경유 시 bar state가 placeholder로 오염되어 `"lib.close is still a Source placeholder"` 에러로 백테스트가 실패하던 문제 수정.
- 클래스 스왑 직후 bar-state 필드의 `__dict__` 앵커를 제거해 특수화 자체를 차단. `lib.ta`/`lib.math` 등 비-bar-state 속성은 빠른 경로를 유지하므로 성능 저하 없음.
- (성능 패치 검증의 전제 조건이라 함께 포함)

**2. `perf: 핫패스 런타임 cast 제거 및 overload quick path 확대` (15.5s → 8.7s)**
- `series.py __getitem__`: `cast(T | NA[T], ...)` 제거. cast 자체는 no-op이나 첫 인자 `T | NA[T]` 표현식이 매 호출 평가되어 시리즈 인덱싱이 `typing` Union 생성을 유발.
- `overload.py`: `min_args` 캐싱 + quick path 조건을 `min_args <= len(args) <= len(param_types)`로 확대. 디폴트 인자를 생략한 호출(디스패치의 86%)이 `inspect.Signature.bind` slow path로 떨어지던 문제 해소. 등록된 전체 오버로드에서 디스패치 결과가 기존 slow path와 동일함을 전수 확인.
- `ta.py`: `ema`/`highest`/`lowest` 반환부 런타임 cast 제거.

**3. `perf: parse_datestring 결과 캐싱 및 safe_div/is_na 정리` (약 12%)**
- `datetime.py`: `parse_datestring` 결과를 `(날짜문자열, syminfo.timezone)` 키로 캐싱. 타임존 의존성을 키에 포함, 빈 문자열(현재시각 의존)은 제외.
- `safe_convert.py`: 중복 0 비교 단일화, `a is NA()`(잠재 버그) → `isinstance` 교체, `NA(float)` → `na_float` 싱글톤.
- `is_na`: 최빈 케이스(NA 인스턴스)를 첫 분기로.

**4. `perf: isolate_function 캐시 히트 경로 최적화` (약 14%)**
- 바당 약 94회·총 665만 회 호출되는 핫함수. 캐시 조회를 함수 첫머리로 이동(히트 시 불필요한 `isinstance`/`hasattr` 검사 회피), 코드/클로저/디폴트가 동일 객체면 `FunctionType` 재생성 생략(665만 회 → 7.1만 회, 99% 감소). main 내부 재정의 함수는 클로저 identity가 달라 기존대로 재생성되므로 시맨틱 동일.

**5. `perf: ta.py min/max/sar 반환부 런타임 cast 제거`**
- 2번과 동일 패턴을 `ta.max`/`ta.min`/`ta.sar`에도 적용. 이 전략에선 미사용이라 효과 0이지만, 이들을 바 단위로 쓰는 전략(특히 Parabolic SAR 추세 전략)을 위한 핫패스 정리.

## 측정 / 검증 방법

```bash
# 시그널 무결성 (벽시계 시각 제거 후 비교)
sed 's/^\[[^]]*\] //' base.log    | grep '🚨' > base_signals.txt
sed 's/^\[[^]]*\] //' patched.log | grep '🚨' > patch_signals.txt
diff base_signals.txt patch_signals.txt   # → SIGNALS IDENTICAL (224건)
```

> 참고: `pyne run` CLI가 `workdir/config/realtime_trade.toml`의 `[realtime] enabled`를 읽어 동작 모드를 정하므로, 백테스트 검증은 `enabled = false` 상태에서 수행해야 시그널이 정상 출력됩니다.

## 범위 밖 (이 PR에 미포함)
- `setup.sh` 변경 2건은 `setup/python-selection` 브랜치로 분리.
- `isolate_function` 호출 오버헤드 자체 제거(transformer call-site 캐시 변수), core 모듈 mypyc/Cython 컴파일은 후속 과제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)