### PR TITLE
WS broadcast 큐/writer 재작성 + 대시보드 실시간 상태 표시 개선

### DIFF
--- a/data_service/main.py
+++ b/data_service/main.py
@@ -87,9 +87,9 @@ def _default_session(registry: SessionRegistry):
     return None
 
 
-async def _hub_status_heartbeat(registry: SessionRegistry, interval: float = 10.0) -> None:
+async def _hub_status_heartbeat(registry: SessionRegistry, interval: float = 1.0) -> None:
     """Periodically push the session snapshot to /ws/hub clients so the dashboard's
-    'Last bar' / status stay fresh without each client polling /api/sessions.
+    'Last bar' / price / status stay fresh without each client polling /api/sessions.
     One broadcast serves all connected dashboards (no-op when none are connected)."""
     while True:
         await asyncio.sleep(interval)

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -30,10 +30,7 @@ def build_app(registry: SessionRegistry) -> FastAPI:
     @app.websocket("/ws/hub")
     async def hub_ws(ws: WebSocket):
         await registry.hub_ws.connect(ws)
-        try:
-            await ws.send_json({"type": "sessions", "sessions": registry.snapshots()})
-        except Exception:
-            pass
+        await registry.hub_ws.send(ws, {"type": "sessions", "sessions": registry.snapshots()})
         try:
             while True:
                 # Dashboard clients only receive pushes; ignore inbound keepalive.

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -48,8 +48,8 @@ class SessionPaths:
 # ======================================================================
 # Feed: one shared data feed per (provider, exchange, symbol, timeframe).
 # Owns the collector/file_update tasks, the OHLCV file, and the live DataState.
-# Fans data-plane events (bar / prerun_ready / run_ready) out to every Session
-# subscribed to this market.
+# Fans data-plane events out to every Session subscribed to this market. Live
+# bars are chart-only; prerun_ready/run_ready are runner-only.
 # ======================================================================
 class Feed:
     def __init__(self, spec: FeedSpec) -> None:
@@ -60,9 +60,6 @@ class Feed:
         self.collector_error: Optional[str] = None
         # session_id -> Session
         self.subscribers: Dict[str, "Session"] = {}
-
-    def _ws_managers(self) -> List[WSManager]:
-        return [s.ws_manager for s in self.subscribers.values()]
 
     async def broadcast_bar(self, bar: list) -> None:
         payload = {
@@ -76,13 +73,13 @@ class Feed:
                 "volume": float(bar[5]),
             },
         }
-        for wm in self._ws_managers():
-            await wm.broadcast_json(payload)
+        for session in list(self.subscribers.values()):
+            await session.send_to_charts(payload)
 
     async def emit_event(self, payload: dict) -> None:
         # prerun_ready / run_ready fan out to every runner subscribed to this feed.
-        for wm in self._ws_managers():
-            await wm.broadcast_json(payload)
+        for session in list(self.subscribers.values()):
+            await session.send_to_runners(payload)
 
     def history_ready(self) -> bool:
         return self.paths.ohlcv_path.exists()
@@ -113,7 +110,7 @@ class Session:
         self.feed = feed
         self.paths = SessionPaths.build(spec.id)
 
-        self.ws_manager = WSManager()
+        self.ws_manager = WSManager(on_disconnect=self._cleanup_client)
         self.trades_history: List[Dict[str, Any]] = []
         self.plot_options: Dict[str, Dict[str, Any]] = {}
         self.plotchar_history: List[Dict[str, Any]] = []
@@ -154,28 +151,19 @@ class Session:
         await self.ws_manager.connect(ws)
         self.client_roles[ws] = None
         if self.runner_count > 0:
-            await ws.send_json({"type": "runner_connected"})
-
-        # Replay the feed's pending after-history prerun to every newly connected
-        # runner (each strategy's runner needs its own history prerun). Unlike the
-        # single-session version we do NOT clear it on ack, so late-joining runners
-        # on the same shared feed still receive it.
-        async with self.feed.state.lock:
-            if self.feed.state.pending_prerun_event is not None:
-                try:
-                    await ws.send_json(self.feed.state.pending_prerun_event)
-                except Exception as e:
-                    print(f"[{self.spec.id}] Failed to send pending event: {e}")
+            await self.ws_manager.send(ws, {"type": "runner_connected"})
 
     async def on_disconnect(self, ws: WebSocket) -> None:
         await self.ws_manager.disconnect(ws)
+
+    async def _cleanup_client(self, ws: WebSocket) -> None:
         role = self.client_roles.pop(ws, None)
         if role == "runner":
             self.runner_count -= 1
             if self.runner_count <= 0:
                 self.runner_count = 0
                 self.runner_ready = False
-                await self.ws_manager.broadcast_json({"type": "runner_disconnected"})
+                await self.send_to_charts({"type": "runner_disconnected"})
             await self._notify_status()
 
     async def handle_text(self, ws: WebSocket, msg_text: str) -> None:
@@ -195,18 +183,29 @@ class Session:
 
         if msg_type == "client_hello":
             role = event.get("role")
-            self.client_roles[ws] = role
             if role == "runner":
+                # Replay the feed's pending after-history prerun only after the
+                # client identifies as a runner. Until then it receives no live
+                # bars, so long pre_run cannot build up a chart-message backlog.
+                async with self.feed.state.lock:
+                    pending_prerun_event = self.feed.state.pending_prerun_event
+                if pending_prerun_event is not None:
+                    await ws_manager.send(ws, pending_prerun_event)
+
+                self.client_roles[ws] = role
                 self.runner_count += 1
                 self.runner_ready = False  # fresh runner: pre_run not done yet (amber)
-                await ws_manager.broadcast_json({"type": "runner_connected"})
+                await self.send_to_charts({"type": "runner_connected"})
                 await self._notify_status()
                 # Push this session's webhook/telegram config to the runner only
                 # (carries url/token — must not reach chart-page browsers).
