### PR TITLE
feat: 차트 재기 도구 추가

### DIFF
--- a/data_service/templates/chart.js
+++ b/data_service/templates/chart.js
@@ -97,22 +97,52 @@ App.chart = {
     if (time && typeof time.timestamp === "number") return time.timestamp;
     return App.state.lastBarTime || null;
   },
-  manualAlertContextFromPointer(pointer) {
-    if (!pointer || !this.chart || !this.candleSeries) return null;
+  plotPointFromClient(clientX, clientY) {
+    if (!this.chart || !this.candleSeries || !this.container) return null;
     const rect = this.container.getBoundingClientRect();
-    const x = pointer.clientX - rect.left;
-    const y = pointer.clientY - rect.top;
+    const x = clientX - rect.left;
+    const y = clientY - rect.top;
+    if (x < 0 || x > rect.width || y < 0 || y > rect.height) return null;
+
+    let priceScaleWidth = 0;
+    try {
+      priceScaleWidth = this.chart.priceScale("right").width() || 0;
+    } catch {}
+    // The right price scale and bottom time scale also live inside #chart, but
+    // they are not candle area. Keep right-side chart whitespace clickable.
+    const timeScaleHeight = 28;
+    if (priceScaleWidth > 0 && x >= rect.width - priceScaleWidth) return null;
+    if (y >= rect.height - timeScaleHeight) return null;
+
+    const timeScale = this.chart.timeScale();
+    const time = timeScale.coordinateToTime(x);
+    let logical = null;
+    try {
+      logical = timeScale.coordinateToLogical(x);
+    } catch {}
     const price = this.candleSeries.coordinateToPrice(y);
     if (!Number.isFinite(Number(price))) return null;
-    const time = this.chart.timeScale().coordinateToTime(x);
+    return {
+      x,
+      y,
+      price: Number(price),
+      time,
+      logical: Number.isFinite(Number(logical)) ? Number(logical) : null
+    };
+  },
+  manualAlertContextFromPointer(pointer) {
+    if (!pointer) return null;
+    const point = this.plotPointFromClient(pointer.clientX, pointer.clientY);
+    if (!point) return null;
     return {
       clientX: pointer.clientX,
       clientY: pointer.clientY,
-      price: Number(price),
-      time: this.normalizeAlertTime(time)
+      price: point.price,
+      time: this.normalizeAlertTime(point.time)
     };
   },
   openManualAlertMenuFromPointer(pointer) {
+    if (App.state.measureToolActive) return;
     if (App.state.sourcePanelOpen) return;
     if (!App.ui.elements.alertTemplateModal.classList.contains("hidden")) return;
     const context = this.manualAlertContextFromPointer(pointer);
@@ -162,6 +192,9 @@ App.chart = {
     const size = this.getContainerSize();
     this.chart.applyOptions(size);
     this.positionNavButtons();
+    if (App.measure) {
+      App.measure.scheduleRender();
+    }
   },
   applyInitialVisibleRange(dataLength) {
     const ts = this.chart.timeScale();
@@ -301,6 +334,9 @@ App.chart = {
     collections.markerKeys.clear();
     collections.plotcharMarkers.length = 0;
     collections.plotcharMarkerKeys.clear();
+    collections.ohlcvData.length = 0;
+    collections.ohlcvIndexByTime.clear();
+    collections.ohlcvVolumePrefix.length = 0;
     collections.entryMarkerData.length = 0;
     collections.closeMarkerData.length = 0;
     collections.entryPriceKeys.clear();
@@ -317,6 +353,9 @@ App.chart = {
     }
     this.currentPriceLine = null;
     this.removeManualAlertPriceGuide();
+    if (App.measure) {
+      App.measure.clear();
+    }
   },
   updatePriceLineWithTimer() {
     const state = App.state;

--- a/data_service/templates/data.js
+++ b/data_service/templates/data.js
@@ -4,6 +4,60 @@ App.data = {
   STYLE_CIRCLES: 2,
   STYLE_CROSS: 4,
   STYLE_LINEBR: 7,
+  rebuildOhlcvCache(data) {
+    const collections = App.collections;
+    collections.ohlcvData = Array.isArray(data)
+      ? data
+          .filter(d => d && Number.isFinite(Number(d.time)))
+          .map(d => ({
+            time: Number(d.time),
+            open: Number(d.open),
+            high: Number(d.high),
+            low: Number(d.low),
+            close: Number(d.close),
+            volume: Number(d.volume) || 0
+          }))
+          .sort((a, b) => a.time - b.time)
+      : [];
+    collections.ohlcvIndexByTime = new Map();
+    collections.ohlcvVolumePrefix = [];
+    let volumeTotal = 0;
+    collections.ohlcvData.forEach((bar, index) => {
+      collections.ohlcvIndexByTime.set(bar.time, index);
+      volumeTotal += Number(bar.volume) || 0;
+      collections.ohlcvVolumePrefix[index] = volumeTotal;
+    });
+    if (App.measure) {
+      App.measure.scheduleRender();
+    }
+  },
+  upsertOhlcvCache(bar) {
+    if (!bar || !Number.isFinite(Number(bar.time))) return;
+    const collections = App.collections;
+    const time = Number(bar.time);
+    const cachedBar = {
+      time,
+      open: Number(bar.open),
+      high: Number(bar.high),
+      low: Number(bar.low),
+      close: Number(bar.close),
+      volume: Number(bar.volume) || 0
+    };
+    const existingIndex = collections.ohlcvIndexByTime.get(time);
+    if (existingIndex != null) {
+      collections.ohlcvData[existingIndex] = cachedBar;
+      this.rebuildOhlcvCache(collections.ohlcvData);
+      return;
+    }
+    const last = collections.ohlcvData[collections.ohlcvData.length - 1];
+    if (!last || time > last.time) {
+      collections.ohlcvData.push(cachedBar);
+    } else {
+      collections.ohlcvData.push(cachedBar);
+      collections.ohlcvData.sort((a, b) => a.time - b.time);
+    }
+    this.rebuildOhlcvCache(collections.ohlcvData);
+  },
   toLinePoint(time, value) {
     const pointTime = Number(time);
     if (!Number.isFinite(pointTime)) {
@@ -311,6 +365,7 @@ App.data = {
             await App.util.sleep(1000);
             continue;
           }
+          this.rebuildOhlcvCache(cleanData);
           chart.candleSeries.setData(cleanData);
           chart.volumeSeries.setData(cleanData.map(d => ({
             time: d.time,

--- a/data_service/templates/index.html
+++ b/data_service/templates/index.html
@@ -9,6 +9,26 @@
 </head>
 <body>
   <div id="chart"></div>
+  <div id="drawing-toolbar" class="drawing-toolbar" aria-label="Drawing tools">
+    <button id="drawing-tools-toggle" class="drawing-tool-btn drawing-tools-toggle" type="button" title="Tools" aria-label="Tools" aria-expanded="false">
+      <svg class="tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+        <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
+      </svg>
+    </button>
+    <div id="drawing-tool-palette" class="drawing-tool-palette hidden" role="menu" aria-label="Drawing tool list">
+      <button id="measure-tool-toggle" class="drawing-tool-btn measure-tool-icon" type="button" title="Measure price change" aria-label="Measure price change" role="menuitem">
+        <svg class="tool-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M21.3 15.3a2.4 2.4 0 0 1 0 3.4l-2.6 2.6a2.4 2.4 0 0 1-3.4 0L2.7 8.7a2.41 2.41 0 0 1 0-3.4l2.6-2.6a2.41 2.41 0 0 1 3.4 0Z"/>
+          <path d="m14.5 12.5 2-2"/>
+          <path d="m11.5 9.5 2-2"/>
+          <path d="m8.5 6.5 2-2"/>
+          <path d="m17.5 15.5 2-2"/>
+        </svg>
+      </button>
+    </div>
+  </div>
+  <svg id="measure-overlay" class="measure-overlay" aria-hidden="true"></svg>
+  <div id="measure-label" class="measure-label hidden"></div>
   <button id="nav-to-start" class="nav-btn nav-btn-left" title="처음으로">&laquo;</button>
   <button id="nav-to-end" class="nav-btn nav-btn-right" title="최신으로">&raquo;</button>
   <div id="chart-info">
@@ -133,6 +153,7 @@
   <script src="/static/state.js"></script>
   <script src="/static/ui.js"></script>
   <script src="/static/chart.js"></script>
+  <script src="/static/measure.js"></script>
   <script src="/static/data.js"></script>
   <script src="/static/ws.js"></script>
   <script src="/static/main.js"></script>

--- a/data_service/templates/main.js
+++ b/data_service/templates/main.js
@@ -6,6 +6,7 @@ App.data.loadChartInfo();
 App.data.loadScriptSource();
 App.data.loadWebhookConfig();
 App.ui.loadManualAlertTemplates({ migrateLocal: true });
+App.measure.init();
 App.chart.startJankMonitor();
 App.chart.attachResizeHandler();
 App.chart.attachNavButtons();

--- a/data_service/templates/measure.js
+++ b/data_service/templates/measure.js
@@ -1,0 +1,389 @@
+var App = window.App || (window.App = {});
+
+App.measure = {
+  overlay: document.getElementById("measure-overlay"),
+  label: document.getElementById("measure-label"),
+  toolsButton: document.getElementById("drawing-tools-toggle"),
+  palette: document.getElementById("drawing-tool-palette"),
+  toggleButton: document.getElementById("measure-tool-toggle"),
+  pointerId: null,
+  pointerCandidate: null,
+  renderFrame: null,
+  lastToolbarTouchAt: 0,
+
+  init() {
+    if (!this.overlay || !this.label || !this.toolsButton || !this.palette || !this.toggleButton) return;
+    this.installToolbarDoubleTapGuard();
+
+    this.toolsButton.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.togglePalette();
+    });
+
+    this.toggleButton.addEventListener("click", (e) => {
+      e.stopPropagation();
+      this.closePalette();
+      this.setActive(!App.state.measureToolActive);
+    });
+
+    App.chart.container.addEventListener("pointerdown", (e) => this.onPointerDown(e));
+    App.chart.container.addEventListener("pointermove", (e) => this.onPointerMove(e));
+    window.addEventListener("pointermove", (e) => this.onPointerMove(e));
+    window.addEventListener("pointerup", (e) => this.onPointerUp(e));
+    window.addEventListener("pointercancel", (e) => this.onPointerUp(e));
+
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && App.state.measureToolActive) {
+        this.setActive(false);
+      }
+      if (e.key === "Escape") {
+        this.closePalette();
+      }
+    });
+
+    document.addEventListener("pointerdown", (e) => {
+      if (!this.palette || this.palette.classList.contains("hidden")) return;
+      if (e.target.closest("#drawing-toolbar")) return;
+      this.closePalette();
+    });
+
+    try {
+      App.chart.chart.timeScale().subscribeVisibleLogicalRangeChange(() => this.scheduleRender());
+    } catch {}
+
+    window.addEventListener("resize", () => this.scheduleRender());
+    window.addEventListener("orientationchange", () => this.scheduleRender());
+    this.scheduleRender();
+  },
+
+  installToolbarDoubleTapGuard() {
+    const toolbar = document.getElementById("drawing-toolbar");
+    if (!toolbar) return;
+    toolbar.addEventListener("touchend", (e) => {
+      const now = Date.now();
+      const isDoubleTap = now - this.lastToolbarTouchAt < 360;
+      this.lastToolbarTouchAt = now;
+      if (!isDoubleTap) return;
+
+      const button = e.target.closest("button");
+      if (!button || !toolbar.contains(button)) return;
+      e.preventDefault();
+      button.click();
+    }, { passive: false });
+  },
+
+  togglePalette(forceOpen = null) {
+    const open = forceOpen === null ? this.palette.classList.contains("hidden") : Boolean(forceOpen);
+    this.palette.classList.toggle("hidden", !open);
+    this.toolsButton.setAttribute("aria-expanded", open ? "true" : "false");
+  },
+
+  closePalette() {
+    this.togglePalette(false);
+  },
+
+  setActive(active) {
+    App.state.measureToolActive = Boolean(active);
+    document.body.classList.toggle("measure-active", App.state.measureToolActive);
+    this.toolsButton.classList.toggle("active", App.state.measureToolActive);
+    this.toggleButton.classList.toggle("active", App.state.measureToolActive);
+    this.toggleButton.setAttribute("aria-pressed", App.state.measureToolActive ? "true" : "false");
+    if (App.state.measureToolActive) {
+      if (App.ui) {
+        App.ui.closeManualAlertConfirm();
+        App.ui.closeManualAlertMenu();
+        App.ui.closeAlertTemplateModal();
+      }
+      if (App.chart) {
+        App.chart.setMagnetMode(false);
+      }
+    } else {
+      App.state.measureDraft = null;
+      this.pointerId = null;
+      this.pointerCandidate = null;
+      if (App.chart) {
+        App.chart.restoreMagnetMode();
+      }
+    }
+    this.scheduleRender();
+  },
+
+  clear() {
+    App.state.measureDraft = null;
+    App.state.measureResult = null;
+    this.pointerId = null;
+    this.pointerCandidate = null;
+    this.overlay.innerHTML = "";
+    this.label.classList.add("hidden");
+  },
+
+  chartRect() {
+    return App.chart.container.getBoundingClientRect();
+  },
+
+  normalizeTime(time) {
+    if (typeof time === "number" && Number.isFinite(time)) return Number(time);
+    if (time && typeof time.timestamp === "number") return Number(time.timestamp);
+    return null;
+  },
+
+  shouldSnapToOhlc(e) {
+    const isCoarsePointer = window.matchMedia &&
+      window.matchMedia("(hover: none) and (pointer: coarse)").matches;
+    return Boolean(
+      e &&
+      e.metaKey &&
+      e.pointerType !== "touch" &&
+      !isCoarsePointer
+    );
+  },
+
+  snapPointToOhlc(point) {
+    const bars = App.collections && Array.isArray(App.collections.ohlcvData)
+      ? App.collections.ohlcvData
+      : [];
+    if (!point || !bars.length || !Number.isFinite(Number(point.logical))) return point;
+
+    const index = Math.max(0, Math.min(bars.length - 1, Math.round(Number(point.logical))));
+    const bar = bars[index];
+    if (!bar) return point;
+
+    const candidates = ["open", "high", "low", "close"]
+      .map(key => ({ key, price: Number(bar[key]) }))
+      .filter(candidate => Number.isFinite(candidate.price));
+    if (!candidates.length) return point;
+
+    let nearest = candidates[0];
+    let nearestDistance = Math.abs(nearest.price - Number(point.price));
+    for (let i = 1; i < candidates.length; i += 1) {
+      const distance = Math.abs(candidates[i].price - Number(point.price));
+      if (distance < nearestDistance) {
+        nearest = candidates[i];
+        nearestDistance = distance;
+      }
+    }
+
+    return {
+      time: Number(bar.time),
+      logical: index,
+      price: nearest.price,
+      snap: nearest.key
+    };
+  },
+
+  pointFromEvent(e) {
+    const plotPoint = App.chart.plotPointFromClient(e.clientX, e.clientY);
+    if (!plotPoint) return null;
+    const time = this.normalizeTime(plotPoint.time);
+    const logical = Number(plotPoint.logical);
+    if (time == null && !Number.isFinite(logical)) return null;
+    const point = {
+      time,
+      logical: Number.isFinite(logical) ? logical : null,
+      price: plotPoint.price
+    };
+    return this.shouldSnapToOhlc(e) ? this.snapPointToOhlc(point) : point;
+  },
+
+  pointToCoordinate(point) {
+    if (!point || !App.chart || !App.chart.chart || !App.chart.candleSeries) return null;
+    const rect = this.chartRect();
+    const timeScale = App.chart.chart.timeScale();
+    let x = null;
+    if (Number.isFinite(Number(point.logical))) {
+      try {
+        x = timeScale.logicalToCoordinate(Number(point.logical));
+      } catch {}
+    }
+    if (!Number.isFinite(Number(x)) && point.time != null) {
+      x = timeScale.timeToCoordinate(point.time);
+    }
+    const y = App.chart.candleSeries.priceToCoordinate(point.price);
+    if (!Number.isFinite(Number(x)) || !Number.isFinite(Number(y))) return null;
+    return {
+      x: rect.left + Number(x),
+      y: rect.top + Number(y)
+    };
+  },
+
+  onPointerDown(e) {
+    if (!App.state.measureToolActive || e.button !== 0) return;
+    const point = this.pointFromEvent(e);
+    if (!point) return;
+    this.pointerId = e.pointerId;
+    this.pointerCandidate = {
+      pointerId: e.pointerId,
+      point,
+      clientX: e.clientX,
+      clientY: e.clientY,
+      moved: false
+    };
+  },
+
+  onPointerMove(e) {
+    if (!App.state.measureToolActive) return;
+    if (this.pointerCandidate && this.pointerCandidate.pointerId === e.pointerId) {
+      const distance = Math.hypot(
+        e.clientX - this.pointerCandidate.clientX,
+        e.clientY - this.pointerCandidate.clientY
+      );
+      if (distance > 6) {
+        this.pointerCandidate.moved = true;
+      }
+      if (this.pointerCandidate.moved) {
+        return;
+      }
+    }
+    if (!App.state.measureDraft) return;
+    const point = this.pointFromEvent(e);
+    if (!point) return;
+    App.state.measureDraft.end = point;
+    this.scheduleRender();
+  },
+
+  onPointerUp(e) {
+    if (!this.pointerCandidate || this.pointerCandidate.pointerId !== e.pointerId) return;
+    const candidate = this.pointerCandidate;
+    const distance = Math.hypot(e.clientX - candidate.clientX, e.clientY - candidate.clientY);
+    const isPointClick = !candidate.moved && distance <= 6;
+    this.pointerCandidate = null;
+    this.pointerId = null;
+    if (!isPointClick) return;
+
+    const point = this.pointFromEvent(e) || candidate.point;
+    if (App.state.measureResult && !App.state.measureDraft) {
+      this.clear();
+      return;
+    }
+    if (!App.state.measureDraft) {
+      App.state.measureDraft = { start: point, end: point };
+      App.state.measureResult = null;
+    } else {
+      App.state.measureDraft.end = point;
+      App.state.measureResult = App.state.measureDraft;
+      App.state.measureDraft = null;
+    }
+    this.scheduleRender();
+  },
+
+  activeMeasurement() {
+    return App.state.measureDraft || App.state.measureResult;
+  },
+
+  statsFor(measure) {
+    const start = measure.start;
+    const end = measure.end;
+    const delta = end.price - start.price;
+    const pct = start.price !== 0 ? (delta / start.price) * 100 : 0;
+    const startIndex = start.time == null ? null : App.collections.ohlcvIndexByTime.get(start.time);
+    const endIndex = end.time == null ? null : App.collections.ohlcvIndexByTime.get(end.time);
+    const hasIndexes = Number.isInteger(startIndex) && Number.isInteger(endIndex);
+    let bars = hasIndexes ? Math.abs(endIndex - startIndex) : null;
+    if (bars == null && Number.isFinite(Number(start.logical)) && Number.isFinite(Number(end.logical))) {
+      bars = Math.abs(Math.round(Number(end.logical) - Number(start.logical)));
+    }
+    let durationSec = null;
+    if (start.time != null && end.time != null) {
+      durationSec = Math.abs(end.time - start.time);
+    } else if (bars != null) {
+      durationSec = bars * (App.state.timeframeInterval || App.state.configuredTimeframeSec || 60);
+    }
+    return {
+      delta,
+      pct,
+      bars,
+      durationSec
+    };
+  },
+
+  formatSigned(value, decimals = 2) {
+    const sign = value > 0 ? "+" : "";
+    return `${sign}${App.ui.formatNumber(value, decimals)}`;
+  },
+
+  formatDuration(seconds) {
+    if (seconds == null || !Number.isFinite(Number(seconds))) return "-";
+    const sec = Math.max(0, Math.round(Number(seconds) || 0));
+    const days = Math.floor(sec / 86400);
+    const hours = Math.floor((sec % 86400) / 3600);
+    const minutes = Math.floor((sec % 3600) / 60);
+    if (days > 0) return `${days}d ${hours}h`;
+    if (hours > 0) return `${hours}h ${minutes}m`;
+    if (minutes > 0) return `${minutes}m`;
+    return `${sec}s`;
+  },
+
+  labelHtml(stats) {
+    const bars = stats.bars == null ? "-" : String(stats.bars);
+    return [
+      `${this.formatSigned(stats.delta, 2)} (${this.formatSigned(stats.pct, 2)}%)`,
+      `${bars} bars, ${this.formatDuration(stats.durationSec)}`
+    ].join("<br>");
+  },
+
+  scheduleRender() {
+    if (this.renderFrame !== null) return;
+    this.renderFrame = requestAnimationFrame(() => {
+      this.renderFrame = null;
+      this.render();
+    });
+  },
+
+  render() {
+    const measure = this.activeMeasurement();
+    if (!measure) {
+      this.overlay.innerHTML = "";
+      this.label.classList.add("hidden");
+      return;
+    }
+
+    const start = this.pointToCoordinate(measure.start);
+    const end = this.pointToCoordinate(measure.end);
+    if (!start || !end) {
+      this.overlay.innerHTML = "";
+      this.label.classList.add("hidden");
+      return;
+    }
+
+    const width = Math.max(1, window.innerWidth);
+    const height = Math.max(1, window.innerHeight);
+    const x1 = start.x;
+    const y1 = start.y;
+    const x2 = end.x;
+    const y2 = end.y;
+    const left = Math.min(x1, x2);
+    const top = Math.min(y1, y2);
+    const rectWidth = Math.abs(x2 - x1);
+    const rectHeight = Math.abs(y2 - y1);
+    const stats = this.statsFor(measure);
+    const color = stats.delta > 0 ? "#26a69a" : (stats.delta < 0 ? "#ef5350" : "#666666");
+    const fill = stats.delta > 0 ? "rgba(38,166,154,0.14)" : (stats.delta < 0 ? "rgba(239,83,80,0.14)" : "rgba(90,90,90,0.12)");
+
+    this.overlay.setAttribute("viewBox", `0 0 ${width} ${height}`);
+    this.overlay.innerHTML =
+      `<rect x="${left}" y="${top}" width="${rectWidth}" height="${rectHeight}" fill="${fill}" stroke="${color}" stroke-opacity="0.36" stroke-width="1"></rect>` +
+      `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${color}" stroke-width="1.5"></line>` +
+      `<line x1="${x1}" y1="${y1}" x2="${x2}" y2="${y1}" stroke="${color}" stroke-width="1" stroke-dasharray="4 3" stroke-opacity="0.75"></line>` +
+      `<line x1="${x2}" y1="${y1}" x2="${x2}" y2="${y2}" stroke="${color}" stroke-width="1" stroke-dasharray="4 3" stroke-opacity="0.75"></line>` +
+      `<circle cx="${x1}" cy="${y1}" r="4" fill="#ffffff" stroke="${color}" stroke-width="1.5"></circle>` +
+      `<circle cx="${x2}" cy="${y2}" r="4" fill="${color}" stroke="#ffffff" stroke-width="1.5"></circle>`;
+
+    this.label.classList.toggle("up", stats.delta > 0);
+    this.label.classList.toggle("down", stats.delta < 0);
+    this.label.classList.toggle("flat", stats.delta === 0);
+    this.label.innerHTML = this.labelHtml(stats);
+    this.label.classList.remove("hidden");
+
+    const labelRect = this.label.getBoundingClientRect();
+    const margin = 8;
+    let labelLeft = x2 - labelRect.width / 2;
+    let labelTop = y2 + 12;
+    if (labelTop + labelRect.height > height - margin) {
+      labelTop = y2 - labelRect.height - 12;
+    }
+    labelLeft = Math.max(margin, Math.min(labelLeft, width - labelRect.width - margin));
+    labelTop = Math.max(margin, Math.min(labelTop, height - labelRect.height - margin));
+    this.label.style.left = `${Math.round(labelLeft)}px`;
+    this.label.style.top = `${Math.round(labelTop)}px`;
+  }
+};

--- a/data_service/templates/state.js
+++ b/data_service/templates/state.js
@@ -54,10 +54,16 @@ window.App.state = {
   manualAlertTemplateOpen: false,
   manualAlertConfirmOpen: false,
   manualAlertSelectedTemplateIndex: -1,
-  manualAlertSuppressClickUntil: 0
+  manualAlertSuppressClickUntil: 0,
+  measureToolActive: false,
+  measureDraft: null,
+  measureResult: null
 };
 
 window.App.collections = {
+  ohlcvData: [],
+  ohlcvIndexByTime: new Map(),
+  ohlcvVolumePrefix: [],
   plotSeriesMap: new Map(),
   plotSeriesList: [],
   markers: [],

--- a/data_service/templates/styles.css
+++ b/data_service/templates/styles.css
@@ -76,6 +76,110 @@ body.source-open #chart {
   align-items: center;
   position: relative;
 }
+.drawing-toolbar {
+  position: fixed;
+  left: 12px;
+  top: 104px;
+  z-index: 15;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 5px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 8px;
+  background: rgba(255, 255, 255, 0.88);
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.12);
+  touch-action: manipulation;
+  -webkit-user-select: none;
+  user-select: none;
+}
+.drawing-tool-palette {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.drawing-tool-palette:not(.hidden) {
+  animation: drawing-palette-reveal 0.16s ease-out;
+}
+@keyframes drawing-palette-reveal {
+  from {
+    opacity: 0;
+    transform: translateY(-6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+.drawing-tool-btn {
+  width: 32px;
+  height: 32px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 6px;
+  background: #ffffff;
+  color: #111;
+  font-size: 13px;
+  font-weight: 700;
+  line-height: 1;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: transparent;
+}
+.drawing-tool-btn.active {
+  border-color: rgba(11, 51, 232, 0.42);
+  background: #eef2ff;
+  color: #0b33e8;
+}
+.drawing-tool-btn:active {
+  transform: translateY(1px);
+}
+.drawing-tools-toggle.active {
+  border-color: rgba(11, 51, 232, 0.42);
+}
+.tool-icon {
+  width: 19px;
+  height: 19px;
+  display: block;
+}
+.measure-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 14;
+  width: 100vw;
+  height: 100vh;
+  height: 100dvh;
+  pointer-events: none;
+  touch-action: none;
+}
+body.measure-active #chart {
+  cursor: crosshair;
+}
+.measure-label {
+  position: fixed;
+  z-index: 16;
+  min-width: 128px;
+  padding: 7px 9px;
+  border-radius: 6px;
+  color: #ffffff;
+  font-size: 12px;
+  line-height: 1.35;
+  text-align: center;
+  pointer-events: none;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.18);
+  white-space: nowrap;
+}
+.measure-label.up {
+  background: rgba(38, 166, 154, 0.94);
+}
+.measure-label.down {
+  background: rgba(239, 83, 80, 0.94);
+}
+.measure-label.flat {
+  background: rgba(90, 90, 90, 0.94);
+}
 .toolbar-btn {
   border: 1px solid rgba(0, 0, 0, 0.15);
   background: #ffffff;
@@ -926,6 +1030,26 @@ body.source-open .source-panel {
 
   .template-btn {
     padding: 7px 10px;
+  }
+
+  .drawing-toolbar {
+    left: max(8px, env(safe-area-inset-left));
+    top: max(112px, calc(env(safe-area-inset-top) + 112px));
+    gap: 5px;
+    padding: 4px;
+  }
+
+  .drawing-tool-btn {
+    width: 34px;
+    height: 34px;
+    border-radius: 7px;
+    font-size: 13px;
+  }
+
+  .measure-label {
+    max-width: calc(100vw - 24px);
+    white-space: normal;
+    font-size: 11.5px;
   }
 
   .manual-alert-menu {

--- a/data_service/templates/ui.js
+++ b/data_service/templates/ui.js
@@ -72,6 +72,12 @@ App.ui = {
       App.data.loadWebhookConfig();
     }
   },
+  isAlertsMenuEventTarget(target) {
+    return Boolean(
+      target &&
+      (this.elements.alertsMenu.contains(target) || this.elements.alertsToggle.contains(target))
+    );
+  },
   alertTemplateStorageKey() {
     return App.config.storageKey("manualAlertTemplates");
   },
@@ -1121,7 +1127,7 @@ App.ui = {
     });
 
     document.addEventListener("click", (e) => {
-      if (!alertsMenu.contains(e.target) && e.target !== alertsToggle) {
+      if (!this.isAlertsMenuEventTarget(e.target)) {
         this.toggleAlertsMenu(false);
       }
       if (Date.now() < App.state.manualAlertSuppressClickUntil) {
@@ -1141,6 +1147,9 @@ App.ui = {
     });
 
     document.addEventListener("pointerdown", (e) => {
+      if (!this.isAlertsMenuEventTarget(e.target)) {
+        this.toggleAlertsMenu(false);
+      }
       if (!e.target.closest(".template-placeholder")) {
         this.clearActiveTemplatePlaceholder();
       }

--- a/data_service/templates/ws.js
+++ b/data_service/templates/ws.js
@@ -60,6 +60,7 @@ App.ws = {
             value: msg.data.volume,
             color: msg.data.close >= msg.data.open ? "#26a69a" : "#ef5350"
           });
+          App.data.upsertOhlcvCache(msg.data);
           state.lastBarTime = msg.data.time;
           state.lastOhlcv = msg.data;
 
@@ -77,6 +78,7 @@ App.ws = {
           if (state.lastOhlcv && state.lastOhlcv.time === msg.data.time) {
             const fixedBar = { ...state.lastOhlcv, open: msg.data.open };
             chart.candleSeries.update(fixedBar);
+            App.data.upsertOhlcvCache(fixedBar);
             state.lastOhlcv = fixedBar;
           }
           state.lastBarTime = Math.max(state.lastBarTime, msg.data.time);

--- a/data_service/ui.py
+++ b/data_service/ui.py
@@ -13,6 +13,7 @@ _STATIC_FILES = {
     "state.js": "text/javascript",
     "ui.js": "text/javascript",
     "chart.js": "text/javascript",
+    "measure.js": "text/javascript",
     "data.js": "text/javascript",
     "ws.js": "text/javascript",
     "main.js": "text/javascript",


### PR DESCRIPTION
## Summary
- Add a chart drawing toolbar with a measure tool for price delta, percent change, bar count, and duration.
- Support measuring in chart whitespace via logical coordinates and add desktop Cmd-based OHLC snapping.
- Prevent conflicts between measure mode and manual alerts, improve mobile Alert dropdown outside-touch closing, and block iOS double-tap page zoom on the tool button.

## Tests
- node --check data_service/templates/chart.js
- node --check data_service/templates/data.js
- node --check data_service/templates/main.js
- node --check data_service/templates/measure.js
- node --check data_service/templates/state.js
- node --check data_service/templates/ui.js
- node --check data_service/templates/ws.js
- git diff --check -- data_service/templates/chart.js data_service/templates/data.js data_service/templates/index.html data_service/templates/main.js data_service/templates/measure.js data_service/templates/state.js data_service/templates/styles.css data_service/templates/ui.js data_service/templates/ws.js data_service/ui.py