### PR TITLE
수동 얼럿 템플릿 및 차트 전송 기능 추가

### DIFF
--- a/data_service/api.py
+++ b/data_service/api.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import ast
+import json
+import urllib.error
+import urllib.request
 from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -17,7 +21,13 @@ import ccxt.pro as ccxtpro
 
 from registry import SessionNotFoundError, SessionExistsError, SessionLimitError, SessionRegistry
 from runtime import Session
-from config import SessionSpec
+from config import (
+    SessionSpec,
+    default_telegram_chat_id,
+    default_telegram_token,
+    default_webhook_url,
+    sanitize_manual_alert_templates,
+)
 from ohlcv_io import make_ccxt_pro_client
 
 # Cache of exchange -> set(symbols) so symbol validation hits the network at most
@@ -147,6 +157,67 @@ def _load_script_source_info(spec: SessionSpec, info: dict) -> tuple[str | None,
     if not title and name:
         title = name
     return title, name, source, has_source
+
+
+def _post_json_webhook(url: str, payload: Any) -> dict:
+    data = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            body = resp.read(4096).decode("utf-8", errors="replace")
+            return {"status": int(resp.status), "body": body}
+    except urllib.error.HTTPError as e:
+        body = e.read(4096).decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {e.code}: {body}") from e
+
+
+def _post_telegram_message(token: str, chat_id: str, text: str) -> dict:
+    import requests
+
+    payload = {
+        "chat_id": chat_id,
+        "text": text,
+    }
+    try:
+        resp = requests.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data=payload,
+            timeout=(5, 10),
+        )
+        resp.raise_for_status()
+        return {"status": int(resp.status_code), "body": resp.text[:4096]}
+    except requests.HTTPError as e:
+        body = e.response.text[:4096] if e.response is not None else ""
+        status = e.response.status_code if e.response is not None else "?"
+        raise RuntimeError(f"HTTP {status}: {body}") from e
+    except requests.RequestException as e:
+        raise RuntimeError(type(e).__name__) from e
+
+
+def _manual_alert_signal_text(message: Any) -> str:
+    if isinstance(message, str):
+        return message
+    try:
+        return json.dumps(message, ensure_ascii=False).replace('"', '')
+    except Exception:
+        return str(message)
+
+
+def _manual_alert_telegram_text(*, script_title: str | None, timeframe: str,
+                                ticker: str, message: Any) -> str:
+    time_str = datetime.now().strftime("%H:%M:%S")
+    return (
+        f"🚨 [M][{script_title or 'No title'}]\n"
+        f"Time: {time_str}\n"
+        f"Timeframe: {timeframe or ''}\n"
+        f"Ticker: {ticker or ''}\n"
+        f"Signal: {_manual_alert_signal_text(message)}"
+    )
 
 
 # ----------------------------------------------------------------------
@@ -326,9 +397,10 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
         if rt is None:
             return JSONResponse({"error": "session not found"}, status_code=404)
         wh = rt.spec.webhook
+        url = (wh.get("url") or "").strip() or default_webhook_url()
         return JSONResponse({
             "enabled": bool(wh.get("enabled", False)),
-            "url": wh.get("url", "") or "",
+            "url": url,
             "telegram_notification": bool(wh.get("telegram_notification", False)),
             "telegram_token": wh.get("telegram_token", "") or "",
             "telegram_chat_id": wh.get("telegram_chat_id", "") or "",
@@ -358,6 +430,73 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
         except Exception as e:
             return JSONResponse({"error": f"failed to update webhook: {e}"}, status_code=500)
         return JSONResponse(updated)
+
+    @r.get("/api/{session_id}/manual-alert-templates")
+    def get_manual_alert_templates(session_id: str) -> JSONResponse:
+        rt = _rt(session_id)
+        if rt is None:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        return JSONResponse({
+            "templates": [dict(t) for t in rt.spec.manual_alert_templates],
+        })
+
+    @r.post("/api/{session_id}/manual-alert-templates")
+    async def update_manual_alert_templates(session_id: str, payload: dict = Body(default_factory=dict)) -> JSONResponse:
+        templates = payload.get("templates")
+        if not isinstance(templates, list):
+            return JSONResponse({"error": "templates must be array"}, status_code=400)
+        if len(templates) > 50:
+            return JSONResponse({"error": "templates can contain at most 50 items"}, status_code=400)
+        sanitized = sanitize_manual_alert_templates(templates)
+        if len(sanitized) != len(templates):
+            return JSONResponse({"error": "each template requires string title and message"}, status_code=400)
+        try:
+            updated = await registry.update_manual_alert_templates(session_id, sanitized)
+        except SessionNotFoundError:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        except Exception as e:
+            return JSONResponse({"error": f"failed to update templates: {e}"}, status_code=500)
+        return JSONResponse({"templates": updated})
+
+    @r.post("/api/{session_id}/manual-alert")
+    async def send_manual_alert(session_id: str, payload: dict = Body(default_factory=dict)) -> JSONResponse:
+        rt = _rt(session_id)
+        if rt is None:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        if "message" not in payload:
+            return JSONResponse({"error": "message is required"}, status_code=400)
+
+        wh = rt.spec.webhook
+        url = (wh.get("url") or "").strip() or default_webhook_url()
+        if not url:
+            return JSONResponse({"error": "webhook url is empty"}, status_code=400)
+        if not url.startswith(("http://", "https://")):
+            return JSONResponse({"error": "webhook url must start with http:// or https://"}, status_code=400)
+
+        try:
+            webhook_result = await asyncio.to_thread(_post_json_webhook, url, payload["message"])
+        except Exception as e:
+            return JSONResponse({"error": f"webhook send failed: {e}"}, status_code=502)
+
+        token = (wh.get("telegram_token") or "").strip() or default_telegram_token()
+        chat_id = (wh.get("telegram_chat_id") or "").strip() or default_telegram_chat_id()
+        telegram_result: dict[str, Any] = {"sent": False}
+        if token and chat_id:
+            script_title, _, _, _ = _load_script_source_info(rt.spec, rt.chart_info)
+            text = _manual_alert_telegram_text(
+                script_title=script_title,
+                timeframe=rt.spec.timeframe,
+                ticker=rt.spec.symbol,
+                message=payload["message"],
+            )
+            try:
+                telegram_result = {
+                    "sent": True,
+                    **await asyncio.to_thread(_post_telegram_message, token, chat_id, text),
+                }
+            except Exception as e:
+                telegram_result = {"sent": False, "error": str(e)}
+        return JSONResponse({"ok": True, "webhook": webhook_result, "telegram": telegram_result})
 
     return r
 

--- a/data_service/config.py
+++ b/data_service/config.py
@@ -4,7 +4,7 @@ import json
 import os
 import re
 import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from pynecore.cli.app import app_state
@@ -34,6 +34,25 @@ def slugify_session_id(exchange: str, symbol: str, timeframe: str, script_name: 
     return _slug(raw)
 
 
+def sanitize_manual_alert_templates(raw: object) -> list[dict]:
+    if not isinstance(raw, list):
+        return []
+    templates: list[dict] = []
+    for item in raw[:50]:
+        if not isinstance(item, dict):
+            continue
+        title = item.get("title")
+        message = item.get("message")
+        if not isinstance(title, str) or not isinstance(message, str):
+            continue
+        title = title.strip()[:100]
+        message = message.strip()
+        if not title or not message:
+            continue
+        templates.append({"title": title, "message": message[:5000]})
+    return templates
+
+
 @dataclass(frozen=True)
 class SessionSpec:
     """Immutable per-session definition loaded from config / sessions.json."""
@@ -46,6 +65,7 @@ class SessionSpec:
     script_name: str
     webhook: dict  # {"enabled": bool, "telegram_notification": bool}  (decision 8-1)
     autostart_runner: bool = False  # start the runner automatically on hub boot
+    manual_alert_templates: list[dict] = field(default_factory=list)
 
     @classmethod
     def from_dict(cls, d: dict) -> "SessionSpec":
@@ -76,6 +96,7 @@ class SessionSpec:
                 "telegram_chat_id": (webhook.get("telegram_chat_id") or ""),
             },
             autostart_runner=bool(d.get("autostart_runner", False)),
+            manual_alert_templates=sanitize_manual_alert_templates(d.get("manual_alert_templates")),
         )
 
     def with_webhook(self, *, enabled: bool | None = None,
@@ -99,6 +120,16 @@ class SessionSpec:
             symbol=self.symbol, timeframe=self.timeframe,
             history_since=self.history_since, script_name=self.script_name,
             webhook=wh, autostart_runner=self.autostart_runner,
+            manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
+        )
+
+    def with_manual_alert_templates(self, templates: list[dict]) -> "SessionSpec":
+        return SessionSpec(
+            id=self.id, provider=self.provider, exchange=self.exchange,
+            symbol=self.symbol, timeframe=self.timeframe,
+            history_since=self.history_since, script_name=self.script_name,
+            webhook=dict(self.webhook), autostart_runner=self.autostart_runner,
+            manual_alert_templates=sanitize_manual_alert_templates(templates),
         )
 
     def to_dict(self) -> dict:
@@ -112,6 +143,7 @@ class SessionSpec:
             "script_name": self.script_name,
             "webhook": dict(self.webhook),
             "autostart_runner": self.autostart_runner,
+            "manual_alert_templates": [dict(t) for t in self.manual_alert_templates],
         }
 
     @property
@@ -153,6 +185,46 @@ def _toml_path() -> Path:
 def _read_toml() -> dict:
     with open(_toml_path(), "rb") as f:
         return tomllib.load(f)