-                try:
-                    await ws.send_json(self._webhook_config_payload())
-                except Exception:
-                    pass
+                await ws_manager.send(ws, self._webhook_config_payload())
+            elif role == "chart":
+                self.client_roles[ws] = role
+                if self.runner_count > 0:
+                    await ws_manager.send(ws, {"type": "runner_connected"})
+            else:
+                self.client_roles[ws] = None
 
         elif msg_type == "runner_ready":
             # Runner finished its first pre_run -> flip the LED to green.
@@ -217,7 +216,7 @@ class Session:
             last_bar_index = event.get("last_bar_index", -1)
             event_data = event.get("data")
             if isinstance(event_data, dict):
-                await ws_manager.broadcast_json({
+                await self.send_to_charts({
                     "type": "last_bar_open_fix",
                     "data": event_data,
                 })
@@ -237,7 +236,7 @@ class Session:
                                 "volume": float(last_bar.volume),
                             },
                         }
-                        await ws_manager.broadcast_json(payload)
+                        await self.send_to_charts(payload)
                         reader.close()
                 except Exception as e:
                     print(f"[{self.spec.id}] Failed to send confirmed bar: {e}")
@@ -245,12 +244,12 @@ class Session:
         elif msg_type in ("trade_entry", "trade_close"):
             if event not in self.trades_history:
                 self.trades_history.append(event)
-            await ws_manager.broadcast_json(event)
+            await self.send_to_charts(event)
 
         elif msg_type == "plotchar":
             if event not in self.plotchar_history:
                 self.plotchar_history.append(event)
-            await ws_manager.broadcast_json(event)
+            await self.send_to_charts(event)
 
         elif msg_type == "plot_options":
             self.plot_options.update(event.get("data", {}))
@@ -282,7 +281,7 @@ class Session:
                                     "time": int(candle.timestamp),
                                     "value": None if (value == "" or value is None) else float(value),
                                 }
-                                await ws_manager.broadcast_json(plot_data_event)
+                                await self.send_to_charts(plot_data_event)
                             reader.close()
                 except Exception as e:
                     print(f"[{self.spec.id}] Failed to broadcast plot data: {e}")
@@ -295,7 +294,7 @@ class Session:
             )
             if "source" in event:
                 self.chart_info["script_source"] = event.get("source") or ""
