### PR TITLE
chore: setup.sh Python 자동 탐지 및 source 실행 호환성 개선

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,41 +1,52 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
-find_python() {
-  local dir path
+_find_python() {
+  local candidate minor
 
-  IFS=':' read -ra path_dirs <<< "$PATH"
-  for dir in "${path_dirs[@]}"; do
-    [[ -d "$dir" ]] || continue
+  {
+    command -v python3 2>/dev/null || true
+    command -v python 2>/dev/null || true
 
-    for path in "$dir"/python3 "$dir"/python3.[0-9]*; do
-      [[ -x "$path" && ! -d "$path" ]] || continue
-
-      "$path" - <<'PY' 2>/dev/null || continue
+    minor=11
+    while [ "$minor" -le 99 ]; do
+      command -v "python3.$minor" 2>/dev/null || true
+      minor=$((minor + 1))
+    done
+  } | while IFS= read -r candidate; do
+      [ -n "$candidate" ] || continue
+      [ -x "$candidate" ] || continue
+      "$candidate" - <<'PY' 2>/dev/null || continue
 import sys
 raise SystemExit(0 if sys.version_info >= (3, 11) else 1)
 PY
-
-      "$path" - <<'PY'
+      "$candidate" - <<'PY'
 import sys
 version = sys.version_info
 print(f"{version.major:03d}.{version.minor:03d}.{version.micro:03d}\t{sys.executable}")
 PY
-    done
-  done | LC_ALL=C sort -u | LC_ALL=C sort | tail -n 1 | cut -f2-
+    done | LC_ALL=C sort -u | tail -n 1 | cut -f2-
 }
 
-PYTHON_BIN="$(find_python)"
-if [[ -z "$PYTHON_BIN" ]]; then
-  echo "Need Python 3.11+" >&2
-  exit 1
-fi
+_setup_main() {
+  local python_bin
 
-"$PYTHON_BIN" -m venv ./venv
-source venv/bin/activate
+  python_bin="$(_find_python)"
+  if [ -z "$python_bin" ]; then
+    echo "Need Python 3.11+" >&2
+    return 1
+  fi
 
-python -m ensurepip --upgrade
-python -m pip install --upgrade setuptools
+  "$python_bin" -m venv ./venv || return 1
+  . venv/bin/activate || return 1
 
-python -m pip install -e ".[all]"
-python -m pip install python-dateutil dotenv flask pandas numpy 'uvicorn[standard]' fastapi tomlkit
+  python -m ensurepip --upgrade || return 1
+  python -m pip install --upgrade setuptools || return 1
+
+  python -m pip install -e ".[all]" || return 1
+  python -m pip install python-dateutil dotenv flask pandas numpy 'uvicorn[standard]' fastapi tomlkit || return 1
+}
+
+_setup_main "$@"
+_setup_status=$?
+unset -f _find_python _setup_main 2>/dev/null || true
+return "$_setup_status" 2>/dev/null || exit "$_setup_status"

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,37 @@
-python3.12 -m venv ./venv
+#!/usr/bin/env bash
+set -euo pipefail
+
+find_python() {
+  local dir path
+
+  IFS=':' read -ra path_dirs <<< "$PATH"
+  for dir in "${path_dirs[@]}"; do
+    [[ -d "$dir" ]] || continue
+
+    for path in "$dir"/python3 "$dir"/python3.[0-9]*; do
+      [[ -x "$path" && ! -d "$path" ]] || continue
+
+      "$path" - <<'PY' 2>/dev/null || continue
+import sys
+raise SystemExit(0 if sys.version_info >= (3, 11) else 1)
+PY
+
+      "$path" - <<'PY'
+import sys
+version = sys.version_info
+print(f"{version.major:03d}.{version.minor:03d}.{version.micro:03d}\t{sys.executable}")
+PY
+    done
+  done | LC_ALL=C sort -u | LC_ALL=C sort | tail -n 1 | cut -f2-
+}
+
+PYTHON_BIN="$(find_python)"
+if [[ -z "$PYTHON_BIN" ]]; then
+  echo "Need Python 3.11+" >&2
+  exit 1
+fi
+
+"$PYTHON_BIN" -m venv ./venv
 source venv/bin/activate
 
 python -m ensurepip --upgrade


### PR DESCRIPTION
## 개요

`setup.sh`가 하드코딩된 `python3.12`에 의존하던 것을 **시스템에 설치된 Python 3.11+ 중 최신 버전을 자동 탐지**하도록 개선하고, `source`로 실행했을 때의 호환성을 보강합니다.

## 변경 내용

**1. `Update setup Python selection`**
- `python3.12 -m venv` 하드코딩 제거. `python3`, `python`, `python3.11`~`python3.99`를 순회하며 실행 가능하고 3.11 이상인 인터프리터를 찾아 **버전이 가장 높은 것을 선택**.
- 적합한 Python이 없으면 `Need Python 3.11+` 에러와 함께 종료.

**2. `setup.sh의 source 실행 호환성 개선`**
- 로직을 `_setup_main` 함수로 감싸고 각 단계에 `|| return 1` 실패 전파 추가.
- `source setup.sh` / `./setup.sh` 양쪽 모두에서 동작하도록 마지막에 `return` 실패 시 `exit`로 폴백, 임시 함수(`_find_python`/`_setup_main`)는 정리(`unset -f`).
- shebang(`#!/usr/bin/env bash`) 추가.

## 비고

- `develop` 대비 **`setup.sh` 한 파일만 변경** (50 insertions, 6 deletions).
- 이 두 커밋은 원래 perf 작업 브랜치(#20)에 섞여 있던 것을 분리해 별도 브랜치로 옮긴 것입니다. PR #20과 변경 파일이 겹치지 않아 독립적으로 머지 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)