+
+
+def default_webhook_url() -> str:
+    try:
+        webhook = (_read_toml().get("webhook", {}) or {})
+    except Exception:
+        return ""
+    return str(webhook.get("url") or "").strip()
+
+
+def _dotenv_value(name: str) -> str:
+    value = os.getenv(name)
+    if value:
+        return value.strip()
+
+    candidates = [
+        Path.cwd() / ".env",
+        app_state.config_dir.parent.parent / ".env",
+    ]
+    for path in candidates:
+        try:
+            for line in path.read_text(encoding="utf-8").splitlines():
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                key, raw_value = line.split("=", 1)
+                if key.strip() != name:
+                    continue
+                return raw_value.strip().strip("\"'")
+        except Exception:
+            continue
+    return ""
+
+
+def default_telegram_token() -> str:
+    return _dotenv_value("BOT_TOKEN")
+
+
+def default_telegram_chat_id() -> str:
+    return _dotenv_value("CHAT_ID")
 
 
 def load_hub_config() -> HubConfig:

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -203,6 +203,14 @@ class SessionRegistry:
         await self.notify_hub()
         return dict(session.spec.webhook)
 
+    async def update_manual_alert_templates(self, session_id: str, templates: list[dict]) -> list[dict]:
+        session = self.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFoundError(session_id)
+        session.spec = session.spec.with_manual_alert_templates(templates)
+        self._persist()
+        return [dict(t) for t in session.spec.manual_alert_templates]
+
     # ------------------------------------------------------------------
     # Runner control
     # ------------------------------------------------------------------

--- a/data_service/templates/chart.js
+++ b/data_service/templates/chart.js
@@ -8,8 +8,10 @@ App.chart = {
   entryMarkerSeries: null,
   closeMarkerSeries: null,
   currentPriceLine: null,
+  manualAlertPriceLine: null,
   resizeObserver: null,
   touchGuardsAttached: false,
+  manualAlertLastTap: null,
   isMobileViewport() {
     return window.matchMedia("(max-width: 640px), (hover: none) and (pointer: coarse)").matches;
   },
@@ -20,6 +22,126 @@ App.chart = {
     if (!(target instanceof Element)) return false;
     if (target.closest("#source-panel")) return false;
     return Boolean(target.closest("#chart, #chart-info, .nav-btn"));
+  },
+  candleTextColor(bar) {
+    if (!bar) return "#d32f2f";
+    return Number(bar.close) >= Number(bar.open) ? "#26a69a" : "#ef5350";
+  },
+  formatCandleChangePercent(bar) {
+    if (!bar) return "";
+    const open = Number(bar.open);
+    const close = Number(bar.close);
+    if (!Number.isFinite(open) || !Number.isFinite(close) || open === 0) return "";
+    const pct = ((close - open) / open) * 100;
+    if (!Number.isFinite(pct)) return "";
+    const sign = pct >= 0 ? "+" : "";
+    return ` (${sign}${pct.toFixed(2)}%)`;
+  },
+  formatOhlcvText(bar, volumeValue = null) {
+    if (!bar) return "";
+    const color = this.candleTextColor(bar);
+    const volume = volumeValue == null ? bar.volume : volumeValue;
+    const changeText = this.formatCandleChangePercent(bar);
+    const value = (label, number) =>
+      `${label} <span style="color:${color}">${App.ui.formatNumber(number, 2)}</span>`;
+    return value("O", bar.open) +
+      ` ${value("H", bar.high)}` +
+      ` ${value("L", bar.low)}` +
+      ` ${value("C", bar.close)}` +
+      ` Vol <span style="color:${color}">${App.ui.formatNumber(volume, 2)}${changeText}</span>`;
+  },
+  setMagnetMode(enabled) {
+    if (!this.chart) return;
+    this.chart.applyOptions({
+      crosshair: {
+        mode: enabled ? LightweightCharts.CrosshairMode.Magnet : LightweightCharts.CrosshairMode.Normal
+      }
+    });
+  },
+  restoreMagnetMode() {
+    this.setMagnetMode(true);
+  },
+  removeManualAlertPriceGuide() {
+    if (this.manualAlertPriceLine && this.candleSeries && this.candleSeries.removePriceLine) {
+      this.candleSeries.removePriceLine(this.manualAlertPriceLine);
+    }
+    this.manualAlertPriceLine = null;
+  },
+  updateManualAlertPriceGuide(price) {
+    if (!this.candleSeries || !Number.isFinite(Number(price))) return;
+    const dottedLineStyle = (LightweightCharts.LineStyle && LightweightCharts.LineStyle.Dotted != null)
+      ? LightweightCharts.LineStyle.Dotted
+      : 1;
+    const options = {
+      price: Number(price),
+      color: "#111111",
+      lineWidth: 1,
+      lineStyle: dottedLineStyle,
+      axisLabelVisible: true,
+      title: "Alert"
+    };
+    if (this.manualAlertPriceLine) {
+      this.manualAlertPriceLine.applyOptions(options);
+    } else {
+      this.manualAlertPriceLine = this.candleSeries.createPriceLine(options);
+    }
+  },
+  priceFromClientY(clientY) {
+    if (!this.candleSeries || !this.container) return null;
+    const rect = this.container.getBoundingClientRect();
+    const price = this.candleSeries.coordinateToPrice(clientY - rect.top);
+    return Number.isFinite(Number(price)) ? Number(price) : null;
+  },
+  normalizeAlertTime(time) {
+    if (typeof time === "number") return time;
+    if (time && typeof time.timestamp === "number") return time.timestamp;
+    return App.state.lastBarTime || null;
+  },
+  manualAlertContextFromPointer(pointer) {
+    if (!pointer || !this.chart || !this.candleSeries) return null;
+    const rect = this.container.getBoundingClientRect();
+    const x = pointer.clientX - rect.left;
+    const y = pointer.clientY - rect.top;
+    const price = this.candleSeries.coordinateToPrice(y);
+    if (!Number.isFinite(Number(price))) return null;
+    const time = this.chart.timeScale().coordinateToTime(x);
+    return {
+      clientX: pointer.clientX,
+      clientY: pointer.clientY,
+      price: Number(price),
+      time: this.normalizeAlertTime(time)
+    };
+  },
+  openManualAlertMenuFromPointer(pointer) {
+    if (App.state.sourcePanelOpen) return;
+    if (!App.ui.elements.alertTemplateModal.classList.contains("hidden")) return;
+    const context = this.manualAlertContextFromPointer(pointer);
+    if (!context) return;
+    App.ui.showManualAlertMenu(context);
+    this.setMagnetMode(false);
+  },
+  attachManualAlertGesture() {
+    this.container.addEventListener("dblclick", (e) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      App.ui.closeManualAlertMenu();
+      this.openManualAlertMenuFromPointer({ clientX: e.clientX, clientY: e.clientY });
+    }, { passive: false });
+
+    this.container.addEventListener("pointerup", (e) => {
+      if (e.pointerType === "mouse") return;
+      const now = performance.now();
+      const previous = this.manualAlertLastTap;
+      this.manualAlertLastTap = { time: now, clientX: e.clientX, clientY: e.clientY };
+      if (!previous) return;
+      const dt = now - previous.time;
+      const distance = Math.hypot(e.clientX - previous.clientX, e.clientY - previous.clientY);
+      if (dt > 360 || distance > 28) return;
+      e.preventDefault();
+      this.manualAlertLastTap = null;
+      App.ui.closeManualAlertMenu();
+      this.openManualAlertMenuFromPointer({ clientX: e.clientX, clientY: e.clientY });
+    }, { passive: false });
   },
   clearPersistedChartView() {
     try {
@@ -138,12 +260,7 @@ App.chart = {
           App.ui.setChartInfo();
           return;
         }
-        const ohlcvText = `O <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.open, 2)}</span>` +
-          ` H <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.high, 2)}</span>` +
-          ` L <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.low, 2)}</span>` +
-          ` C <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.close, 2)}</span>` +
-          ` Vol <span style="color:#d32f2f">${App.ui.formatNumber(state.lastOhlcv.volume, 2)}</span>`;
-        App.ui.setChartInfo(ohlcvText);
+        App.ui.setChartInfo(this.formatOhlcvText(state.lastOhlcv));
         return;
       }
       const bar = param.seriesData.get(this.candleSeries);
@@ -153,13 +270,9 @@ App.chart = {
         return;
       }
       const volumeValue = volBar ? volBar.value : (state.lastOhlcv ? state.lastOhlcv.volume : null);
-      const ohlcvText = `O <span style="color:#d32f2f">${App.ui.formatNumber(bar.open, 2)}</span>` +
-        ` H <span style="color:#d32f2f">${App.ui.formatNumber(bar.high, 2)}</span>` +
-        ` L <span style="color:#d32f2f">${App.ui.formatNumber(bar.low, 2)}</span>` +
-        ` C <span style="color:#d32f2f">${App.ui.formatNumber(bar.close, 2)}</span>` +
-        ` Vol <span style="color:#d32f2f">${App.ui.formatNumber(volumeValue, 2)}</span>`;
-      App.ui.setChartInfo(ohlcvText);
+      App.ui.setChartInfo(this.formatOhlcvText(bar, volumeValue));
     });