-            await ws_manager.broadcast_json({
+            await self.send_to_charts({
                 "type": "script_info",
                 "title": title,
                 "source_name": self.chart_info.get("script_source_name"),
@@ -310,11 +309,11 @@ class Session:
                 self.chart_info["script_title"] = None
                 self.chart_info["script_source_name"] = None
                 self.chart_info["script_source"] = ""
-                await ws_manager.broadcast_json({"type": "script_modified"})
+                await self.send_to_charts({"type": "script_modified"})
 
         elif msg_type == "ack_prerun_ready_after_history_download":
             # No-op: with a shared feed the pending event must reach every session's
-            # runner, so it is not cleared globally (see on_connect).
+            # runner, so it is not cleared globally (see client_hello handling).
             pass
 
     # ------------------------------------------------------------------
@@ -331,17 +330,19 @@ class Session:
             "telegram_chat_id": wh.get("telegram_chat_id", "") or "",
         }
 
-    async def _send_to_runners(self, payload: dict) -> None:
+    async def send_to_charts(self, payload: dict) -> None:
+        for ws, role in list(self.client_roles.items()):
+            if role == "chart":
+                await self.ws_manager.send(ws, payload)
+
+    async def send_to_runners(self, payload: dict) -> None:
         for ws, role in list(self.client_roles.items()):
             if role == "runner":
-                try:
-                    await ws.send_json(payload)
-                except Exception:
-                    pass
+                await self.ws_manager.send(ws, payload)
 
     async def push_webhook_config(self) -> None:
         # Runner-only (contains url/token); never broadcast to chart browsers.
-        await self._send_to_runners(self._webhook_config_payload())
+        await self.send_to_runners(self._webhook_config_payload())
 
     # ------------------------------------------------------------------
     # Status snapshot (merges feed data-plane state)

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -58,6 +58,8 @@ class Feed:
         self.state = DataState()
         self.tasks: List[Any] = []
         self.collector_error: Optional[str] = None
+        self._history_start_mtime: Optional[float] = None
+        self._history_start_time: Optional[int] = None
         # session_id -> Session
         self.subscribers: Dict[str, "Session"] = {}
 
@@ -84,10 +86,37 @@ class Feed:
     def history_ready(self) -> bool:
         return self.paths.ohlcv_path.exists()
 
+    def history_start_time(self) -> Optional[int]:
+        path = self.paths.ohlcv_path
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            self._history_start_mtime = None
+            self._history_start_time = None
+            return None
+        if self._history_start_mtime == mtime:
+            return self._history_start_time
+        try:
+            from pynecore.core.ohlcv_file import OHLCVReader
+            with OHLCVReader(path) as reader:
+                start_ts = reader.start_timestamp
+                reader.close()
+        except Exception:
+            start_ts = None
+        self._history_start_mtime = mtime
+        self._history_start_time = int(start_ts) if start_ts is not None else None
+        return self._history_start_time
+
     def last_bar_time(self) -> Optional[int]:
         bars = self.state.live_bars
         if bars:
             return int(bars[-1][0] // 1000)
+        return None
+
+    def last_price(self) -> Optional[float]:
+        bars = self.state.live_bars
+        if bars:
+            return float(bars[-1][4])
         return None
 
     def collector_status(self) -> str:
@@ -356,6 +385,7 @@ class Session:
             "exchange": self.spec.exchange,
             "symbol": self.spec.symbol,
             "timeframe": self.spec.timeframe,
+            "history_since": self.spec.history_since,
             "script_name": self.spec.script_name,
             "tv_symbol": self.logo_info.get("tv_symbol", ""),
             "symbol_logo_url": self.logo_info.get("symbol_logo_url", ""),
@@ -369,6 +399,8 @@ class Session:
             },
             "collector": feed.collector_status(),
             "history_ready": feed.history_ready(),
+            "data_since_time": feed.history_start_time(),
             "runner_connected": self.runner_count > 0,
             "last_bar_time": feed.last_bar_time(),
+            "last_price": feed.last_price(),
         }

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -145,9 +145,70 @@ tr:last-child td { border-bottom: none; }
 .market-logo { border-radius: 50%; }
 .exchange-logo { border-radius: 4px; }
 
+.last-bar-value {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+  line-height: 1.25;
+}
+.last-bar-time {
+  color: var(--muted);
+  font-size: 12px;
+  white-space: nowrap;
+}
+.last-bar-price {
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  white-space: nowrap;
+}
+
 .badge {
   font-size: 11px; padding: 2px 7px; border-radius: 10px;
   border: 1px solid var(--border); color: var(--muted);
+}
+.data-cell {
+  overflow: visible;
+}
+.data-badge-wrap {
+  position: relative;
+  display: inline-block;
+  vertical-align: middle;
+}
+.data-badge {
+  cursor: help;
+}
+.data-since-popover {
+  position: absolute;
+  z-index: 20;
+  left: 0;
+  top: calc(100% + 3px);
+  width: max-content;
+  max-width: min(320px, 80vw);
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #0b0e13;
+  color: var(--text);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  font-size: 12px;
+  line-height: 1.35;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(-2px);
+  transition: opacity 0.12s ease, transform 0.12s ease;
+}
+.data-badge-wrap.show-since .data-since-popover {
+  opacity: 1;
+  transform: translateY(0);
+}
+@media (hover: hover) and (pointer: fine) {
+  .data-badge-wrap:hover .data-since-popover {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 .badge-running { color: #28a745; border-color: #28a745; }
 .badge-error { color: var(--danger); border-color: var(--danger); }
@@ -353,6 +414,15 @@ tr:last-child td { border-bottom: none; }
     text-align: right;
   }
   .symbol-cell { max-width: 70%; }
+  .last-bar-value {
+    align-items: flex-end;
+    text-align: right;
+  }
+  .data-since-popover {
+    left: auto;
+    right: 0;
+    text-align: left;
+  }
   /* bigger touch targets on mobile */
   .btn { padding: 8px 12px; }
   input[type="checkbox"] { width: 18px; height: 18px; }

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -4,6 +4,7 @@
   let keepaliveTimer = null;
   let removeSessionId = null;
   let scriptsLoading = false;
+  const priceFormatters = new Map();
 
   const el = (id) => document.getElementById(id);
 
@@ -17,6 +18,79 @@
         hourCycle: "h23",
       });
     } catch { return String(ts); }
+  }
+
+  function fmtPrice(value) {
+    if (value == null || value === "") return "-";
+    const n = Number(value);
+    if (!Number.isFinite(n)) return "-";
+    const abs = Math.abs(n);
+    const digits = abs >= 100 ? 2 : abs >= 1 ? 4 : 8;
+    if (!priceFormatters.has(digits)) {
+      priceFormatters.set(digits, new Intl.NumberFormat("en-US", {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: digits,
+      }));
+    }
+    return priceFormatters.get(digits).format(n);
+  }
+
+  function sessionId(s) {
+    return String((s && s.id) || "");
+  }
+
+  function sessionPrice(s) {
+    const raw = s && s.last_price;
+    if (raw != null && raw !== "") {
+      const direct = Number(raw);
+      if (Number.isFinite(direct)) return direct;
+    }
+    return null;
+  }
+
+  function formatUtcDate(d) {
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ` +
+      `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`;
+  }
+
+  function parseDateAsUtc(raw) {
+    const value = String(raw || "").trim();
+    if (!value) return null;
+    const hasZone = /(?:z|[+-]\d{2}:?\d{2})$/i.test(value);
+    const iso = value.includes("T") ? value : value.replace(" ", "T");
+    const normalized = hasZone ? iso : (iso.length <= 10 ? `${iso}T00:00:00Z` : `${iso}Z`);
+    const d = new Date(normalized);
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
+
+  function historySinceText(s) {
+    const actual = Number(s && s.data_since_time);
+    if (Number.isFinite(actual) && actual > 0) {
+      return `Data since: ${formatUtcDate(new Date(actual * 1000))}`;
+    }
+    const raw = String((s && s.history_since) || "").trim();
+    if (!raw) return "Data since: default window";
+    if (raw === "continue") return "Data since: continue";
+    if (/^\d+$/.test(raw)) {
+      const d = new Date(Date.now() - Number(raw) * 24 * 60 * 60 * 1000);
+      d.setUTCSeconds(0, 0);
+      return `Data since: ${formatUtcDate(d)} (${raw} days)`;
+    }
+    const d = parseDateAsUtc(raw);
+    return d ? `Data since: ${formatUtcDate(d)}` : `Data since: ${raw}`;
+  }
+
+  function lastBarCell(s) {
+    return `<span class="last-bar-value">` +
+      `<span class="last-bar-time">${fmtTime(s.last_bar_time)}</span>` +
+      `<span class="last-bar-price">${fmtPrice(sessionPrice(s))}</span>` +
+      `</span>`;
+  }
+
+  function applySessions(nextSessions) {
+    sessions = nextSessions || [];
+    render();
   }
 
   function runnerButtons(s) {
@@ -40,54 +114,195 @@
            `loading="lazy" referrerpolicy="no-referrer" onerror="this.remove()">`;
   }
 
+  function setText(node, text) {
+    const next = String(text == null ? "" : text);
+    if (node && node.textContent !== next) node.textContent = next;
+  }
+
+  function setClass(node, cls) {
+    if (node && node.className !== cls) node.className = cls;
+  }
+
+  function setHTML(node, html) {
+    if (node && node.innerHTML !== html) node.innerHTML = html;
+  }
+
+  function setChecked(node, checked) {
+    if (node && node.checked !== checked) node.checked = checked;
+  }
+
+  function isTouchTooltipMode() {
+    return window.matchMedia("(hover: none)").matches ||
+      window.matchMedia("(pointer: coarse)").matches;
+  }
+
+  function closeDataSinceTooltips(exceptWrap) {
+    document.querySelectorAll(".data-badge-wrap.show-since").forEach((wrap) => {
+      if (wrap !== exceptWrap) wrap.classList.remove("show-since");
+    });
+  }
+
+  function toggleDataSinceTooltip(tr) {
+    const wrap = tr.querySelector(".data-badge-wrap");
+    if (!wrap) return;
+    const show = !wrap.classList.contains("show-since");
+    closeDataSinceTooltips(wrap);
+    wrap.classList.toggle("show-since", show);
+  }
+
+  function createSessionRow(id) {
+    const tr = document.createElement("tr");
+    tr.dataset.sessionId = id;
+    tr.innerHTML =
+      `<td data-label="Status"><span data-field="runner-led" class="led"></span></td>` +
+      `<td data-label="Symbol" class="mono"><span data-field="symbol-cell" class="symbol-cell"></span></td>` +
+      `<td data-label="TF" data-field="timeframe"></td>` +
+      `<td data-label="Exchange"><span data-field="exchange-cell" class="exchange-cell"></span></td>` +
+      `<td data-label="Script" class="mono" data-field="script-name"></td>` +
+      `<td data-label="Data" class="data-cell"><span class="data-badge-wrap">` +
+        `<span data-field="collector-badge" class="badge data-badge" ` +
+        `data-act="data-since"></span>` +
+        `<span data-field="data-since-popover" class="data-since-popover"></span></span>` +
+        ` <span data-field="history-loading" class="muted">loading</span>` +
+        `</td>` +
+      `<td data-label="Last bar" class="muted">${lastBarCell({})}</td>` +
+      `<td data-label="Webhook"><span class="cell-inline">` +
+        `<input type="checkbox" data-act="webhook">` +
+        `<button class="btn btn-icon" data-act="webhook-settings" title="Webhook URL">&#9881;</button></span></td>` +
+      `<td data-label="Telegram"><span class="cell-inline">` +
+        `<input type="checkbox" data-act="telegram">` +
+        `<button class="btn btn-icon" data-act="telegram-settings" title="Telegram bot">&#9881;</button></span></td>` +
+      `<td data-label="Runner" class="runner-cell" data-field="runner-cell"></td>` +
+      `<td data-label="Chart"><a data-field="chart-link" class="btn btn-chart" target="_blank">Open</a></td>` +
+      `<td data-label="Remove"><button class="btn btn-danger" data-act="delete" title="Delete session">&times;</button></td>`;
+
+    tr.addEventListener("change", (e) => {
+      const target = e.target;
+      const id = tr.dataset.sessionId;
+      if (!target || !id) return;
+      if (target.getAttribute("data-act") === "webhook") {
+        toggleWebhook(id, { enabled: target.checked });
+      } else if (target.getAttribute("data-act") === "telegram") {
+        toggleWebhook(id, { telegram_notification: target.checked });
+      }
+    });
+
+    tr.addEventListener("click", (e) => {
+      const target = e.target && e.target.closest
+        ? e.target.closest("[data-runner], [data-act]")
+        : null;
+      const id = tr.dataset.sessionId;
+      if (!target || !tr.contains(target) || !id) return;
+      const runnerAct = target.getAttribute("data-runner");
+      if (runnerAct) {
+        runnerAction(id, runnerAct);
+        return;
+      }
+      const act = target.getAttribute("data-act");
+      if (act === "data-since") {
+        if (isTouchTooltipMode()) {
+          e.preventDefault();
+          e.stopPropagation();
+          toggleDataSinceTooltip(tr);
+        }
+      } else if (act === "delete") openRemoveConfirm(id);
+      else if (act === "logs") openLogs(id);
+      else if (act === "webhook-settings") openSettings(id, "webhook");
+      else if (act === "telegram-settings") openSettings(id, "telegram");
+    });
+    return tr;
+  }
+
+  function patchSessionRow(tr, s) {
+    const id = sessionId(s);
+    const runner = s.runner || "stopped";
+    const collector = s.collector || "stopped";
+    const wh = s.webhook || {};
+    const exchange = (s.exchange || "").toUpperCase();
+
+    const led = tr.querySelector('[data-field="runner-led"]');
+    setClass(led, `led led-${runner}`);
+    if (led && led.title !== runner) led.title = runner;
+
+    const symbolKey = JSON.stringify([s.symbol || "", s.tv_symbol || "", s.symbol_logo_url || ""]);
+    if (tr.dataset.symbolKey !== symbolKey) {
+      const symbolLogo = logoImg(s.symbol_logo_url, s.tv_symbol || s.symbol, "market-logo");
+      setHTML(
+        tr.querySelector('[data-field="symbol-cell"]'),
+        `${symbolLogo}<span class="symbol-text">${esc(s.symbol)}</span>`,
+      );
+      tr.dataset.symbolKey = symbolKey;
+    }
+
+    const exchangeKey = JSON.stringify([exchange, s.exchange_logo_url || ""]);
+    if (tr.dataset.exchangeKey !== exchangeKey) {
+      const exchangeLogo = logoImg(s.exchange_logo_url, exchange, "exchange-logo");
+      setHTML(
+        tr.querySelector('[data-field="exchange-cell"]'),
+        `${exchangeLogo}<span>${esc(exchange)}</span>`,
+      );
+      tr.dataset.exchangeKey = exchangeKey;
+    }
+
+    setText(tr.querySelector('[data-field="timeframe"]'), s.timeframe);
+    setText(tr.querySelector('[data-field="script-name"]'), s.script_name);
+
+    const badge = tr.querySelector('[data-field="collector-badge"]');
+    setClass(badge, `badge data-badge badge-${collector}`);
+    setText(badge, collector);
+    const sinceText = historySinceText(s);
+    if (badge) {
+      badge.setAttribute("aria-label", sinceText);
+    }
+    setText(tr.querySelector('[data-field="data-since-popover"]'), sinceText);
+    const loading = tr.querySelector('[data-field="history-loading"]');
+    if (loading) loading.hidden = !!s.history_ready;
+
+    setText(tr.querySelector(".last-bar-time"), fmtTime(s.last_bar_time));
+    setText(tr.querySelector(".last-bar-price"), fmtPrice(sessionPrice(s)));
+
+    setChecked(tr.querySelector('[data-act="webhook"]'), !!wh.enabled);
+    setChecked(tr.querySelector('[data-act="telegram"]'), !!wh.telegram_notification);
+
+    if (tr.dataset.runnerControlsKey !== runner) {
+      setHTML(
+        tr.querySelector('[data-field="runner-cell"]'),
+        `${runnerButtons(s)}<button class="btn" data-act="logs">Logs</button>`,
+      );
+      tr.dataset.runnerControlsKey = runner;
+    }
+
+    const chart = tr.querySelector('[data-field="chart-link"]');
+    const href = `/s/${encodeURIComponent(id)}`;
+    if (chart && chart.getAttribute("href") !== href) chart.setAttribute("href", href);
+  }
+
   function render() {
     const body = el("sessions-body");
-    body.innerHTML = "";
     el("empty").style.display = sessions.length ? "none" : "block";
     el("session-count").textContent = `${sessions.length} / ${MAX_SESSIONS} sessions`;
 
+    const rows = new Map(Array.from(body.children).map((row) => [row.dataset.sessionId, row]));
+    const liveIds = new Set(sessions.map(sessionId).filter((id) => id));
+    rows.forEach((row, id) => {
+      if (!liveIds.has(id)) {
+        row.remove();
+        rows.delete(id);
+      }
+    });
+    let cursor = body.firstElementChild;
+
     sessions.forEach((s) => {
-      const runner = s.runner || "stopped";
-      const collector = s.collector || "stopped";
-      const wh = s.webhook || {};
-      const exchange = (s.exchange || "").toUpperCase();
-      const symbolLogo = logoImg(s.symbol_logo_url, s.tv_symbol || s.symbol, "market-logo");
-      const exchangeLogo = logoImg(s.exchange_logo_url, exchange, "exchange-logo");
-      const tr = document.createElement("tr");
-      tr.innerHTML =
-        `<td data-label="Status"><span class="led led-${runner}" title="${runner}"></span></td>` +
-        `<td data-label="Symbol" class="mono"><span class="symbol-cell">${symbolLogo}` +
-          `<span class="symbol-text">${esc(s.symbol)}</span></span></td>` +
-        `<td data-label="TF">${esc(s.timeframe)}</td>` +
-        `<td data-label="Exchange"><span class="exchange-cell">${exchangeLogo}` +
-          `<span>${esc(exchange)}</span></span></td>` +
-        `<td data-label="Script" class="mono">${esc(s.script_name)}</td>` +
-        `<td data-label="Data"><span class="badge badge-${collector}">${collector}</span>` +
-          `${s.history_ready ? "" : " <span class='muted'>loading</span>"}</td>` +
-        `<td data-label="Last bar" class="muted">${fmtTime(s.last_bar_time)}</td>` +
-        `<td data-label="Webhook"><span class="cell-inline">` +
-          `<input type="checkbox" data-act="webhook" ${wh.enabled ? "checked" : ""}>` +
-          `<button class="btn btn-icon" data-act="webhook-settings" title="Webhook URL">&#9881;</button></span></td>` +
-        `<td data-label="Telegram"><span class="cell-inline">` +
-          `<input type="checkbox" data-act="telegram" ${wh.telegram_notification ? "checked" : ""}>` +
-          `<button class="btn btn-icon" data-act="telegram-settings" title="Telegram bot">&#9881;</button></span></td>` +
-        `<td data-label="Runner" class="runner-cell">${runnerButtons(s)}` +
-          `<button class="btn" data-act="logs">Logs</button></td>` +
-        `<td data-label="Chart"><a class="btn btn-chart" href="/s/${encodeURIComponent(s.id)}" target="_blank">Open</a></td>` +
-        `<td data-label="Remove"><button class="btn btn-danger" data-act="delete" title="Delete session">&times;</button></td>`;
-
-      tr.querySelector('[data-act="webhook"]').addEventListener("change", (e) =>
-        toggleWebhook(s.id, { enabled: e.target.checked }));
-      tr.querySelector('[data-act="telegram"]').addEventListener("change", (e) =>
-        toggleWebhook(s.id, { telegram_notification: e.target.checked }));
-      tr.querySelector('[data-act="delete"]').addEventListener("click", () => openRemoveConfirm(s.id));
-      tr.querySelector('[data-act="logs"]').addEventListener("click", () => openLogs(s.id));
-      tr.querySelector('[data-act="webhook-settings"]').addEventListener("click", () => openSettings(s.id, "webhook"));
-      tr.querySelector('[data-act="telegram-settings"]').addEventListener("click", () => openSettings(s.id, "telegram"));
-      tr.querySelectorAll("[data-runner]").forEach((btn) =>
-        btn.addEventListener("click", () => runnerAction(s.id, btn.getAttribute("data-runner"))));
-
-      body.appendChild(tr);
+      const id = sessionId(s);
+      if (!id) return;
+      let row = rows.get(id);
+      if (!row) row = createSessionRow(id);
+      patchSessionRow(row, s);
+      if (row === cursor) {
+        cursor = cursor.nextElementSibling;
+      } else {
+        body.insertBefore(row, cursor);
+      }
     });
   }
 
