### PR TITLE
바이낸스 거래소 지원 정책 추가

### DIFF
--- a/data_service/api.py
+++ b/data_service/api.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, Body
 from fastapi.responses import JSONResponse
 
 from pynecore.cli.app import app_state
+from pynecore.core.exchange_policy import tradingview_hides_zero_volume
 from pynecore.core.ohlcv_file import OHLCVReader
 from pynecore.core.csv_file import CSVReader
 
@@ -239,8 +240,8 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
         if not ohlcv_path.exists():
             return JSONResponse([])
 
-        # OKX hides zero-volume bars like TradingView; BITGET/Hyperliquid keep them.
-        skip_zero_volume = rt.spec.exchange.upper() == "OKX"
+        # Match TradingView: OKX/Binance hide zero-volume bars; BITGET/Hyperliquid keep them.
+        skip_zero_volume = tradingview_hides_zero_volume(rt.spec.exchange)
         out: List[Dict[str, Any]] = []
         with OHLCVReader(ohlcv_path) as reader:
             if reader.start_timestamp is None:

--- a/data_service/collector_loop.py
+++ b/data_service/collector_loop.py
@@ -111,7 +111,7 @@ async def fix_missing_bars_loop(
 
                 prev_close = bars[-1][4]
                 # No trades occurred in this interval. Store the placeholder as true 0-volume.
-                # OKX policy will hide it; BITGET/Hyperliquid policy will still treat it as a visible bar.
+                # OKX/Binance policy will hide it; BITGET/Hyperliquid still treat it as visible.
                 fake = [missing_ts, prev_close, prev_close, prev_close, prev_close, 0.0]
                 bars.append(fake)
                 # print(f"[fix_missing_bars_loop] {exchange_name} bar: {fake}")

--- a/data_service/ohlcv_io.py
+++ b/data_service/ohlcv_io.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from dateutil.relativedelta import relativedelta
+from pynecore.core.exchange_policy import fetch_current_open_from_exchange
 from pynecore.core.ohlcv_file import OHLCVReader, OHLCVWriter
 from pynecore.types.ohlcv import OHLCV
 from ohlcv_cache import import_from_ohlcv
@@ -214,8 +215,8 @@ def fix_last_open_if_needed(
         prev_close_price = prev.close
         reader.close()
 
-    if exchange.upper() in ("OKX", "HYPERLIQUID"):
-        # OKX, HYPERLIQUID 의 경우 이전 봉 종가 != 현재 봉 시가 이므로 fetch 로 현재 봉 값을 가져와야 함.
+    if fetch_current_open_from_exchange(exchange):
+        # OKX, Binance, HYPERLIQUID 의 경우 이전 봉 종가 != 현재 봉 시가 이므로 fetch 로 현재 봉 값을 가져와야 함.
         # fetch 에서 에러가 발생할 경우 현재 봉 시가 fix 가 안되므로 retry 필요함 (현재 봉 시가는 현재 봉이 confirmed 되면 계산에 쓰이므로 fix 되어야 함)
         target_open_price = None
         for attempt in range(1, max_attempts + 1):

--- a/data_service/templates/data.js
+++ b/data_service/templates/data.js
@@ -350,7 +350,7 @@ App.data = {
           if (state.configuredTimeframeSec) {
             state.timeframeInterval = state.configuredTimeframeSec;
           } else if (data.length >= 2) {
-            // Fallback only: on OKX zero-volume bars are hidden, so the gap
+            // Fallback only: on OKX/Binance zero-volume bars are hidden, so the gap
             // between the first two visible bars may not be the timeframe.
             state.timeframeInterval = data[1].time - data[0].time;
           }

--- a/data_service/templates/state.js
+++ b/data_service/templates/state.js
@@ -22,7 +22,7 @@ window.App.state = {
   firstBarTime: null,
   timeframeInterval: 60,
   // Timeframe from /api/info (seconds). Source of truth for the countdown:
-  // bar spacing cannot be trusted because OKX charts hide zero-volume bars.
+  // bar spacing cannot be trusted because some exchange charts hide zero-volume bars.
   configuredTimeframeSec: null,
   lastBarTime: 0,
   lastOpenPrice: { time: 0, value: 0 },

--- a/pynecore/cli/commands/benchmark.py
+++ b/pynecore/cli/commands/benchmark.py
@@ -10,6 +10,7 @@ from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn
 
 from ..app import app, app_state
+from ...core.exchange_policy import tradingview_hides_zero_volume
 from ...core.ohlcv_file import OHLCVReader
 from ...core.syminfo import SymInfo
 from ...core.script_runner import ScriptRunner
@@ -116,7 +117,7 @@ def benchmark(
                 # Get only the requested number of candles
                 ohlcv_list = []
                 # Match realtime/CLI run behavior for exchange-specific hidden bars.
-                skip_zero_volume = syminfo.prefix.upper() == "OKX"
+                skip_zero_volume = tradingview_hides_zero_volume(syminfo.prefix)
                 # Use read_from to get all data from the beginning
                 for idx, ohlcv in enumerate(
                     reader.read_from(reader.start_timestamp, reader.end_timestamp, skip_zero_volume=skip_zero_volume)

--- a/pynecore/cli/commands/run.py
+++ b/pynecore/cli/commands/run.py
@@ -20,6 +20,7 @@ from ...utils.rich.date_column import DateColumn
 from pynecore.core.ohlcv_file import OHLCVReader
 from pynecore.core.data_converter import DataConverter, DataFormatError, ConversionError
 
+from pynecore.core.exchange_policy import tradingview_hides_zero_volume
 from pynecore.core.syminfo import SymInfo
 from pynecore.core.script_runner import ScriptRunner
 from pynecore.pynesys.compiler import PyneComp
@@ -294,8 +295,8 @@ def run(
         total_seconds = int((time_to - time_from).total_seconds())
 
         # Use the same exchange-specific hidden-bar policy as realtime runner.
-        # OKX zero-volume bars are hidden; BITGET/Hyperliquid zero-volume bars are visible.
-        skip_zero_volume = syminfo.prefix.upper() == "OKX"
+        # OKX/Binance zero-volume bars are hidden; BITGET/Hyperliquid bars remain visible.
+        skip_zero_volume = tradingview_hides_zero_volume(syminfo.prefix)
         preload_list = list(reader.read_from(time_from_ts, time_to_ts, skip_zero_volume=skip_zero_volume))
         size = len(preload_list)
         if size == 0:

--- a/pynecore/core/exchange_policy.py
+++ b/pynecore/core/exchange_policy.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+
+_ZERO_VOLUME_HIDDEN_EXCHANGES = {
+    "OKX",
+    "BINANCE",
+    "BINANCEUSDM",
+    "BINANCECOINM",
+}
+
+_FETCH_CURRENT_OPEN_EXCHANGES = _ZERO_VOLUME_HIDDEN_EXCHANGES | {
+    "HYPERLIQUID",
+}
+
+
+def normalize_exchange_name(exchange: str | None) -> str:
+    return (exchange or "").upper()
+
+
+def tradingview_hides_zero_volume(exchange: str | None) -> bool:
+    return normalize_exchange_name(exchange) in _ZERO_VOLUME_HIDDEN_EXCHANGES
+
+
+def fetch_current_open_from_exchange(exchange: str | None) -> bool:
+    return normalize_exchange_name(exchange) in _FETCH_CURRENT_OPEN_EXCHANGES

--- a/pynecore/core/ohlcv_file.py
+++ b/pynecore/core/ohlcv_file.py
@@ -1538,7 +1538,7 @@ class OHLCVReader:
             ohlcv = self.read(pos)
             if ohlcv is not None:
                 # volume < 0: Pyne가 gap 보정용으로 만든 봉이므로 항상 제외.
-                # volume == 0: OKX처럼 TradingView가 hidden 처리하는 거래소에서만 제외.
+                # volume == 0: OKX/Binance처럼 TradingView가 hidden 처리하는 거래소에서만 제외.
                 # BITGET/Hyperliquid는 0-volume 봉도 TV 차트/계산에 포함되므로 skip_zero_volume=False로 읽어야 한다.
                 if skip_gaps and (ohlcv.volume < 0 or (skip_zero_volume and ohlcv.volume == 0)):
                     continue

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -20,6 +20,7 @@ import websockets
 from appendable_iter import AppendableIterable
 from pynecore.cli.app import app_state
 from pynecore.core.ohlcv_file import OHLCVReader
+from pynecore.core.exchange_policy import tradingview_hides_zero_volume
 from pynecore.core.script_runner import ScriptRunner
 from pynecore.core.syminfo import SymInfo
 from pynecore.types.ohlcv import OHLCV
@@ -267,9 +268,9 @@ def on_alert_event(message: str, runner: ScriptRunner):
 
 def hide_zero_volume_bars(exchange: str | None) -> bool:
     # TradingView policy differs by exchange:
-    # - OKX: zero-volume candles are hidden and excluded from calculations.
+    # - OKX/Binance: zero-volume candles are hidden and excluded from calculations.
     # - BITGET/Hyperliquid: zero-volume candles remain visible and are included.
-    return (exchange or "").upper() == "OKX"
+    return tradingview_hides_zero_volume(exchange)
 
 
 def is_visible_ohlcv(ohlcv: OHLCV, *, hide_zero_volume: bool) -> bool:
@@ -702,8 +703,8 @@ async def main():
             last_visible_bar = get_runner_candle(runner, runner.last_bar_index)
             # In normal realtime pre-run, the file may already contain the open current bar.
             # If that bar is visible, keep it in the stream for the next run_ready and
-            # pre-run only up to the last confirmed bar. If the raw last bar is hidden
-            # (OKX zero-volume), the visible list already ends at a confirmed bar.
+            # pre-run only up to the last confirmed bar. If the raw last bar is a
+            # hidden zero-volume candle, the visible list already ends at a confirmed bar.
             has_unconfirmed_visible_bar = (
                 last_visible_bar is not None
                 and reader.end_timestamp is not None
@@ -833,7 +834,7 @@ async def main():
             confirmed_visible = is_visible_ohlcv(confirmed_ohlcv, hide_zero_volume=hide_zero_volume)
             new_visible = is_visible_ohlcv(new_ohlcv, hide_zero_volume=hide_zero_volume)
 
-            # OKX fake/no-trade bars can stay in the raw file with volume 0, but they must not
+            # Hidden fake/no-trade bars can stay in the raw file with volume 0, but they must not
             # enter the runner stream. BITGET/Hyperliquid leave hide_zero_volume=False, so their
             # 0-volume bars still take this visible path.
             confirmed_appended = False
@@ -901,7 +902,7 @@ async def main():
                     if step_res is None:
                         break
 
-                # OKX hidden-bar fix:
+                # Hidden-bar fix:
                 # 새로 열린 봉이 volume 0 hidden bar 면 new_ohlcv 가 stream 에 append 되지
                 # 않아(line 619-620) confirmed bar 의 main() 에서 접수된 주문을 체결할
                 # process_orders() 패스가 없어 webhook alert 이 나가지 않는다. fake bar 의


### PR DESCRIPTION
## 요약
- Binance, Binance USD-M, Binance COIN-M 거래소를 TradingView 동작 기준으로 지원하도록 추가했습니다.
- 거래소별 zero-volume 숨김 정책과 현재 봉 open fetch 보정 정책을 공통 함수로 분리했습니다.
- runner, 차트 API, CLI run/benchmark가 동일한 zero-volume 정책을 사용하도록 맞췄습니다.

## 상세
- Binance 계열은 OKX처럼 zero-volume 봉을 TradingView에서 숨기는 것으로 확인되어 전략 계산/차트 표시/CLI 실행에서 제외합니다.
- Binance 계열 현재 봉 open 값은 OKX/Hyperliquid와 동일하게 거래소 OHLCV fetch 값으로 보정합니다.
- Bitget/Hyperliquid의 기존 zero-volume 포함 정책은 유지합니다.

## 검증
- venv/bin/python -m py_compile pynecore/core/exchange_policy.py runner_service/main.py data_service/ohlcv_io.py data_service/api.py pynecore/cli/commands/run.py pynecore/cli/commands/benchmark.py pynecore/core/ohlcv_file.py data_service/collector_loop.py
- git diff --check -- data_service/api.py data_service/collector_loop.py data_service/ohlcv_io.py data_service/templates/data.js data_service/templates/state.js pynecore/cli/commands/benchmark.py pynecore/cli/commands/run.py pynecore/core/ohlcv_file.py runner_service/main.py pynecore/core/exchange_policy.py