+    this.attachManualAlertGesture();
     this.attachTouchGuards();
   },
   resetChartState(resetCandles = true) {
@@ -203,6 +316,7 @@ App.chart = {
       this.candleSeries.removePriceLine(this.currentPriceLine);
     }
     this.currentPriceLine = null;
+    this.removeManualAlertPriceGuide();
   },
   updatePriceLineWithTimer() {
     const state = App.state;

--- a/data_service/templates/data.js
+++ b/data_service/templates/data.js
@@ -388,6 +388,9 @@ App.data = {
       const exchange = (info.exchange || "Unknown").toUpperCase();
       const symbol = info.symbol || "Unknown";
       const timeframe = info.timeframe || "Unknown";
+      state.exchange = exchange;
+      state.symbol = symbol;
+      state.timeframe = timeframe;
       const tfSeconds = App.data.timeframeToSeconds(info.timeframe);
       if (tfSeconds) {
         state.configuredTimeframeSec = tfSeconds;
@@ -465,14 +468,20 @@ App.data = {
     const ui = App.ui;
     try {
       const resp = await fetch(`${App.config.apiBase}/webhook-config`);
-      if (!resp.ok) return;
+      if (!resp.ok) {
+        state.webhookUrl = "";
+        return null;
+      }
       const cfg = await resp.json();
       state.webhookEnabled = Boolean(cfg.enabled);
       state.telegramEnabled = Boolean(cfg.telegram_notification);
+      state.webhookUrl = cfg.url || "";
       ui.elements.webhookToggle.checked = state.webhookEnabled;
       ui.elements.telegramToggle.checked = state.telegramEnabled;
+      return cfg;
     } catch (e) {
-      // ignore
+      state.webhookUrl = "";
+      return null;
     }
   },
   async updateWebhookConfig(payload) {
@@ -488,11 +497,65 @@ App.data = {
       const cfg = await resp.json();
       App.state.webhookEnabled = Boolean(cfg.enabled);
       App.state.telegramEnabled = Boolean(cfg.telegram_notification);
+      App.state.webhookUrl = cfg.url || "";
       App.ui.elements.webhookToggle.checked = App.state.webhookEnabled;
       App.ui.elements.telegramToggle.checked = App.state.telegramEnabled;
       return true;
     } catch (e) {
       return false;
+    }
+  },
+  normalizeManualAlertTemplates(templates) {
+    return Array.isArray(templates)
+      ? templates.filter(t => t && typeof t.title === "string" && typeof t.message === "string")
+      : [];
+  },
+  async loadManualAlertTemplates() {
+    try {
+      const resp = await fetch(`${App.config.apiBase}/manual-alert-templates`);
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        return { ok: false, error: data.error || `Load failed (${resp.status})` };
+      }
+      const templates = this.normalizeManualAlertTemplates(data.templates);
+      App.state.manualAlertTemplates = templates;
+      return { ok: true, templates };
+    } catch (e) {
+      return { ok: false, error: "Load failed" };
+    }
+  },
+  async saveManualAlertTemplates(templates) {
+    try {
+      const resp = await fetch(`${App.config.apiBase}/manual-alert-templates`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ templates })
+      });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        return { ok: false, error: data.error || `Save failed (${resp.status})` };
+      }
+      const savedTemplates = this.normalizeManualAlertTemplates(data.templates);
+      App.state.manualAlertTemplates = savedTemplates;
+      return { ok: true, templates: savedTemplates };
+    } catch (e) {
+      return { ok: false, error: "Save failed" };
+    }
+  },
+  async sendManualAlert(payload) {
+    try {
+      const resp = await fetch(`${App.config.apiBase}/manual-alert`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        return { ok: false, error: data.error || `Send failed (${resp.status})` };
+      }
+      return { ok: true, data };
+    } catch (e) {
+      return { ok: false, error: "Send failed" };
     }
   }
 };

--- a/data_service/templates/index.html
+++ b/data_service/templates/index.html
@@ -20,7 +20,9 @@
         <button id="source-toggle" class="toolbar-btn source-btn" title="Source code" aria-controls="source-panel" aria-expanded="false">&lt;/&gt;</button>
         <div id="alerts-menu" class="dropdown">
           <div class="dropdown-row">
-            <span>Webhook</span>
+            <span class="dropdown-label">Webhook
+              <button id="alert-template-settings" class="inline-icon-btn" title="Alert message templates" aria-label="Alert message templates">⚙</button>
+            </span>
             <label class="toggle-pill">
               <input type="checkbox" id="alert-webhook-toggle" />
               <span>ON</span>
@@ -56,6 +58,77 @@
       <textarea id="source-code" class="source-editor" spellcheck="false" autocapitalize="off" autocomplete="off" autocorrect="off" wrap="soft">No source loaded.</textarea>
     </div>
   </aside>
+  <div id="alert-template-backdrop" class="template-backdrop hidden"></div>
+  <section id="alert-template-modal" class="template-modal hidden" aria-hidden="true" aria-label="Alert message templates">
+    <div class="template-modal-header">
+      <div class="template-modal-title-group">
+        <div class="template-modal-title">Manual Alert Templates</div>
+        <button id="alert-template-help-toggle" class="template-help-toggle" type="button" aria-expanded="false" aria-controls="alert-template-help" aria-label="Manual alert help">?</button>
+      </div>
+    </div>
+    <div id="alert-template-help" class="template-help hidden">
+      <div><strong>Purpose</strong>: send a one-off manual webhook alert from the chart at a selected price.</div>
+      <div><strong>Use</strong>: double-click or double-tap the chart, choose a template, drag the menu to adjust price, then Send.</div>
+      <div>
+        <strong>Placeholders</strong>:
+        <span class="template-placeholder-list">
+          <button class="template-placeholder" type="button" data-help="Selected alert price. Drag the manual alert menu to adjust it."><code>{{price}}</code></button>
+          <button class="template-placeholder" type="button" data-help="Latest live close/last price at the final Send click."><code>{{market}}</code></button>
+          <button class="template-placeholder" type="button" data-help="Chart time under the cursor, or the latest bar time if unavailable."><code>{{time}}</code></button>
+          <button class="template-placeholder" type="button" data-help="Session symbol, for example BTC/USDT:USDT."><code>{{symbol}}</code></button>
+          <button class="template-placeholder" type="button" data-help="Alias of symbol, kept for webhook template readability."><code>{{ticker}}</code></button>
+          <button class="template-placeholder" type="button" data-help="Session exchange id, for example okx, bitget, binance, hyperliquid."><code>{{exchange}}</code></button>
+          <button class="template-placeholder" type="button" data-help="Session timeframe, for example 1m or 5m."><code>{{timeframe}}</code></button>
+          <button class="template-placeholder" type="button" data-help="Template title selected in the manual alert menu."><code>{{title}}</code></button>
+        </span>
+      </div>
+      <pre>{"signal":"LONG 1","price":{{market}},"weight":0.0275}</pre>
+      <pre>{"signal":"CLOSE TP3","ticker":"{{ticker}}"}</pre>
+    </div>
+    <div class="template-table">
+      <div class="template-table-head">
+        <div>TITLE</div>
+        <div>MESSAGE</div>
+        <div></div>
+      </div>
+      <div id="alert-template-rows"></div>
+    </div>
+    <div class="template-actions">
+      <button id="alert-template-add" class="template-btn" title="Add template" aria-label="Add template">+</button>
+      <span id="alert-template-status" class="template-status"></span>
+      <button id="alert-template-save" class="template-btn primary">Save</button>
+    </div>
+  </section>
+  <div id="alert-template-placeholder-tip" class="template-placeholder-tooltip hidden" role="tooltip"></div>
+  <div id="manual-alert-menu" class="manual-alert-menu hidden">
+    <div id="manual-alert-drag" class="manual-alert-drag">
+      <div id="manual-alert-price" class="manual-alert-price"></div>
+    </div>
+    <div class="manual-alert-controls">
+      <div id="manual-alert-template-picker" class="manual-alert-template-picker">
+        <button id="manual-alert-template-button" class="manual-alert-template-button" type="button" aria-haspopup="listbox" aria-expanded="false">
+          <span id="manual-alert-template-label" class="manual-alert-template-label"></span>
+          <span class="manual-alert-template-caret" aria-hidden="true"></span>
+        </button>
+        <div id="manual-alert-template-options" class="manual-alert-template-options hidden" role="listbox"></div>
+      </div>
+      <button id="manual-alert-send" class="template-btn primary">Send</button>
+    </div>
+    <div id="manual-alert-status" class="manual-alert-status"></div>
+  </div>
+  <div id="manual-alert-confirm-backdrop" class="manual-alert-confirm-backdrop hidden"></div>
+  <section id="manual-alert-confirm" class="manual-alert-confirm hidden" aria-hidden="true" aria-label="Confirm manual alert">
+    <div class="manual-alert-confirm-title">Send Manual Alert?</div>
+    <div class="manual-alert-confirm-body">
+      <div>Webhook URL</div>
+      <div id="manual-alert-confirm-url" class="manual-alert-confirm-url"></div>
+      <div class="manual-alert-confirm-note">Telegram will also be sent if credentials are configured.</div>
+    </div>
+    <div class="manual-alert-confirm-actions">
+      <button id="manual-alert-confirm-cancel" class="template-btn" type="button">Cancel</button>
+      <button id="manual-alert-confirm-send" class="template-btn primary" type="button">Send</button>
+    </div>
+  </section>
   <!--RUNTIME_CONFIG-->
   <script src="/static/state.js"></script>
   <script src="/static/ui.js"></script>

--- a/data_service/templates/main.js
+++ b/data_service/templates/main.js
@@ -5,6 +5,7 @@ App.ws.startKeepalive();
 App.data.loadChartInfo();
 App.data.loadScriptSource();
 App.data.loadWebhookConfig();
+App.ui.loadManualAlertTemplates({ migrateLocal: true });
 App.chart.startJankMonitor();
 App.chart.attachResizeHandler();
 App.chart.attachNavButtons();