@@ -187,6 +402,8 @@
   // ---- live log viewer ----------------------------------------------------
   let logTimer = null;
   let logSession = null;
+  let logRequestSeq = 0;
+  let logAbort = null;
   let savedScrollY = 0;
 
   // Lock the page behind the modal (iOS-safe position:fixed technique) so
@@ -210,44 +427,84 @@
     window.scrollTo(0, savedScrollY);
   }
 
-  async function fetchLogs() {
-    if (!logSession) return;
+  function clearLogTimer() {
+    if (logTimer) {
+      clearTimeout(logTimer);
+      logTimer = null;
+    }
+  }
+
+  function cancelLogFetch() {
+    if (logAbort) {
+      logAbort.abort();
+      logAbort = null;
+    }
+  }
+
+  async function fetchLogs(sessionId, seq) {
+    if (!sessionId || seq !== logRequestSeq) return;
+    const controller = new AbortController();
+    logAbort = controller;
     try {
-      const data = await api(`/api/sessions/${encodeURIComponent(logSession)}/runner/logs?lines=500`);
+      const data = await api(
+        `/api/sessions/${encodeURIComponent(sessionId)}/runner/logs?lines=500`,
+        { signal: controller.signal },
+      );
+      if (logAbort === controller) logAbort = null;
+      if (seq !== logRequestSeq || logSession !== sessionId) return;
       const pre = el("log-content");
       const atBottom = pre.scrollTop + pre.clientHeight >= pre.scrollHeight - 30;
       pre.textContent = data.log && data.log.length ? data.log : "(no log output yet)";
       if (atBottom) pre.scrollTop = pre.scrollHeight;  // follow tail unless user scrolled up
     } catch (e) {
+      if (logAbort === controller) logAbort = null;
+      if (e.name === "AbortError" || seq !== logRequestSeq || logSession !== sessionId) return;
       el("log-content").textContent = `failed to load logs: ${e.message}`;
     }
   }
 
+  async function pollLogs(sessionId, seq) {
+    await fetchLogs(sessionId, seq);
+    if (seq !== logRequestSeq || logSession !== sessionId) return;
+    logTimer = setTimeout(() => pollLogs(sessionId, seq), 1500);
+  }
+
   function openLogs(id) {
+    clearLogTimer();
+    cancelLogFetch();
     logSession = id;
+    logRequestSeq += 1;
+    const seq = logRequestSeq;
     el("log-title").textContent = id;
     el("log-content").textContent = "loading…";
     el("log-modal").classList.remove("hidden");
     lockBodyScroll();
-    fetchLogs();
-    if (logTimer) clearInterval(logTimer);
-    logTimer = setInterval(fetchLogs, 1500);
+    pollLogs(id, seq);
   }
 
   function closeLogs() {
     if (el("log-modal").classList.contains("hidden")) return;
+    logRequestSeq += 1;
+    clearLogTimer();
+    cancelLogFetch();
     el("log-modal").classList.add("hidden");
     unlockBodyScroll();
     logSession = null;
-    if (logTimer) { clearInterval(logTimer); logTimer = null; }
   }
 
   async function clearLogs() {
-    if (!logSession) return;
+    const sessionId = logSession;
+    if (!sessionId) return;
+    clearLogTimer();
+    cancelLogFetch();
+    logRequestSeq += 1;
+    const seq = logRequestSeq;
     try {
-      await api(`/api/sessions/${encodeURIComponent(logSession)}/runner/logs`, { method: "DELETE" });
+      await api(`/api/sessions/${encodeURIComponent(sessionId)}/runner/logs`, { method: "DELETE" });
+      if (seq !== logRequestSeq || logSession !== sessionId) return;
       el("log-content").textContent = "(cleared)";
-      fetchLogs();
+      logRequestSeq += 1;
+      pollLogs(sessionId, logRequestSeq);
     } catch (e) {
       alert(`clear failed: ${e.message}`);
     }
@@ -337,9 +594,15 @@
 
   document.addEventListener("keydown", (e) => {
     if (e.key !== "Escape") return;
+    closeDataSinceTooltips();
     if (!el("log-modal").classList.contains("hidden")) closeLogs();
     if (!el("settings-modal").classList.contains("hidden")) closeSettings();
     if (!el("remove-modal").classList.contains("hidden")) closeRemoveConfirm();
+  });
+  document.addEventListener("click", (e) => {
+    if (!isTouchTooltipMode()) return;
+    if (!e.target || !e.target.closest || e.target.closest(".data-badge-wrap")) return;
+    closeDataSinceTooltips();
   });
 
   // ---- collapsible "Add session" card (collapsed by default) ---------------
@@ -447,8 +710,7 @@
   async function refresh() {
     try {
       const data = await api("/api/sessions");
-      sessions = data.sessions || [];
-      render();
+      applySessions(data.sessions || []);
     } catch (e) {
       /* ignore */
     }
@@ -479,8 +741,7 @@
       try {
         const msg = JSON.parse(ev.data);
         if (msg.type === "sessions") {
-          sessions = msg.sessions || [];
-          render();
+          applySessions(msg.sessions || []);
         }
       } catch {}
     };
@@ -502,7 +763,7 @@
   // Mobile freezes timers and drops idle sockets while backgrounded, so on return
   // the lazy setTimeout-based reconnect can sit at "reconnecting…" for a long time.
   // Force an immediate reconnect when the page becomes visible / the network is back.
-  // The hub pushes a snapshot every ~10s, so a socket reporting OPEN but silent for
+  // The hub pushes a snapshot every ~1s, so a socket reporting OPEN but silent for
   // >20s is treated as a zombie and rebuilt.
   function forceReconnect() {
     if (reconnectTimer) { clearTimeout(reconnectTimer); reconnectTimer = null; }

--- a/data_service/templates/ws.js
+++ b/data_service/templates/ws.js
@@ -11,6 +11,7 @@ App.ws = {
 
     state.ws.onopen = () => {
       console.log("ws connected");
+      state.ws.send(JSON.stringify({ type: "client_hello", role: "chart" }));
       App.data.loadInitialWithRetry();
     };
 

--- a/data_service/ws_manager.py
+++ b/data_service/ws_manager.py
@@ -1,35 +1,190 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
+from typing import Any, Awaitable, Callable, Deque, Dict, Optional
+
 from fastapi import WebSocket
 
 
+# Per-client outbound queue depth. A client this far behind is
+# treated as hopelessly slow and dropped — it reconnects and resyncs full state via
+# REST (OHLCV / trades / plotchar / plot). Generous enough that a healthy client, and
+# especially a local runner, never approaches it; only a stuck remote browser does.
+MAX_PENDING = 1000
+SEND_TIMEOUT_SECONDS = 10.0
+CLOSE_TIMEOUT_SECONDS = 2.0
+
+
+def _coalesce_key(payload: Any) -> Optional[tuple]:
+    """Key under which a queued message may be overwritten by a newer one (conflation).
+
+    Returns None  -> must-deliver: never dropped, order preserved.
+    Returns a key -> latest-wins: a newer message with the same key overwrites the one
+                     already queued (keeping its position), reducing queue growth.
+
+    'bar' is keyed by bar timestamp, so intra-candle tick updates conflate while each
+    distinct candle stays in the stream. 'sessions' is the hub's whole-state snapshot,
+    so only the latest matters.
+    """
+    if not isinstance(payload, dict):
+        return None
+    t = payload.get("type")
+    if t == "bar":
+        data = payload.get("data") or {}
+        return ("bar", data.get("time"))
+    if t == "sessions":
+        return ("sessions",)
+    return None
+
+
+class _Channel:
+    """One outbound queue + dedicated writer task per WebSocket.
+
+    A single writer per socket guarantees sends never overlap (WebSocket framing is not
+    safe under concurrent sends), and the producer only ever enqueues — it never awaits a
+    client send, so one slow client cannot stall bar delivery to the runner or to other
+    clients. Backpressure is handled per client: replaceable messages conflate, and a
+    client that falls hopelessly behind is closed (then resyncs on reconnect)."""
+
+    def __init__(self, ws: WebSocket, manager: "WSManager") -> None:
+        self.ws = ws
+        self._manager = manager
+        # each entry is a 2-element list [coalesce_key_or_None, payload]
+        self._items: Deque[list] = deque()
+        self._wake = asyncio.Event()
+        self._overflow = False
+        self._closing = False
+        self._closed = False
+        self.task: Optional[asyncio.Task] = None
+
+    def start(self) -> None:
+        self.task = asyncio.create_task(self._run())
+
+    def enqueue(self, payload: Any) -> None:
+        """Synchronous and non-blocking: append (or conflate) and wake the writer.
+        Being sync, it is atomic with respect to the writer — no lock needed."""
+        if self._closing or self._overflow:
+            return
+        key = _coalesce_key(payload)
+        if key is not None:
+            for item in self._items:
+                if item[0] == key:
+                    item[1] = payload          # conflate: keep latest, hold queue position
+                    self._wake.set()
+                    return
+        if len(self._items) >= MAX_PENDING:
+            # Hopelessly behind: stop queuing and let the writer close the socket. The
+            # client reconnects and resyncs authoritative state.
+            self._overflow = True
+            self._items.clear()
+            self._wake.set()
+            return
+        self._items.append([key, payload])
+        self._wake.set()
+
+    async def _run(self) -> None:
+        try:
+            while True:
+                if self._closing or self._overflow:
+                    break
+                if self._items:
+                    payload = self._items.popleft()[1]
+                    await asyncio.wait_for(self.ws.send_json(payload), SEND_TIMEOUT_SECONDS)
+                else:
+                    self._wake.clear()
+                    await self._wake.wait()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            # send failure / cancellation -> fall through to teardown
+            pass
+        finally:
+            await self._close_ws()
+            await self._manager._on_channel_dead(self)
+
+    async def close(self) -> None:
+        self._closing = True
+        self._items.clear()
+        self._wake.set()
+        if self.task is None:
+            await self._close_ws()
+            return
+        if self.task is asyncio.current_task():
+            return
+        try:
+            await asyncio.wait_for(asyncio.shield(self.task), CLOSE_TIMEOUT_SECONDS)
+        except asyncio.TimeoutError:
+            self.task.cancel()
+            try:
+                await asyncio.wait_for(asyncio.shield(self.task), CLOSE_TIMEOUT_SECONDS)
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+
+        if self.task.done() and not self._closed:
+            await self._close_ws()
+
+    async def _close_ws(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            await asyncio.wait_for(self.ws.close(), CLOSE_TIMEOUT_SECONDS)
+        except Exception:
+            pass
+
+
 class WSManager:
-    def __init__(self) -> None:
-        self._clients: set[WebSocket] = set()
+    def __init__(self, on_disconnect: Optional[Callable[[WebSocket], Awaitable[None]]] = None) -> None:
+        self._channels: Dict[WebSocket, _Channel] = {}
         self._lock = asyncio.Lock()
+        self._on_disconnect = on_disconnect
 
     async def connect(self, ws: WebSocket) -> None:
         await ws.accept()
+        ch = _Channel(ws, self)
         async with self._lock:
-            self._clients.add(ws)
+            self._channels[ws] = ch
+        ch.start()
 
     async def disconnect(self, ws: WebSocket) -> None:
         async with self._lock:
-            self._clients.discard(ws)
+            ch = self._channels.pop(ws, None)
+        if ch is not None:
+            await ch.close()
+            await self._notify_disconnect(ws)
 
-    async def broadcast_json(self, payload: dict) -> None:
+    async def _on_channel_dead(self, ch: _Channel) -> None:
+        # Called from a channel's writer teardown. Drop it from the registry; the writer
+        # is already exiting so we must not cancel ourselves.
+        should_notify = False
         async with self._lock:
-            clients = list(self._clients)
+            if self._channels.get(ch.ws) is ch:
+                self._channels.pop(ch.ws, None)
+                should_notify = True
+        if should_notify:
+            await self._notify_disconnect(ch.ws)
 
-        dead: list[WebSocket] = []
-        for ws in clients:
-            try:
-                await ws.send_json(payload)
-            except Exception:
-                dead.append(ws)
+    async def _notify_disconnect(self, ws: WebSocket) -> None:
+        if self._on_disconnect is None:
+            return
+        try:
+            await self._on_disconnect(ws)
+        except Exception:
+            pass
 
-        if dead:
-            async with self._lock:
-                for ws in dead:
-                    self._clients.discard(ws)
+    async def broadcast_json(self, payload: Any) -> None:
+        async with self._lock:
+            for ch in self._channels.values():
+                ch.enqueue(payload)
+
+    async def send(self, ws: WebSocket, payload: Any) -> None:
+        """Queue a message to a single client through its writer (same ordering and
+        single-writer guarantee as broadcast_json). Use instead of ws.send_json so direct
+        sends can't race a concurrent broadcast on the same socket."""
+        async with self._lock:
+            ch = self._channels.get(ws)
+            if ch is not None:
+                ch.enqueue(payload)


### PR DESCRIPTION
## 요약

두 갈래의 작업을 담은 PR입니다.

1. **WebSocket broadcast 견고화** — 소켓당 큐/writer 모델 + role 기반 라우팅
2. **대시보드 실시간 상태 표시 개선** — 실시간 가격 표시 + 증분 DOM 렌더링 + Data 배지/Logs 모달 보강

커밋:
- `60753c8` refactor(data_service): WS broadcast를 소켓당 큐/writer + role 기반 라우팅으로 재작성
- `249b12e` 대시보드 실시간 상태 표시 개선

---

## 1. WS broadcast 견고화 (`60753c8`)

### 배경 / 문제
- 기존 `WSManager.broadcast_json()`은 `_lock`이 client set 복사/삭제만 덮고 실제 `send_json` 구간은 lock 밖이라, 서로 다른 task(collector의 bar, 수신 루프의 trade 등)가 동시에 broadcast하면 **같은 소켓에 send가 겹칠 수 있었다**(WebSocket 프레임은 동시 send에 안전하지 않음).
- 순차 `await send_json` 때문에 **느린 차트 브라우저 하나가 같은 매니저에 묶인 러너의 bar 전달을 지연**시킬 수 있었다(head-of-line blocking).
- 러너는 `type:"bar"`를 사용하지 않고 `prerun_ready`/`run_ready`/`webhook_config`로만 동작 → 차트/러너 스트림을 분리 가능.

### 변경
- **`ws_manager.py`** (전면 재작성): 소켓당 outbound 큐 + 전용 writer task 1개. producer는 `enqueue`만(무블로킹), 동시 send 차단. `bar`/`sessions`는 conflate(최신만), 나머지는 must-deliver 순서보존. `MAX_PENDING` 초과 시 소켓 close → 재연결 resync. `SEND_TIMEOUT`/`CLOSE_TIMEOUT` + writer 소유 close(close/send 겹침 방지). `on_disconnect` 콜백으로 정리 일원화.
- **`runtime.py`**: role 기반 라우팅(`send_to_charts`/`send_to_runners`) — 러너엔 bar 미전송, 차트엔 runner 전용 이벤트 미전송. 직접 `ws.send_json`은 전부 `ws_manager.send()` 경유로 통일. 역할 정리는 `_cleanup_client` 콜백으로 일원화(overflow/timeout 종료에도 보장). `pending_prerun`은 runner 식별 후에만 replay.
- **`main.py`**: hub 초기 스냅샷을 `hub_ws.send()` 경유로 변경.
- **`templates/ws.js`**: 차트가 `onopen` 시 `client_hello {role:"chart"}` 전송(role 라우팅 작동에 필수).

### 보장
- 소켓당 writer 1개 → 동시 send 원천 차단(직접 send까지 통일)
- producer 무블로킹 → 느린 클라가 러너/타 클라 전달을 막지 못함
- 타입별 정책(conflate/must-deliver) + 차트/러너 스트림 분리
- bound 초과 시 disconnect→resync, send/close timeout + writer 소유 close

---

## 2. 대시보드 실시간 상태 표시 개선 (`249b12e`)

- **실시간 가격**: 세션 snapshot에 `last_price`(`live_bars[-1][4]`) 추가, "Last bar" 라벨에 시각과 함께 표시.
- **hub 주기 1초 + 증분 DOM 패치**: 세션 row를 매번 전체 재생성하던 것을 기존 DOM 패치 방식으로 전환 → 심볼 로고 깜빡임과 running 애니메이션 재시작 제거(1초 주기에서 드러나던 jitter 해소).
- **Data 배지**: 호버/터치 시 실제 OHLCV 시작 시각을 UTC로 표시.
- **Logs 모달**: `setInterval` 폴링 대신 요청 완료 후 다음 조회 예약, 모달 전환/닫기/Clear 시 진행 중 요청 취소(중첩 요청·늦은 응답 덮어쓰기 방지).

---

## 검증
- `ws_manager` 회귀 테스트(로컬, `.gitignore`의 `test*.py`라 미포함) 11종 통과: 순서보존 · 단일 writer(동시 send 0) · bar/sessions conflation · overflow→close · `send` 타겟 격리 · clean disconnect · coalesceable 타임스탬프 bound · send timeout · close-send 비겹침 · role 라우팅 격리.
- `py_compile` OK.
- 실거래 세션에서 대시보드 가격/상태 표시 동작 확인.

## 후속 (이번 범위 밖)
- **resync 폭주 방지 backoff**: 차트는 close 후 1초 뒤 무조건 재연결(backoff 없음). overflow가 만성화된 극단 클라는 ~1초마다 resync 가능 — 별도 프론트 작업으로 둘 만함.
- **가격 부드러움**: 현재 1초 샘플링이라 값이 계단식. 더 부드럽게 하려면 hub 주기 단축 또는 틱 단위 price-only 스트림 도입 검토.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
