### PR TITLE
Bybit 거래소 OHLCV 정책 추가

### DIFF
--- a/data_service/api.py
+++ b/data_service/api.py
@@ -311,7 +311,7 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
         if not ohlcv_path.exists():
             return JSONResponse([])
 
-        # Match TradingView: OKX/Binance hide zero-volume bars; BITGET/Hyperliquid keep them.
+        # Match TradingView: OKX/Binance/Bybit hide zero-volume bars; BITGET/Hyperliquid keep them.
         skip_zero_volume = tradingview_hides_zero_volume(rt.spec.exchange)
         out: List[Dict[str, Any]] = []
         with OHLCVReader(ohlcv_path) as reader:

--- a/data_service/collector_loop.py
+++ b/data_service/collector_loop.py
@@ -111,7 +111,7 @@ async def fix_missing_bars_loop(
 
                 prev_close = bars[-1][4]
                 # No trades occurred in this interval. Store the placeholder as true 0-volume.
-                # OKX/Binance policy will hide it; BITGET/Hyperliquid still treat it as visible.
+                # OKX/Binance/Bybit policy will hide it; BITGET/Hyperliquid still treat it as visible.
                 fake = [missing_ts, prev_close, prev_close, prev_close, prev_close, 0.0]
                 bars.append(fake)
                 # print(f"[fix_missing_bars_loop] {exchange_name} bar: {fake}")

--- a/data_service/templates/data.js
+++ b/data_service/templates/data.js
@@ -405,7 +405,7 @@ App.data = {
           if (state.configuredTimeframeSec) {
             state.timeframeInterval = state.configuredTimeframeSec;
           } else if (data.length >= 2) {
-            // Fallback only: on OKX/Binance zero-volume bars are hidden, so the gap
+            // Fallback only: on OKX/Binance/Bybit zero-volume bars are hidden, so the gap
             // between the first two visible bars may not be the timeframe.
             state.timeframeInterval = data[1].time - data[0].time;
           }

--- a/pynecore/cli/commands/run.py
+++ b/pynecore/cli/commands/run.py
@@ -295,7 +295,7 @@ def run(
         total_seconds = int((time_to - time_from).total_seconds())
 
         # Use the same exchange-specific hidden-bar policy as realtime runner.
-        # OKX/Binance zero-volume bars are hidden; BITGET/Hyperliquid bars remain visible.
+        # OKX/Binance/Bybit zero-volume bars are hidden; BITGET/Hyperliquid bars remain visible.
         skip_zero_volume = tradingview_hides_zero_volume(syminfo.prefix)
         preload_list = list(reader.read_from(time_from_ts, time_to_ts, skip_zero_volume=skip_zero_volume))
         size = len(preload_list)

--- a/pynecore/core/exchange_policy.py
+++ b/pynecore/core/exchange_policy.py
@@ -6,9 +6,17 @@ _ZERO_VOLUME_HIDDEN_EXCHANGES = {
     "BINANCE",
     "BINANCEUSDM",
     "BINANCECOINM",
+    "BYBIT",
 }
 
-_FETCH_CURRENT_OPEN_EXCHANGES = _ZERO_VOLUME_HIDDEN_EXCHANGES | {
+# Bybit hides zero-volume bars like TradingView, but sampled REST/TradingView
+# candles keep previous close equal to the next open, so it does not need the
+# current-open REST correction used by OKX/Binance/Hyperliquid.
+_FETCH_CURRENT_OPEN_EXCHANGES = {
+    "OKX",
+    "BINANCE",
+    "BINANCEUSDM",
+    "BINANCECOINM",
     "HYPERLIQUID",
 }
 

--- a/pynecore/core/ohlcv_file.py
+++ b/pynecore/core/ohlcv_file.py
@@ -1538,7 +1538,7 @@ class OHLCVReader:
             ohlcv = self.read(pos)
             if ohlcv is not None:
                 # volume < 0: Pyne가 gap 보정용으로 만든 봉이므로 항상 제외.
-                # volume == 0: OKX/Binance처럼 TradingView가 hidden 처리하는 거래소에서만 제외.
+                # volume == 0: OKX/Binance/Bybit처럼 TradingView가 hidden 처리하는 거래소에서만 제외.
                 # BITGET/Hyperliquid는 0-volume 봉도 TV 차트/계산에 포함되므로 skip_zero_volume=False로 읽어야 한다.
                 if skip_gaps and (ohlcv.volume < 0 or (skip_zero_volume and ohlcv.volume == 0)):
                     continue

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -268,7 +268,7 @@ def on_alert_event(message: str, runner: ScriptRunner):
 
 def hide_zero_volume_bars(exchange: str | None) -> bool:
     # TradingView policy differs by exchange:
-    # - OKX/Binance: zero-volume candles are hidden and excluded from calculations.
+    # - OKX/Binance/Bybit: zero-volume candles are hidden and excluded from calculations.
     # - BITGET/Hyperliquid: zero-volume candles remain visible and are included.
     return tradingview_hides_zero_volume(exchange)
 


### PR DESCRIPTION
## 요약
- Bybit을 TradingView zero-volume 숨김 정책 대상에 추가
- Bybit은 이전 봉 종가와 현재 봉 시가가 이어지는 것으로 확인되어 current-open REST 보정 대상에서는 제외
- 백테스트, realtime runner, API, collector, 차트 초기 로드 주석의 거래소별 zero-volume 정책 설명 갱신

## 검증
- python py_compile: exchange_policy, data_service, runner 관련 파일 통과
- node --check data_service/templates/data.js 통과
- git diff --check 통과

## 참고
- Markdown 파일 변경은 요청에 따라 이번 PR 커밋에서 제외