### PR TITLE
거래소 시간 동기화 공유 clock 적용

### DIFF
--- a/data_service/collector_loop.py
+++ b/data_service/collector_loop.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import asyncio
-import time
 from typing import Callable, Optional, Awaitable
 
 import ccxt.pro as ccxt
 
 from state import DataState
 from ohlcv_io import convert_timeframe, make_ccxt_pro_client
+from exchange_clock import release_exchange_clock, retain_exchange_clock
 
 
 async def _safe_close(ex) -> None:
@@ -81,35 +81,15 @@ async def fix_missing_bars_loop(
 ) -> None:
     tf_ms = convert_timeframe(timeframe, to_ms=True)
     grace_ms = 0.2 * 1000
-    ex = make_ccxt_pro_client(ccxt, exchange_name)
-
-    # Exchange time is sampled every time_sync_interval_sec and applied as an
-    # offset to the local clock. Polling fetch_time() on every tick exceeds the
-    # exchange rate limit (OKX public time endpoint: 10 req per 2s per IP).
-    time_offset_ms = 0.0
-    next_sync = 0.0  # monotonic deadline for the next fetch_time sync
+    clock = retain_exchange_clock(exchange_name, time_sync_interval_sec)
 
     try:
         while True:
             await asyncio.sleep(check_interval_sec)
 
-            mono = time.monotonic()
-            if mono >= next_sync:
-                try:
-                    server_ms = await ex.fetch_time()
-                    time_offset_ms = server_ms - time.time() * 1000
-                    next_sync = mono + time_sync_interval_sec
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    print(f"[fix_missing_bars_loop] fetch_time error: {type(e).__name__}: {e}; reconnecting")
-                    await _safe_close(ex)
-                    ex = make_ccxt_pro_client(ccxt, exchange_name)
-                    next_sync = mono + 5.0
-
-            # Until the first successful sync this equals plain local time
-            # (offset 0), same as the previous fallback behavior.
-            now_ms = time.time() * 1000 + time_offset_ms
+            # Shared per exchange, so many feeds do not stampede the public
+            # time endpoint with synchronized fetch_time requests.
+            now_ms = await clock.now_ms()
 
             missing_ts: Optional[int] = None
 
@@ -134,6 +114,7 @@ async def fix_missing_bars_loop(
                 # OKX policy will hide it; BITGET/Hyperliquid policy will still treat it as a visible bar.
                 fake = [missing_ts, prev_close, prev_close, prev_close, prev_close, 0.0]
                 bars.append(fake)
+                # print(f"[fix_missing_bars_loop] {exchange_name} bar: {fake}")
                 state.last_fix_bar_ts = missing_ts
     finally:
-        await _safe_close(ex)
+        await release_exchange_clock(exchange_name)

--- a/data_service/exchange_clock.py
+++ b/data_service/exchange_clock.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import asyncio
+import random
+import time
+from dataclasses import dataclass, field
+
+import ccxt.pro as ccxt
+
+from ohlcv_io import make_ccxt_pro_client
+
+
+@dataclass
+class ExchangeClock:
+    exchange_name: str
+    sync_interval_sec: float = 30.0
+    time_offset_ms: float = 0.0
+    next_sync: float = 0.0
+    backoff_sec: float = 5.0
+    ref_count: int = 0
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    ex: object | None = None
+
+    async def now_ms(self) -> float:
+        mono = time.monotonic()
+        if mono < self.next_sync:
+            return time.time() * 1000 + self.time_offset_ms
+
+        async with self.lock:
+            mono = time.monotonic()
+            if mono < self.next_sync:
+                return time.time() * 1000 + self.time_offset_ms
+
+            if self.ex is None:
+                self.ex = make_ccxt_pro_client(ccxt, self.exchange_name)
+
+            try:
+                server_ms = await self.ex.fetch_time()
+                if server_ms is None:
+                    raise RuntimeError("fetch_time returned None")
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                delay = self.backoff_sec
+                jitter = random.uniform(0.0, min(1.0, delay * 0.2))
+                self.next_sync = mono + delay + jitter
+                self.backoff_sec = min(delay * 2.0, 60.0)
+                print(
+                    f"[exchange_clock] {self.exchange_name} fetch_time error: "
+                    f"{type(e).__name__}: {e}; using cached/local clock, "
+                    f"retrying in {delay:g}s"
+                )
+                return time.time() * 1000 + self.time_offset_ms
+
+            self.time_offset_ms = server_ms - time.time() * 1000
+            jitter = random.uniform(0.0, min(2.0, self.sync_interval_sec * 0.1))
+            self.next_sync = mono + self.sync_interval_sec + jitter
+            self.backoff_sec = 5.0
+            return time.time() * 1000 + self.time_offset_ms
+
+    async def close(self) -> None:
+        if self.ex is None:
+            return
+        try:
+            await self.ex.close()
+        except Exception:
+            pass
+        finally:
+            self.ex = None
+
+
+_CLOCKS: dict[str, ExchangeClock] = {}
+
+
+def retain_exchange_clock(exchange_name: str, sync_interval_sec: float = 30.0) -> ExchangeClock:
+    key = exchange_name.lower()
+    clock = _CLOCKS.get(key)
+    if clock is None:
+        clock = ExchangeClock(exchange_name=exchange_name, sync_interval_sec=sync_interval_sec)
+        _CLOCKS[key] = clock
+    else:
+        clock.sync_interval_sec = sync_interval_sec
+    clock.ref_count += 1
+    return clock
+
+
+async def release_exchange_clock(exchange_name: str) -> None:
+    key = exchange_name.lower()
+    clock = _CLOCKS.get(key)
+    if clock is None:
+        return
+    clock.ref_count -= 1
+    if clock.ref_count > 0:
+        return
+    _CLOCKS.pop(key, None)
+    await clock.close()


### PR DESCRIPTION
## 요약
- fix_missing_bars_loop의 fetch_time 호출을 feed별 ccxt client에서 거래소별 공유 ExchangeClock으로 변경했습니다.
- 같은 거래소의 여러 feed가 동시에 시간 동기화를 요청해도 lock 내부 재확인으로 fetch_time 중복 호출을 막습니다.
- fetch_time 실패 시 기존 offset 또는 로컬 시간으로 루프를 계속 진행하고, backoff와 jitter로 재시도 요청이 몰리지 않게 했습니다.

## 배경
세션/feed가 늘어날수록 OKX/Bitget public time endpoint 요청이 같은 타이밍에 몰려 RequestTimeout 로그가 반복되는 문제가 있었습니다.

## 검증
- venv/bin/python -m py_compile data_service/exchange_clock.py data_service/collector_loop.py
- git diff --check -- data_service/exchange_clock.py data_service/collector_loop.py