### PR TITLE
현재 봉 open 보정 시 차트 볼륨 유지

### DIFF
--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -259,10 +259,6 @@ class Session:
                             "data": {
                                 "time": int(last_bar.timestamp),
                                 "open": float(last_bar.open),
-                                "high": float(last_bar.high),
-                                "low": float(last_bar.low),
-                                "close": float(last_bar.close),
-                                "volume": float(last_bar.volume),
                             },
                         }
                         await self.send_to_charts(payload)

--- a/data_service/templates/ws.js
+++ b/data_service/templates/ws.js
@@ -67,20 +67,19 @@ App.ws = {
             state.lastPrice = msg.data.close;
           }
         } else if (msg.type === "last_bar_open_fix") {
+          if (!msg.data || msg.data.time == null || msg.data.open == null) {
+            return;
+          }
+
           state.lastOpenPrice.time = msg.data.time;
           state.lastOpenPrice.value = msg.data.open;
-
-          chart.candleSeries.update(msg.data);
-          chart.volumeSeries.update({
-            time: msg.data.time,
-            value: msg.data.volume,
-            color: msg.data.close >= msg.data.open ? "#26a69a" : "#ef5350"
-          });
-          state.lastBarTime = Math.max(state.lastBarTime, msg.data.time);
-          state.lastOhlcv = msg.data;
-          if (msg.data && msg.data.close !== undefined) {
-            state.lastPrice = msg.data.close;
+          // Only the opening price is corrected; keep live high/low/close/volume intact.
+          if (state.lastOhlcv && state.lastOhlcv.time === msg.data.time) {
+            const fixedBar = { ...state.lastOhlcv, open: msg.data.open };
+            chart.candleSeries.update(fixedBar);
+            state.lastOhlcv = fixedBar;
           }
+          state.lastBarTime = Math.max(state.lastBarTime, msg.data.time);
 
           const entryIndex = collections.entryMarkerData.findIndex(m => m.time === msg.data.time);
           if (entryIndex !== -1) {

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -393,6 +393,13 @@ def ohlcv_event_data(ohlcv: OHLCV) -> dict:
     }
 
 
+def ohlcv_open_fix_event_data(ohlcv: OHLCV) -> dict:
+    return {
+        "time": int(ohlcv.timestamp),
+        "open": float(ohlcv.open),
+    }
+
+
 def get_runner_candle(runner: ScriptRunner, index: int) -> OHLCV | None:
     candles = getattr(runner, "_all_ohlcv", None)
     if not candles or index < 0 or index >= len(candles):
@@ -743,7 +750,7 @@ async def main():
                     "last_bar_index": runner.last_bar_index,
                 }
                 if last_bar is not None:
-                    event["data"] = ohlcv_event_data(last_bar)
+                    event["data"] = ohlcv_open_fix_event_data(last_bar)
                 await ws.send(json.dumps(event))
             except Exception as e:
                 print(f"[runner] Failed to send bar confirmation: {e}")


### PR DESCRIPTION
## 요약
- last_bar_open_fix 이벤트를 현재 봉 open 보정 전용으로 정리했습니다.
- runner는 time/open만 전송하고, runtime fallback도 time/open만 chart로 보냅니다.
- 프론트는 기존 live OHLCV에 open만 병합해 candle을 업데이트하고, 실시간 volume/high/low/close는 덮어쓰지 않습니다.

## 배경
pre_run 완료 후 runner가 .ohlcv 기반 마지막 봉 전체를 last_bar_open_fix로 보내면서, chart에 이미 누적된 실시간 volume이 .ohlcv current bar의 0.0 volume으로 덮이는 문제가 있었습니다.

## 검증
- venv/bin/python -m py_compile runner_service/main.py data_service/runtime.py
- node --check data_service/templates/ws.js
- git diff --check -- runner_service/main.py data_service/runtime.py data_service/templates/ws.js