### PR TITLE
fix: data download --from continue 재개 경계의 -1.0 volume gap 제거

### DIFF
--- a/pynecore/cli/commands/data.py
+++ b/pynecore/cli/commands/data.py
@@ -16,6 +16,7 @@ from ...providers.provider import Provider
 from ...lib.timeframe import in_seconds
 from ...core.data_converter import DataConverter, SupportedFormats as InputFormats
 from ...core.ohlcv_file import OHLCVReader
+from ...types.ohlcv import OHLCV
 
 from ...utils.rich.date_column import DateColumn
 
@@ -166,6 +167,18 @@ def download(
             if show_info:
                 rprint(sym_info)
 
+        # When resuming, capture the current last bar before opening the writer so it
+        # can be re-downloaded and replaced (and restored if the refetch comes back
+        # empty). Reading it here, while no write handle is open on the file, reuses
+        # OHLCVReader and matches how the rest of the codebase reads single bars.
+        dropped_last_bar: OHLCV | None = None
+        if time_from == "continue" and not truncate \
+                and provider_instance.ohlcv_path and provider_instance.ohlcv_path.exists():
+            with OHLCVReader(str(provider_instance.ohlcv_path)) as resume_reader:
+                if resume_reader.size >= 2:
+                    dropped_last_bar = resume_reader.read(resume_reader.size - 1)
+                resume_reader.close()
+
         # Open the OHLCV file and start downloading
         with provider_instance as ohlcv_writer:
             # Truncate file if overwrite is True
@@ -176,9 +189,20 @@ def download(
             # If the start date is "continue" (default), we resume from the last download
             if time_from == "continue":
                 if ohlcv_writer.end_timestamp:  # Resume from last download
+                    # Re-download and replace the last stored bar instead of starting
+                    # one interval after it. The last bar may have been saved while
+                    # still in-progress (incomplete), and resuming `since` at it rather
+                    # than after it also prevents a -1.0 gap at the boundary: some
+                    # exchanges skip the `since` candle on a full batch (e.g. Bitget
+                    # returns since+timeframe), which would leave the bar right after
+                    # the old resume point (last + interval) gap-filled.
+                    if dropped_last_bar is not None and ohlcv_writer.size >= 2:
+                        # Drop the last bar so it is re-downloaded; end_timestamp then
+                        # points at the previous bar, so the dropped bar is the first
+                        # one fetched back and replaced.
+                        ohlcv_writer.seek(ohlcv_writer.size - 1)
+                        ohlcv_writer.truncate()
                     time_from = datetime.fromtimestamp(ohlcv_writer.end_timestamp, UTC)
-                    # We need to add one interval to the start date to avoid downloading the same data
-                    time_from += timedelta(seconds=ohlcv_writer.interval)
                 else:  # No data, download one year as default
                     time_from = datetime.now(UTC) - timedelta(days=365)
 
@@ -231,6 +255,14 @@ def download(
 
                 # Start downloading
                 provider_instance.download_ohlcv(time_from, time_to, on_progress=cb_progress, limit=chunk_size)
+
+            # Rollback guard: if we dropped the last bar to replace it but the refetch
+            # brought back nothing up to it (transient failure / no newer bars yet),
+            # restore the original bar so `continue` never loses existing data.
+            if dropped_last_bar is not None:
+                end_ts = ohlcv_writer.end_timestamp
+                if end_ts is None or end_ts < dropped_last_bar.timestamp:
+                    ohlcv_writer.write(dropped_last_bar)
 
     except (ImportError, ValueError) as e:
         secho(str(e), err=True, fg=colors.RED)


### PR DESCRIPTION
## 문제

`pyne data download --from continue`로 이어받으면 재개 경계 바로 다음 봉의 **volume이 -1.0**으로 채워졌습니다. (예: 마지막 봉 `2026-06-03 09:20:00 UTC`에서 이어받으면 `09:25:00` 봉이 -1.0)

## 근본 원인

continue 재개 시 다운로드 시작점을 **`마지막봉 + 1interval`**(5m 경계에 정렬된 `09:25:00`)로 잡는데, 이게 Bitget의 `since`-스킵 동작과 충돌합니다.

- Bitget는 full batch(`len == limit`)일 때 `since` 캔들을 건너뛰고 **`since + timeframe`부터** 반환합니다 (`providers/ccxt.py`의 기존 주석에 명시).
- 따라서 `since=09:25:00`이면 첫 반환봉이 `09:30:00`이 되어 `09:25:00`이 누락되고, writer가 그 자리를 `prev_close` + **volume -1.0**으로 gap-fill 합니다 (`core/ohlcv_file.py`).

## 수정

저장된 마지막 봉을 드롭하고 **직전 봉(`last - interval`)부터** 재개합니다.

- 거래소가 반환하는 첫 봉이 정확히 누락되던 봉이 되어 **gap이 생기지 않습니다.**
- 마지막 봉이 새 데이터로 **교체**됩니다 (실시간 파이프라인이 in-progress 봉을 저장한 경우까지 갱신).
- 일반 거래소(`since` 봉을 그대로 반환)에서도 writer의 dedup-skip 후 동일하게 동작합니다.

**손실 방지 가드**: 다운로드 후 재fetch가 비어 있으면(일시적 실패 / 새 봉 없음) 드롭한 봉을 원복해 continue가 기존 데이터를 잃지 않도록 합니다. 드롭 대상 마지막 봉은 writer를 열기 전에 기존 `OHLCVReader.read()`로 캡처합니다(새 API 추가 없이 코드베이스 관례 재사용).

## realtime 영향 없음

`data_service`/realtime 경로는 이 분기를 타지 않습니다:
- `'continue'` 문자열을 쓰지 않고 명시적 datetime을 전달합니다.
- bar 이어받기는 `data_service/ohlcv_io.py`의 별도 함수(`update_ohlcv_data` 등)가 직접 처리하며, **이미 `last - interval`부터 재개**하고 있습니다. (이번 수정은 CLI를 realtime이 이미 하던 방식과 일치시킨 것.)

## 검증

- 실사용: continue 다운로드가 정상적으로 이어받는 것 확인.
- 오프라인 합성 테스트 3개 시나리오 모두 통과: **일반 거래소 / Bitget(since 스킵) / 빈 응답** → gap 없음, 마지막 봉 교체, 빈 응답 시 원본 복원.

변경 범위: `pynecore/cli/commands/data.py` 한 파일.

🤖 Generated with [Claude Code](https://claude.com/claude-code)