--- a/data_service/templates/state.js
+++ b/data_service/templates/state.js
@@ -28,6 +28,9 @@ window.App.state = {
   lastOpenPrice: { time: 0, value: 0 },
   lastPrice: 0,
   lastOhlcv: null,
+  exchange: "",
+  symbol: "",
+  timeframe: "",
   scriptTitle: "No title",
   scriptTitleVisible: false,
   scriptSourceName: "",
@@ -43,7 +46,15 @@ window.App.state = {
   jankReloaded: false,
   lastFrameTs: null,
   webhookEnabled: false,
-  telegramEnabled: false
+  telegramEnabled: false,
+  webhookUrl: "",
+  manualAlertTemplates: [],
+  manualAlertContext: null,
+  manualAlertMenuOpen: false,
+  manualAlertTemplateOpen: false,
+  manualAlertConfirmOpen: false,
+  manualAlertSelectedTemplateIndex: -1,
+  manualAlertSuppressClickUntil: 0
 };
 
 window.App.collections = {

--- a/data_service/templates/styles.css
+++ b/data_service/templates/styles.css
@@ -101,25 +101,49 @@ body.source-open #chart {
   position: absolute;
   top: 36px;
   left: 0;
-  min-width: 180px;
+  width: max-content;
+  min-width: 136px;
   background: #ffffff;
   color: #111;
   border: 1px solid rgba(0, 0, 0, 0.1);
   border-radius: 8px;
   box-shadow: 0 6px 18px rgba(0, 0, 0, 0.12);
-  padding: 8px 10px;
+  padding: 6px 8px;
   display: none;
 }
 .dropdown.open {
   display: block;
 }
 .dropdown-row {
-  display: flex;
+  display: grid;
+  grid-template-columns: 82px max-content;
   align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-  padding: 6px 0;
+  column-gap: 8px;
+  padding: 5px 0;
   font-size: 12px;
+}
+.dropdown-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-width: 0;
+}
+.inline-icon-btn {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  background: #f7f7f7;
+  color: #111;
+  font-size: 12px;
+  line-height: 1;
+  cursor: pointer;
+}
+.inline-icon-btn:active {
+  transform: translateY(1px);
 }
 .dropdown-row + .dropdown-row {
   border-top: 1px solid rgba(0, 0, 0, 0.06);
@@ -127,6 +151,7 @@ body.source-open #chart {
 .toggle-pill {
   display: inline-flex;
   align-items: center;
+  justify-self: start;
   gap: 6px;
   font-size: 11px;
 }
@@ -147,6 +172,381 @@ body.source-open #chart {
   padding: 6px 8px;
   border-radius: 6px;
   cursor: pointer;
+}
+.hidden {
+  display: none !important;
+}
+.template-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 29;
+  background: rgba(0, 0, 0, 0.38);
+}
+.template-modal {
+  position: fixed;
+  top: 72px;
+  left: 50%;
+  z-index: 30;
+  width: min(760px, calc(100vw - 32px));
+  max-height: calc(100dvh - 112px);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #ffffff;
+  color: #111;
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  border-radius: 8px;
+  box-shadow: 0 18px 48px rgba(0, 0, 0, 0.32);
+  transform: translateX(-50%);
+}
+.template-modal-header,
+.template-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+.template-actions {
+  border-top: 1px solid rgba(0, 0, 0, 0.08);
+  border-bottom: 0;
+}
+.template-modal-title {
+  flex: 0 1 auto;
+  font-size: 14px;
+  font-weight: 700;
+}
+.template-modal-title-group {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  flex: 0 1 auto;
+  min-width: 0;
+}
+.template-help-toggle {
+  flex: 0 0 auto;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  border-radius: 50%;
+  background: #f7f7f7;
+  color: #111;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 22px;
+  text-align: center;
+  cursor: pointer;
+}
+.template-help {
+  flex: 0 0 auto;
+  padding: 10px 14px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  background: #fbfbfb;
+  color: #333;
+  font-size: 12px;
+  line-height: 1.45;
+}
+.template-help > div + div {
+  margin-top: 5px;
+}
+.template-help code,
+.template-help pre {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.template-help code {
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: #ececec;
+}
+.template-placeholder-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 5px;
+  vertical-align: middle;
+}
+.template-placeholder {
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  cursor: help;
+}
+.template-placeholder:hover code,
+.template-placeholder:focus-visible code {
+  background: #e0e0e0;
+}
+.template-placeholder-tooltip {
+  position: fixed;
+  z-index: 60;
+  max-width: min(320px, calc(100vw - 24px));
+  box-sizing: border-box;
+  padding: 7px 9px;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: 7px;
+  background: #fff;
+  color: #111;
+  font-size: 11.5px;
+  line-height: 1.35;
+  box-shadow: 0 10px 26px rgba(0, 0, 0, 0.22);
+  pointer-events: none;
+}
+.template-help pre {
+  margin: 7px 0 0;
+  padding: 7px 8px;
+  overflow-x: auto;
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  border-radius: 6px;
+  background: #fff;
+  color: #111;
+  font-size: 11px;
+  line-height: 1.35;
+}
+.template-table {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}
+.template-table-head,
+.template-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 180px) minmax(260px, 1fr) 34px;
+  gap: 8px;
+  align-items: start;
+  padding: 10px 14px;
+}
+.template-table-head {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #f8f8f8;
+  color: #555;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.4px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+.template-row + .template-row {
+  border-top: 1px solid rgba(0, 0, 0, 0.06);
+}
+.template-row input,
+.template-row textarea,
+.manual-alert-template-button {
+  box-sizing: border-box;
+  width: 100%;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111;
+  font: 12px/1.45 system-ui, -apple-system, "Segoe UI", sans-serif;
+}
+.template-row input {
+  padding: 8px 9px;
+}
+.template-row textarea {
+  min-height: 44px;
+  padding: 8px 9px;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.template-btn,
+.template-remove {
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  border-radius: 6px;
+  background: #f7f7f7;
+  color: #111;
+  font-size: 12px;
+  padding: 7px 10px;
+  cursor: pointer;
+}
+.template-remove {
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  font-size: 18px;
+  line-height: 1;
+}
+.template-btn.primary {
+  margin-left: auto;
+  background: #111;
+  color: #fff;
+}
+.template-status,
+.manual-alert-status {
+  color: #666;
+  font-size: 12px;
+}
+.template-status.error,
+.manual-alert-status.error {
+  color: #d32f2f;
+}
+.manual-alert-menu {
+  position: fixed;
+  z-index: 18;
+  width: 160px;
+  box-sizing: border-box;
+  padding: 0;
+  background: rgba(255, 255, 255, 0.96);
+  color: #111;
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  border-radius: 8px;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.26);
+  overflow: visible;
+}
+.manual-alert-drag {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 23px;
+  padding: 3px 5px 3px 7px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+  cursor: move;
+  touch-action: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+.manual-alert-price {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 10.5px;
+  font-weight: 700;
+}
+.manual-alert-controls {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 7px 0;
+}
+.manual-alert-template-picker {
+  flex: 1 1 auto;
+  min-width: 0;
+  position: relative;
+}
+.manual-alert-template-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+  padding: 3px 6px;
+  font-size: 11px;
+  line-height: 1.3;
+  text-align: left;
+  cursor: pointer;
+}
+.manual-alert-template-button:disabled {
+  color: #777;
+  cursor: default;
+}
+.manual-alert-template-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.manual-alert-template-caret {
+  flex: 0 0 auto;
+  width: 0;
+  height: 0;
+  border-left: 4px solid transparent;
+  border-right: 4px solid transparent;
+  border-top: 5px solid currentColor;
+}
+.manual-alert-template-options {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 20;
+  max-height: 132px;
+  overflow: auto;
+  padding: 3px;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.16);
+  border-radius: 7px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.22);
+}
+.manual-alert-template-option {
+  width: 100%;
+  display: block;
+  box-sizing: border-box;
+  padding: 6px 7px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: #111;
+  font-size: 11px;
+  line-height: 1.25;
+  text-align: left;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.manual-alert-template-option.active {
+  background: #111;
+  color: #fff;
+}
+.manual-alert-controls .template-btn.primary {
+  flex: 0 0 auto;
+  margin-left: 0;
+  padding: 3px 7px;
+  font-size: 11px;
+}
+.manual-alert-status {
+  min-height: 11px;
+  padding: 2px 7px 5px;
+  font-size: 10.5px;
+}
+.manual-alert-confirm-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 39;
+  background: rgba(0, 0, 0, 0.28);
+}
+.manual-alert-confirm {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  z-index: 40;
+  width: min(360px, calc(100vw - 32px));
+  box-sizing: border-box;
+  padding: 14px;
+  background: #ffffff;
+  color: #111;
+  border: 1px solid rgba(0, 0, 0, 0.14);
+  border-radius: 8px;
+  box-shadow: 0 16px 42px rgba(0, 0, 0, 0.32);
+  transform: translate(-50%, -50%);
+}
+.manual-alert-confirm-title {
+  font-size: 14px;
+  font-weight: 700;
+}
+.manual-alert-confirm-body {
+  margin-top: 10px;
+  color: #555;
+  font-size: 12px;
+  line-height: 1.4;
+}
+.manual-alert-confirm-url {
+  margin-top: 4px;
+  padding: 7px 8px;
+  overflow-wrap: anywhere;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  background: #f7f7f7;
+  color: #111;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.manual-alert-confirm-note {
+  margin-top: 8px;
+}
+.manual-alert-confirm-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 14px;
 }
 .nav-btn {
   position: absolute;
@@ -460,6 +860,78 @@ body.source-open .source-panel {
     max-width: 112px;
   }
 
+  .template-modal {
+    top: auto;
+    right: max(8px, env(safe-area-inset-right));
+    bottom: max(8px, env(safe-area-inset-bottom));
+    left: max(8px, env(safe-area-inset-left));
+    width: auto;
+    max-height: min(72dvh, 640px);
+    border-radius: 10px;
+    transform: none;
+  }
+
+  .template-modal-header {
+    padding: 10px 12px;
+  }
+
+  .template-modal-title {
+    font-size: 15px;
+  }
+
+  .template-help {
+    padding: 9px 12px;
+    font-size: 11.5px;
+  }
+
+  .template-table-head {
+    display: none;
+  }
+
+  .template-row {
+    grid-template-columns: minmax(0, 1fr) 32px;
+    gap: 7px;
+    padding: 9px 12px;
+    align-items: stretch;
+  }
+
+  .template-row input {
+    grid-column: 1;
+    grid-row: 1;
+    padding: 7px 9px;
+  }
+
+  .template-row textarea {
+    min-height: 74px;
+    padding: 7px 9px;
+    grid-column: 1 / -1;
+    grid-row: 2;
+    resize: vertical;
+  }
+
+  .template-remove {
+    grid-column: 2;
+    grid-row: 1;
+    width: 32px;
+    height: auto;
+    min-height: 32px;
+    align-self: stretch;
+  }
+
+  .template-actions {
+    gap: 8px;
+    padding: 8px 12px;
+    background: #ffffff;
+  }
+
+  .template-btn {
+    padding: 7px 10px;
+  }
+
+  .manual-alert-menu {
+    width: min(160px, calc(100vw - 24px));
+  }
+
   #chart-info {
     top: max(8px, env(safe-area-inset-top));
     left: max(8px, env(safe-area-inset-left));
@@ -494,18 +966,14 @@ body.source-open .source-panel {
     top: 30px;
     left: 0;
     right: auto;
-    min-width: 150px;
+    min-width: 136px;
     max-width: calc(100vw - 24px);
-    padding: 7px 10px;
+    padding: 6px 8px;
   }
 
   .dropdown-row {
+    column-gap: 18px;
     font-size: 12px;
-    gap: 8px;
-  }
-
-  .dropdown-row span:first-child {
-    min-width: 64px;
   }
 
   .nav-btn {

--- a/data_service/templates/ui.js
+++ b/data_service/templates/ui.js
@@ -8,6 +8,30 @@ App.ui = {
     chartInfoTitle: document.getElementById("chart-info-title"),
     alertsToggle: document.getElementById("alerts-toggle"),
     alertsMenu: document.getElementById("alerts-menu"),
+    alertTemplateSettings: document.getElementById("alert-template-settings"),
+    alertTemplateBackdrop: document.getElementById("alert-template-backdrop"),
+    alertTemplateModal: document.getElementById("alert-template-modal"),
+    alertTemplateHelpToggle: document.getElementById("alert-template-help-toggle"),
+    alertTemplateHelp: document.getElementById("alert-template-help"),
+    alertTemplatePlaceholderTip: document.getElementById("alert-template-placeholder-tip"),
+    alertTemplateRows: document.getElementById("alert-template-rows"),
+    alertTemplateAdd: document.getElementById("alert-template-add"),
+    alertTemplateSave: document.getElementById("alert-template-save"),
+    alertTemplateStatus: document.getElementById("alert-template-status"),
+    manualAlertMenu: document.getElementById("manual-alert-menu"),
+    manualAlertDrag: document.getElementById("manual-alert-drag"),
+    manualAlertPrice: document.getElementById("manual-alert-price"),
+    manualAlertTemplatePicker: document.getElementById("manual-alert-template-picker"),
+    manualAlertTemplateButton: document.getElementById("manual-alert-template-button"),
+    manualAlertTemplateLabel: document.getElementById("manual-alert-template-label"),
+    manualAlertTemplateOptions: document.getElementById("manual-alert-template-options"),
+    manualAlertSend: document.getElementById("manual-alert-send"),
+    manualAlertStatus: document.getElementById("manual-alert-status"),
+    manualAlertConfirmBackdrop: document.getElementById("manual-alert-confirm-backdrop"),
+    manualAlertConfirm: document.getElementById("manual-alert-confirm"),
+    manualAlertConfirmUrl: document.getElementById("manual-alert-confirm-url"),
+    manualAlertConfirmCancel: document.getElementById("manual-alert-confirm-cancel"),
+    manualAlertConfirmSend: document.getElementById("manual-alert-confirm-send"),
     webhookToggle: document.getElementById("alert-webhook-toggle"),
     telegramToggle: document.getElementById("alert-telegram-toggle"),
     sourceToggle: document.getElementById("source-toggle"),
@@ -21,6 +45,10 @@ App.ui = {
     sourceHighlight: document.getElementById("source-highlight"),
     sourceCode: document.getElementById("source-code")
   },
+  manualAlertDragState: null,
+  manualAlertPendingSend: null,
+  manualAlertStatusClearTimer: null,
+  activeTemplatePlaceholder: null,
   setChartInfo(ohlcvText = null) {
     const state = App.state;
     const baseLine = ohlcvText
@@ -43,6 +71,584 @@ App.ui = {
     if (shouldOpen) {
       App.data.loadWebhookConfig();
     }
+  },
+  alertTemplateStorageKey() {
+    return App.config.storageKey("manualAlertTemplates");
+  },
+  alertTemplateMigrationKey() {
+    return App.config.storageKey("manualAlertTemplatesMigrated");
+  },
+  readLocalManualAlertTemplates() {
+    try {
+      const raw = localStorage.getItem(this.alertTemplateStorageKey());
+      const parsed = raw ? JSON.parse(raw) : [];
+      return Array.isArray(parsed)
+        ? parsed.filter(t => t && typeof t.title === "string" && typeof t.message === "string")
+        : [];
+    } catch {
+      return [];
+    }
+  },
+  clearLocalManualAlertTemplates() {
+    try {
+      localStorage.removeItem(this.alertTemplateStorageKey());
+    } catch {}
+  },
+  async migrateLocalManualAlertTemplatesIfNeeded(serverTemplates) {
+    if (serverTemplates.length > 0) return serverTemplates;
+    try {
+      if (localStorage.getItem(this.alertTemplateMigrationKey()) === "1") {
+        return serverTemplates;
+      }
+    } catch {
+      return serverTemplates;
+    }
+    const localTemplates = this.readLocalManualAlertTemplates();
+    if (!localTemplates.length) {
+      try {
+        localStorage.setItem(this.alertTemplateMigrationKey(), "1");
+      } catch {}
+      return serverTemplates;
+    }
+    const result = await App.data.saveManualAlertTemplates(localTemplates);
+    if (result.ok) {
+      try {
+        localStorage.setItem(this.alertTemplateMigrationKey(), "1");
+      } catch {}
+      this.clearLocalManualAlertTemplates();
+      return result.templates;
+    }
+    return serverTemplates;
+  },
+  async loadManualAlertTemplates({ migrateLocal = false } = {}) {
+    const result = await App.data.loadManualAlertTemplates();
+    if (!result.ok) return App.state.manualAlertTemplates;
+    if (migrateLocal) {
+      return await this.migrateLocalManualAlertTemplatesIfNeeded(result.templates);
+    }
+    return result.templates;
+  },
+  async persistManualAlertTemplates(templates) {
+    const result = await App.data.saveManualAlertTemplates(templates);
+    if (result.ok) {
+      try {
+        localStorage.setItem(this.alertTemplateMigrationKey(), "1");
+      } catch {}
+      this.clearLocalManualAlertTemplates();
+    }
+    return result;
+  },
+  setTemplateStatus(text = "", isError = false) {
+    const status = this.elements.alertTemplateStatus;
+    status.textContent = text;
+    status.classList.toggle("error", isError);
+  },
+  toggleAlertTemplateHelp(forceOpen = null) {
+    const shouldOpen = forceOpen === null
+      ? this.elements.alertTemplateHelp.classList.contains("hidden")
+      : forceOpen;
+    this.elements.alertTemplateHelp.classList.toggle("hidden", !shouldOpen);
+    this.elements.alertTemplateHelpToggle.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
+    if (!shouldOpen) {
+      this.clearActiveTemplatePlaceholder();
+    }
+  },
+  isCoarsePointer() {
+    return window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+  },
+  showTemplatePlaceholderTip(button) {
+    if (!button) return;
+    this.activeTemplatePlaceholder = button;
+    const tooltip = this.elements.alertTemplatePlaceholderTip;
+    tooltip.textContent = button.dataset.help || "";
+    tooltip.classList.remove("hidden");
+    this.positionTemplatePlaceholderTip(button);
+  },
+  positionTemplatePlaceholderTip(button) {
+    const tooltip = this.elements.alertTemplatePlaceholderTip;
+    if (!button || tooltip.classList.contains("hidden")) return;
+    tooltip.style.left = "0px";
+    tooltip.style.top = "0px";
+    const rect = button.getBoundingClientRect();
+    const tipRect = tooltip.getBoundingClientRect();
+    const margin = 8;
+    let left = rect.left + rect.width / 2 - tipRect.width / 2;
+    left = Math.max(margin, Math.min(left, window.innerWidth - tipRect.width - margin));
+    let top = rect.bottom + margin;
+    if (top + tipRect.height > window.innerHeight - margin) {
+      top = rect.top - tipRect.height - margin;
+    }
+    top = Math.max(margin, Math.min(top, window.innerHeight - tipRect.height - margin));
+    tooltip.style.left = `${Math.round(left)}px`;
+    tooltip.style.top = `${Math.round(top)}px`;
+  },
+  clearActiveTemplatePlaceholder(button = null) {
+    if (button && this.activeTemplatePlaceholder !== button) {
+      return;
+    }
+    this.activeTemplatePlaceholder = null;
+    this.elements.alertTemplatePlaceholderTip.textContent = "";
+    this.elements.alertTemplatePlaceholderTip.classList.add("hidden");
+  },
+  attachAlertTemplatePlaceholderHelp() {
+    this.elements.alertTemplateHelp.querySelectorAll(".template-placeholder").forEach((button) => {
+      button.addEventListener("mouseenter", () => {
+        if (!this.isCoarsePointer()) {
+          this.showTemplatePlaceholderTip(button);
+        }
+      });
+      button.addEventListener("mouseleave", () => {
+        if (!this.isCoarsePointer()) {
+          this.clearActiveTemplatePlaceholder(button);
+        }
+      });
+      button.addEventListener("click", (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (this.isCoarsePointer()) {
+          this.showTemplatePlaceholderTip(button);
+        }
+      });
+    });
+  },
+  addAlertTemplateRow(template = { title: "", message: "{}" }) {
+    const row = document.createElement("div");
+    row.className = "template-row";
+    row.innerHTML =
+      `<input type="text" class="template-title-input" value="${this.escapeHtml(template.title || "")}" placeholder="TITLE" spellcheck="false">` +
+      `<textarea class="template-message-input" placeholder="MESSAGE JSON" spellcheck="false">${this.escapeHtml(template.message || "{}")}</textarea>` +
+      `<button class="template-remove" title="Remove" aria-label="Remove">&times;</button>`;
+    row.querySelector(".template-remove").addEventListener("click", () => {
+      row.remove();
+      this.setTemplateStatus("");
+    });
+    this.elements.alertTemplateRows.appendChild(row);
+  },
+  renderAlertTemplateRows() {
+    this.elements.alertTemplateRows.innerHTML = "";
+    App.state.manualAlertTemplates.forEach(t => this.addAlertTemplateRow(t));
+  },
+  collectAlertTemplateRows() {
+    const templates = [];
+    const rows = Array.from(this.elements.alertTemplateRows.querySelectorAll(".template-row"));
+    for (const row of rows) {
+      const title = row.querySelector(".template-title-input").value.trim();
+      const message = row.querySelector(".template-message-input").value.trim();
+      if (!title && !message) continue;
+      if (!title) return { ok: false, error: "TITLE is required" };
+      if (!message) return { ok: false, error: "MESSAGE is required" };
+      try {
+        this.parseAlertTemplateMessage(message, { price: 1, market: 1, time: 0, title });
+      } catch (e) {
+        return { ok: false, error: `Invalid JSON: ${title}` };
+      }
+      templates.push({ title, message });
+    }
+    return { ok: true, templates };
+  },
+  async openAlertTemplateModal() {
+    this.toggleAlertsMenu(false);
+    this.setTemplateStatus("Loading...");
+    this.elements.alertTemplateBackdrop.classList.remove("hidden");
+    this.elements.alertTemplateModal.classList.remove("hidden");
+    this.elements.alertTemplateModal.setAttribute("aria-hidden", "false");
+    this.toggleAlertTemplateHelp(false);
+    this.refreshMobileViewportLock();
+    await this.loadManualAlertTemplates({ migrateLocal: true });
+    this.renderAlertTemplateRows();
+    this.setTemplateStatus("");
+  },
+  closeAlertTemplateModal() {
+    if (this.elements.alertTemplateModal.contains(document.activeElement)) {
+      document.activeElement.blur();
+    }
+    this.elements.alertTemplateBackdrop.classList.add("hidden");
+    this.elements.alertTemplateModal.classList.add("hidden");
+    this.elements.alertTemplateModal.setAttribute("aria-hidden", "true");
+    this.clearActiveTemplatePlaceholder();
+    this.refreshMobileViewportLock();
+  },
+  async saveAlertTemplates() {
+    const result = this.collectAlertTemplateRows();
+    if (!result.ok) {
+      this.setTemplateStatus(result.error, true);
+      return false;
+    }
+    this.setTemplateStatus("Saving...");
+    this.elements.alertTemplateSave.disabled = true;
+    const saved = await this.persistManualAlertTemplates(result.templates);
+    this.elements.alertTemplateSave.disabled = false;
+    if (!saved.ok) {
+      this.setTemplateStatus(saved.error || "Save failed", true);
+      return false;
+    }
+    this.setTemplateStatus("Saved");
+    return true;
+  },
+  alertTemplateReplacements(context = {}) {
+    return {
+      "{{price}}": context.price,
+      "{{market}}": context.market,
+      "{{time}}": context.time,
+      "{{symbol}}": App.state.symbol || "",
+      "{{ticker}}": App.state.symbol || "",
+      "{{exchange}}": App.state.exchange || "",
+      "{{timeframe}}": App.state.timeframe || "",
+      "{{title}}": context.title || ""
+    };
+  },
+  isInsideJsonString(text, offset) {
+    let inString = false;
+    let escaped = false;
+    for (let i = 0; i < offset; i += 1) {
+      const ch = text[i];
+      if (escaped) {
+        escaped = false;
+      } else if (ch === "\\") {
+        escaped = true;
+      } else if (ch === "\"") {
+        inString = !inString;
+      }
+    }
+    return inString;
+  },
+  renderRawAlertTemplateJson(text, context) {
+    const replacements = this.alertTemplateReplacements(context);
+    return text.replace(/\{\{(price|market|time|symbol|ticker|exchange|timeframe|title)\}\}/g, (match, _key, offset) => {
+      if (this.isInsideJsonString(text, offset)) return match;
+      const replacement = replacements[match];
+      return JSON.stringify(replacement === undefined ? "" : replacement);
+    });
+  },
+  parseAlertTemplateMessage(message, context) {
+    try {
+      return JSON.parse(message);
+    } catch (initialError) {
+      try {
+        return JSON.parse(this.renderRawAlertTemplateJson(message, context));
+      } catch {
+        throw initialError;
+      }
+    }
+  },
+  replaceAlertTemplateValue(value, context) {
+    if (typeof value === "string") {
+      const replacements = this.alertTemplateReplacements(context);
+      if (Object.prototype.hasOwnProperty.call(replacements, value)) {
+        return replacements[value];
+      }
+      return value.replace(/\{\{(price|market|time|symbol|ticker|exchange|timeframe|title)\}\}/g, (match) => {
+        const replacement = replacements[match];
+        return replacement == null ? "" : String(replacement);
+      });
+    }
+    if (Array.isArray(value)) {
+      return value.map(item => this.replaceAlertTemplateValue(item, context));
+    }
+    if (value && typeof value === "object") {
+      const out = {};
+      Object.entries(value).forEach(([key, item]) => {
+        out[key] = this.replaceAlertTemplateValue(item, context);
+      });
+      return out;
+    }
+    return value;
+  },
+  buildManualAlertMessage(template, context) {
+    const parsed = this.parseAlertTemplateMessage(template.message, { ...context, title: template.title });
+    return this.replaceAlertTemplateValue(parsed, { ...context, title: template.title });
+  },
+  currentMarketPrice() {
+    const lastPrice = Number(App.state.lastPrice);
+    if (Number.isFinite(lastPrice) && lastPrice !== 0) return lastPrice;
+    const lastClose = App.state.lastOhlcv ? Number(App.state.lastOhlcv.close) : NaN;
+    return Number.isFinite(lastClose) ? lastClose : null;
+  },
+  buildManualAlertPayload(pending) {
+    if (pending && pending.message !== undefined) return pending;
+    const template = pending.template;
+    const context = {
+      ...pending.context,
+      market: this.currentMarketPrice(),
+      title: template.title
+    };
+    return {
+      title: template.title,
+      price: context.price,
+      market: context.market,
+      time: context.time,
+      message: this.buildManualAlertMessage(template, context)
+    };
+  },
+  clampManualAlertMenuPosition(left, top) {
+    const menu = this.elements.manualAlertMenu;
+    const rect = menu.getBoundingClientRect();
+    return {
+      left: Math.min(window.innerWidth - rect.width - 8, Math.max(8, left)),
+      top: Math.min(window.innerHeight - rect.height - 8, Math.max(8, top))
+    };
+  },
+  setManualAlertMenuPosition(left, top) {
+    const pos = this.clampManualAlertMenuPosition(left, top);
+    this.elements.manualAlertMenu.style.left = `${pos.left}px`;
+    this.elements.manualAlertMenu.style.top = `${pos.top}px`;
+    return pos;
+  },
+  manualAlertPriceCenterY() {
+    const rect = this.elements.manualAlertPrice.getBoundingClientRect();
+    return rect.top + rect.height / 2;
+  },
+  updateManualAlertPriceFromMenu() {
+    const context = App.state.manualAlertContext;
+    if (!context || !App.chart || !App.chart.priceFromClientY) return;
+    const price = App.chart.priceFromClientY(this.manualAlertPriceCenterY());
+    if (price == null) return;
+    context.price = price;
+    this.elements.manualAlertPrice.textContent = `Price ${this.formatNumber(price, 2)}`;
+    App.chart.updateManualAlertPriceGuide(price);
+  },
+  positionManualAlertMenu(x, y) {
+    const menu = this.elements.manualAlertMenu;
+    menu.classList.remove("hidden");
+    menu.style.left = "8px";
+    menu.style.top = "8px";
+    const menuRect = menu.getBoundingClientRect();
+    const priceRect = this.elements.manualAlertPrice.getBoundingClientRect();
+    const priceOffsetY = (priceRect.top - menuRect.top) + priceRect.height / 2;
+    this.setManualAlertMenuPosition(x + 10, y - priceOffsetY);
+    this.updateManualAlertPriceFromMenu();
+  },
+  closeManualAlertTemplateList() {
+    App.state.manualAlertTemplateOpen = false;
+    this.elements.manualAlertTemplateOptions.classList.add("hidden");
+    this.elements.manualAlertTemplateButton.setAttribute("aria-expanded", "false");
+  },
+  showManualAlertConfirm(payload, url) {
+    this.manualAlertPendingSend = payload;
+    App.state.manualAlertConfirmOpen = true;
+    this.elements.manualAlertConfirmUrl.textContent = url;
+    this.elements.manualAlertConfirmBackdrop.classList.remove("hidden");
+    this.elements.manualAlertConfirm.classList.remove("hidden");
+    this.elements.manualAlertConfirm.setAttribute("aria-hidden", "false");
+  },
+  closeManualAlertConfirm() {
+    this.manualAlertPendingSend = null;
+    App.state.manualAlertConfirmOpen = false;
+    this.elements.manualAlertConfirmBackdrop.classList.add("hidden");
+    this.elements.manualAlertConfirm.classList.add("hidden");
+    this.elements.manualAlertConfirm.setAttribute("aria-hidden", "true");
+    this.elements.manualAlertConfirmSend.disabled = false;
+  },
+  async confirmManualAlertSend() {
+    const pending = this.manualAlertPendingSend;
+    const status = this.elements.manualAlertStatus;
+    if (!pending) return;
+    if (this.manualAlertStatusClearTimer !== null) {
+      clearTimeout(this.manualAlertStatusClearTimer);
+      this.manualAlertStatusClearTimer = null;
+    }
+    let payload;
+    try {
+      payload = this.buildManualAlertPayload(pending);
+    } catch (e) {
+      this.closeManualAlertConfirm();
+      status.textContent = "Invalid JSON";
+      status.classList.add("error");
+      return;
+    }
+    status.textContent = "Sending...";
+    status.classList.remove("error");
+    this.elements.manualAlertConfirmSend.disabled = true;
+    this.elements.manualAlertSend.disabled = true;
+    this.closeManualAlertConfirm();
+    const result = await App.data.sendManualAlert(payload);
+    this.elements.manualAlertSend.disabled = false;
+    if (!result || !result.ok) {
+      status.textContent = (result && result.error) || "Send failed";
+      status.classList.add("error");
+      return;
+    }
+    const telegram = result.data && result.data.telegram;
+    if (telegram && telegram.error) {
+      const detail = String(telegram.error || "").slice(0, 180);
+      status.textContent = detail ? `Webhook sent; Telegram failed: ${detail}` : "Webhook sent; Telegram failed";
+      status.classList.add("error");
+      return;
+    }
+    status.textContent = "Sent";
+    this.manualAlertStatusClearTimer = setTimeout(() => {
+      if (status.textContent === "Sent" && !status.classList.contains("error")) {
+        status.textContent = "";
+      }
+      this.manualAlertStatusClearTimer = null;
+    }, 3000);
+  },
+  toggleManualAlertTemplateList(forceOpen = null) {
+    const button = this.elements.manualAlertTemplateButton;
+    if (button.disabled) return;
+    const shouldOpen = forceOpen === null ? !App.state.manualAlertTemplateOpen : forceOpen;
+    App.state.manualAlertTemplateOpen = shouldOpen;
+    this.elements.manualAlertTemplateOptions.classList.toggle("hidden", !shouldOpen);
+    button.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
+    if (shouldOpen) {
+      const active = this.elements.manualAlertTemplateOptions.querySelector(".active");
+      if (active) active.scrollIntoView({ block: "nearest" });
+    }
+  },
+  selectManualAlertTemplate(index) {
+    const templates = App.state.manualAlertTemplates;
+    const safeIndex = Number.isInteger(index) && index >= 0 && index < templates.length ? index : -1;
+    App.state.manualAlertSelectedTemplateIndex = safeIndex;
+    this.elements.manualAlertTemplateLabel.textContent = safeIndex >= 0 ? templates[safeIndex].title : "No templates";
+    Array.from(this.elements.manualAlertTemplateOptions.children).forEach((option) => {
+      const active = Number(option.dataset.index) === safeIndex;
+      option.classList.toggle("active", active);
+      option.setAttribute("aria-selected", active ? "true" : "false");
+    });
+    this.closeManualAlertTemplateList();
+  },
+  renderManualAlertTemplatePicker(templates) {
+    const button = this.elements.manualAlertTemplateButton;
+    const options = this.elements.manualAlertTemplateOptions;
+    const hasTemplates = templates.length > 0;
+    options.innerHTML = "";
+    App.state.manualAlertTemplateOpen = false;
+    button.disabled = !hasTemplates;
+    button.setAttribute("aria-expanded", "false");
+    options.classList.add("hidden");
+
+    templates.forEach((template, index) => {
+      const option = document.createElement("button");
+      option.type = "button";
+      option.className = "manual-alert-template-option";
+      option.dataset.index = String(index);
+      option.setAttribute("role", "option");
+      option.setAttribute("aria-selected", index === 0 ? "true" : "false");
+      option.textContent = template.title;
+      option.addEventListener("click", (e) => {
+        e.stopPropagation();
+        this.selectManualAlertTemplate(index);
+      });
+      options.appendChild(option);
+    });
+
+    App.state.manualAlertSelectedTemplateIndex = hasTemplates ? 0 : -1;
+    this.elements.manualAlertTemplateLabel.textContent = hasTemplates ? templates[0].title : "No templates";
+    if (options.firstElementChild) {
+      options.firstElementChild.classList.add("active");
+    }
+  },
+  async showManualAlertMenu(context) {
+    const status = this.elements.manualAlertStatus;
+    App.state.manualAlertContext = context;
+    App.state.manualAlertMenuOpen = true;
+    App.state.manualAlertSuppressClickUntil = Date.now() + 500;
+    this.elements.manualAlertPrice.textContent = `Price ${this.formatNumber(context.price, 2)}`;
+    this.elements.manualAlertTemplateLabel.textContent = "Loading...";
+    this.elements.manualAlertTemplateButton.disabled = true;
+    this.elements.manualAlertTemplateOptions.innerHTML = "";
+    this.closeManualAlertTemplateList();
+    this.elements.manualAlertSend.disabled = true;
+    status.textContent = "Loading...";
+    status.classList.remove("error");
+    this.positionManualAlertMenu(context.clientX, context.clientY);
+
+    const templates = await this.loadManualAlertTemplates({ migrateLocal: true });
+    if (App.state.manualAlertContext !== context) return;
+    this.renderManualAlertTemplatePicker(templates);
+    this.elements.manualAlertSend.disabled = templates.length === 0;
+    status.textContent = templates.length ? "" : "No templates";
+    status.classList.toggle("error", templates.length === 0);
+  },
+  closeManualAlertMenu() {
+    this.manualAlertDragState = null;
+    if (this.manualAlertStatusClearTimer !== null) {
+      clearTimeout(this.manualAlertStatusClearTimer);
+      this.manualAlertStatusClearTimer = null;
+    }
+    App.state.manualAlertContext = null;
+    App.state.manualAlertMenuOpen = false;
+    this.elements.manualAlertMenu.classList.add("hidden");
+    this.elements.manualAlertStatus.textContent = "";
+    this.elements.manualAlertStatus.classList.remove("error");
+    this.closeManualAlertTemplateList();
+    this.closeManualAlertConfirm();
+    App.state.manualAlertSelectedTemplateIndex = -1;
+    if (App.chart && App.chart.removeManualAlertPriceGuide) {
+      App.chart.removeManualAlertPriceGuide();
+    }
+    if (App.chart && App.chart.restoreMagnetMode) {
+      App.chart.restoreMagnetMode();
+    }
+  },
+  startManualAlertDrag(e) {
+    if (e.pointerType === "mouse" && e.button !== 0) return;
+    this.closeManualAlertTemplateList();
+    const menu = this.elements.manualAlertMenu;
+    const rect = menu.getBoundingClientRect();
+    this.manualAlertDragState = {
+      pointerId: e.pointerId,
+      offsetX: e.clientX - rect.left,
+      offsetY: e.clientY - rect.top
+    };
+    try {
+      this.elements.manualAlertDrag.setPointerCapture(e.pointerId);
+    } catch {}
+    e.preventDefault();
+  },
+  moveManualAlertDrag(e) {
+    const drag = this.manualAlertDragState;
+    if (!drag || drag.pointerId !== e.pointerId) return;
+    this.setManualAlertMenuPosition(e.clientX - drag.offsetX, e.clientY - drag.offsetY);
+    this.updateManualAlertPriceFromMenu();
+    e.preventDefault();
+  },
+  endManualAlertDrag(e) {
+    if (this.manualAlertDragState && this.manualAlertDragState.pointerId === e.pointerId) {
+      this.manualAlertDragState = null;
+    }
+  },
+  async sendManualAlertFromMenu() {
+    const context = App.state.manualAlertContext;
+    const templates = App.state.manualAlertTemplates;
+    const index = App.state.manualAlertSelectedTemplateIndex;
+    const template = templates[index];
+    const status = this.elements.manualAlertStatus;
+    if (!context || !template) return;
+    this.updateManualAlertPriceFromMenu();
+    try {
+      this.buildManualAlertMessage(template, {
+        ...context,
+        market: this.currentMarketPrice(),
+        title: template.title
+      });
+    } catch (e) {
+      status.textContent = "Invalid JSON";
+      status.classList.add("error");
+      return;
+    }
+    status.textContent = "Checking URL...";
+    status.classList.remove("error");
+    this.elements.manualAlertSend.disabled = true;
+    const cfg = await App.data.loadWebhookConfig();
+    this.elements.manualAlertSend.disabled = false;
+    if (!cfg) {
+      status.textContent = "Failed to load webhook URL";
+      status.classList.add("error");
+      return;
+    }
+    const url = cfg.url || "";
+    if (!url) {
+      status.textContent = "Webhook URL is empty";
+      status.classList.add("error");
+      return;
+    }
+    this.showManualAlertConfirm({
+      title: template.title,
+      context: { ...context },
+      template
+    }, url);
+    status.textContent = "";
   },
   renderSourcePanel() {
     const state = App.state;
@@ -244,7 +850,7 @@ App.ui = {
     document.body.classList.toggle("source-open", shouldOpen);
     this.elements.sourcePanel.setAttribute("aria-hidden", shouldOpen ? "false" : "true");
     this.elements.sourceToggle.setAttribute("aria-expanded", shouldOpen ? "true" : "false");
-    this.setMobileViewportLock(shouldOpen);
+    this.refreshMobileViewportLock();
     if (shouldOpen) {
       this.toggleAlertsMenu(false);
       // 열 때마다 디스크 최신본을 다시 불러와 다른 기기에서 저장한 내용이 즉시 보이게 한다.
@@ -262,9 +868,9 @@ App.ui = {
   },
   setMobileViewportLock(lock) {
     // iOS Safari는 포커스되는 입력 요소의 font-size가 16px 미만이면 자동 확대한다.
-    // 발생한 zoom을 사후에 되돌리는 건 최신 iOS에서 신뢰성이 낮으므로, 소스 패널이
-    // 열려 있는 동안 viewport에 maximum-scale=1을 걸어 확대 자체를 막는다(11px 표시
-    // 크기 유지). 닫히면 원복해 핀치줌을 다시 허용한다.
+    // 발생한 zoom을 사후에 되돌리는 건 최신 iOS에서 신뢰성이 낮으므로, 작은 입력창이
+    // 있는 패널이 열려 있는 동안 viewport에 maximum-scale=1을 걸어 확대 자체를 막는다.
+    // 닫히면 원복해 핀치줌을 다시 허용한다.
     if (!window.matchMedia("(max-width: 640px), (hover: none) and (pointer: coarse)").matches) {
       return;
     }
@@ -276,6 +882,10 @@ App.ui = {
         ? "width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
         : "width=device-width, initial-scale=1, viewport-fit=cover"
     );
+  },
+  refreshMobileViewportLock() {
+    const templateOpen = !this.elements.alertTemplateModal.classList.contains("hidden");
+    this.setMobileViewportLock(App.state.sourcePanelOpen || templateOpen);
   },
   getSourcePaneBounds() {
     const viewportWidth = Math.max(1, window.innerWidth || document.documentElement.clientWidth || 1);
@@ -355,6 +965,18 @@ App.ui = {
     const {
       alertsToggle,
       alertsMenu,
+      alertTemplateSettings,
+      alertTemplateBackdrop,
+      alertTemplateHelpToggle,
+      alertTemplateAdd,
+      alertTemplateSave,
+      manualAlertDrag,
+      manualAlertTemplateButton,
+      manualAlertSend,
+      manualAlertConfirm,
+      manualAlertConfirmBackdrop,
+      manualAlertConfirmCancel,
+      manualAlertConfirmSend,
       webhookToggle,
       telegramToggle,
       sourceToggle,
@@ -366,6 +988,90 @@ App.ui = {
     alertsToggle.addEventListener("click", (e) => {
       e.stopPropagation();
       this.toggleAlertsMenu();
+    });
+
+    alertTemplateSettings.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.openAlertTemplateModal();
+    });
+
+    alertTemplateBackdrop.addEventListener("click", () => {
+      this.closeAlertTemplateModal();
+    });
+
+    alertTemplateBackdrop.addEventListener("pointerdown", () => {
+      this.closeAlertTemplateModal();
+    });
+
+    alertTemplateHelpToggle.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.toggleAlertTemplateHelp();
+    });
+
+    this.attachAlertTemplatePlaceholderHelp();
+
+    window.addEventListener("resize", () => {
+      if (this.activeTemplatePlaceholder) {
+        this.positionTemplatePlaceholderTip(this.activeTemplatePlaceholder);
+      }
+    });
+
+    alertTemplateAdd.addEventListener("click", () => {
+      this.addAlertTemplateRow();
+      this.setTemplateStatus("");
+    });
+
+    alertTemplateSave.addEventListener("click", () => {
+      this.saveAlertTemplates();
+    });
+
+    manualAlertSend.addEventListener("click", () => {
+      this.sendManualAlertFromMenu();
+    });
+
+    manualAlertTemplateButton.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.toggleManualAlertTemplateList();
+    });
+
+    manualAlertConfirm.addEventListener("click", (e) => {
+      e.stopPropagation();
+    });
+
+    manualAlertConfirmBackdrop.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.closeManualAlertConfirm();
+    });
+
+    manualAlertConfirmBackdrop.addEventListener("pointerdown", (e) => {
+      e.stopPropagation();
+      this.closeManualAlertConfirm();
+    });
+
+    manualAlertConfirmCancel.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.closeManualAlertConfirm();
+    });
+
+    manualAlertConfirmSend.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.confirmManualAlertSend();
+    });
+
+    manualAlertDrag.addEventListener("pointerdown", (e) => {
+      this.startManualAlertDrag(e);
+    });
+
+    window.addEventListener("pointermove", (e) => {
+      this.moveManualAlertDrag(e);
+    });
+
+    window.addEventListener("pointerup", (e) => {
+      this.endManualAlertDrag(e);
+    });
+
+    window.addEventListener("pointercancel", (e) => {
+      this.endManualAlertDrag(e);
     });
 
     sourceToggle.addEventListener("click", (e) => {
@@ -407,6 +1113,9 @@ App.ui = {
 
     document.addEventListener("keydown", (e) => {
       if (e.key === "Escape") {
+        this.closeManualAlertConfirm();
+        this.closeManualAlertMenu();
+        this.closeAlertTemplateModal();
         this.toggleSourcePanel(false);
       }
     });
@@ -415,7 +1124,38 @@ App.ui = {
       if (!alertsMenu.contains(e.target) && e.target !== alertsToggle) {
         this.toggleAlertsMenu(false);
       }
+      if (Date.now() < App.state.manualAlertSuppressClickUntil) {
+        return;
+      }
+      if (App.state.manualAlertConfirmOpen) {
+        return;
+      }
+      if (!this.elements.manualAlertMenu.classList.contains("hidden") &&
+          !this.elements.manualAlertMenu.contains(e.target)) {
+        this.closeManualAlertMenu();
+      }
+      if (!this.elements.manualAlertTemplateOptions.classList.contains("hidden") &&
+          !this.elements.manualAlertTemplatePicker.contains(e.target)) {
+        this.closeManualAlertTemplateList();
+      }
     });
+
+    document.addEventListener("pointerdown", (e) => {
+      if (!e.target.closest(".template-placeholder")) {
+        this.clearActiveTemplatePlaceholder();
+      }
+      if (App.state.manualAlertConfirmOpen) {
+        return;
+      }
+      if (!this.elements.manualAlertMenu.classList.contains("hidden") &&
+          !this.elements.manualAlertMenu.contains(e.target)) {
+        this.closeManualAlertMenu();
+      }
+      if (!this.elements.manualAlertTemplateOptions.classList.contains("hidden") &&
+          !this.elements.manualAlertTemplatePicker.contains(e.target)) {
+        this.closeManualAlertTemplateList();
+      }
+    }, { capture: true });
 
     webhookToggle.addEventListener("change", async () => {
       const enabled = webhookToggle.checked;


### PR DESCRIPTION
## Summary

- 세션별 Manual Alert Templates 저장/조회 API를 추가했습니다.
- 차트 더블클릭 및 모바일 두 번 터치로 수동 얼럿 메뉴를 열 수 있게 했습니다.
- 수동 얼럿 템플릿 placeholder 치환을 추가했습니다.
  - `{{price}}`: 메뉴 위치 기준 선택 가격
  - `{{market}}`: 최종 Send 클릭 시점의 실시간 가격
  - `{{time}}`, `{{symbol}}`, `{{ticker}}`, `{{exchange}}`, `{{timeframe}}`, `{{title}}`
- 수동 얼럿 전송 전 webhook URL 확인 모달을 추가했습니다.
- 수동 얼럿 webhook 전송 성공 후 Telegram 자격증명이 있으면 Telegram 메시지도 전송합니다.
- Manual Alert Templates 도움말과 placeholder tooltip을 추가했습니다.
- 차트 OHLCV 라벨 색상 및 Vol 옆 등락률 표시를 개선했습니다.

## Notes

- 수동 얼럿은 전략 alert의 webhook 체크박스와 독립적으로 전송됩니다.
- Telegram 메시지는 `🚨 [M][script title]` 형식으로 전송됩니다.
- `data_service` 재시작이 필요합니다.

## Test

- `node --check data_service/templates/chart.js`
- `node --check data_service/templates/data.js`
- `node --check data_service/templates/main.js`
- `node --check data_service/templates/state.js`
- `node --check data_service/templates/ui.js`
- `venv/bin/python -m py_compile data_service/api.py data_service/config.py data_service/registry.py`
- `git diff --cached --check`