### PR TITLE
수동 알림 가격 트리거 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ To send a manual alert:
 3. Drag the menu if you need to adjust the selected chart price.
 4. Click `Send` and confirm the webhook URL.
 
+To set a price trigger, enter or adjust the `Price`, choose a template, and
+click `Set`. PyneReal keeps the red dotted alert line with the session, so the
+trigger stays active after the chart is closed or the browser reconnects.
+When the live price touches the line, PyneReal sends the selected manual-alert
+template and then automatically unsets the trigger. While a trigger is active,
+you can move it by dragging the alert label on the price axis, click `Unset`, or
+use `Send` to send a one-off manual alert immediately.
+
 Manual alerts are independent from the Webhook checkbox. The checkbox controls
 strategy-generated alerts only; a manual alert can still be sent while the
 checkbox is off. A valid webhook URL is still required. PyneReal sends the final

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -2,17 +2,15 @@ from __future__ import annotations
 
 import asyncio
 import ast
-import json
 from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import requests
 from fastapi import APIRouter, Body
 from fastapi.responses import JSONResponse
 
 from pynecore.cli.app import app_state
-from pynecore.core.exchange_policy import normalize_exchange_name, tradingview_hides_zero_volume
+from pynecore.core.exchange_policy import tradingview_hides_zero_volume
 from pynecore.core.ohlcv_file import OHLCVReader
 from pynecore.core.csv_file import CSVReader
 
@@ -22,19 +20,16 @@ from registry import SessionNotFoundError, SessionExistsError, SessionLimitError
 from runtime import Session
 from config import (
     SessionSpec,
-    default_telegram_chat_id,
-    default_telegram_token,
     default_webhook_url,
     sanitize_manual_alert_templates,
+    sanitize_manual_alert_trigger,
 )
+from manual_alerts import send_manual_alert_payload
 from ohlcv_io import make_ccxt_pro_client
 
 # Cache of exchange -> set(symbols) so symbol validation hits the network at most
 # once per exchange for the hub's lifetime.
 _markets_cache: dict[str, set] = {}
-DEFAULT_WEBHOOK_REQUEST_TIMEOUT = (5, 10)
-HYPERLIQUID_WEBHOOK_REQUEST_TIMEOUT = (5, 30)
-TELEGRAM_REQUEST_TIMEOUT = (5, 10)
 
 
 async def _load_exchange_symbols(exchange: str) -> set:
@@ -159,69 +154,6 @@ def _load_script_source_info(spec: SessionSpec, info: dict) -> tuple[str | None,
     if not title and name:
         title = name
     return title, name, source, has_source
-
-
-def _webhook_request_timeout(exchange: str | None) -> tuple[int, int]:
-    if normalize_exchange_name(exchange) == "HYPERLIQUID":
-        return HYPERLIQUID_WEBHOOK_REQUEST_TIMEOUT
-    return DEFAULT_WEBHOOK_REQUEST_TIMEOUT
-
-
-def _post_json_webhook(url: str, payload: Any, exchange: str | None) -> dict:
-    try:
-        resp = requests.post(url, json=payload, timeout=_webhook_request_timeout(exchange))
-        resp.raise_for_status()
-        return {"status": int(resp.status_code), "body": resp.text[:4096]}
-    except requests.HTTPError as e:
-        body = e.response.text[:4096] if e.response is not None else ""
-        status = e.response.status_code if e.response is not None else "?"
-        raise RuntimeError(f"HTTP {status}: {body}") from e
-    except requests.RequestException as e:
-        raise RuntimeError(type(e).__name__) from e
-
-
-def _post_telegram_message(token: str, chat_id: str, text: str) -> dict:
-    payload = {
-        "chat_id": chat_id,
-        "text": text,
-    }
-    try:
-        resp = requests.post(
-            f"https://api.telegram.org/bot{token}/sendMessage",
-            data=payload,
-            timeout=TELEGRAM_REQUEST_TIMEOUT,
-        )
-        resp.raise_for_status()
-        return {"status": int(resp.status_code), "body": resp.text[:4096]}
-    except requests.HTTPError as e:
-        body = e.response.text[:4096] if e.response is not None else ""
-        status = e.response.status_code if e.response is not None else "?"
-        raise RuntimeError(f"HTTP {status}: {body}") from e
-    except requests.RequestException as e:
-        raise RuntimeError(type(e).__name__) from e
-
-
-def _manual_alert_signal_text(message: Any) -> str:
-    if isinstance(message, str):
-        return message
-    try:
-        return json.dumps(message, ensure_ascii=False).replace('"', '')
-    except Exception:
-        return str(message)
-
-
-def _manual_alert_telegram_text(*, script_title: str | None, timeframe: str,
-                                ticker: str, message: Any,
-                                webhook_status: str) -> str:
-    time_str = datetime.now().strftime("%H:%M:%S")
-    return (
-        f"🚨 [Manual][{script_title or 'No title'}]\n"
-        f"Webhook: {webhook_status}\n"
-        f"Time: {time_str}\n"
-        f"Timeframe: {timeframe or ''}\n"
-        f"Ticker: {ticker or ''}\n"
-        f"Signal: {_manual_alert_signal_text(message)}"
-    )
 
 
 # ----------------------------------------------------------------------
@@ -462,6 +394,35 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
             return JSONResponse({"error": f"failed to update templates: {e}"}, status_code=500)
         return JSONResponse({"templates": updated})
 
+    @r.get("/api/{session_id}/manual-alert-trigger")
+    def get_manual_alert_trigger(session_id: str) -> JSONResponse:
+        rt = _rt(session_id)
+        if rt is None:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        return JSONResponse({"trigger": dict(rt.spec.manual_alert_trigger)})
+
+    @r.post("/api/{session_id}/manual-alert-trigger")
+    async def update_manual_alert_trigger(session_id: str, payload: dict = Body(default_factory=dict)) -> JSONResponse:
+        enabled = bool(payload.get("enabled", False))
+        if enabled:
+            trigger = sanitize_manual_alert_trigger({
+                "enabled": True,
+                "price": payload.get("price"),
+                "template": payload.get("template"),
+            })
+            if not trigger.get("enabled"):
+                return JSONResponse({"error": "trigger requires valid price and template"}, status_code=400)
+        else:
+            trigger = {"enabled": False}
+
+        try:
+            updated = await registry.update_manual_alert_trigger(session_id, trigger)
+        except SessionNotFoundError:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        except Exception as e:
+            return JSONResponse({"error": f"failed to update trigger: {e}"}, status_code=500)
+        return JSONResponse({"trigger": updated})
+
     @r.post("/api/{session_id}/manual-alert")
     async def send_manual_alert(session_id: str, payload: dict = Body(default_factory=dict)) -> JSONResponse:
         rt = _rt(session_id)
@@ -470,38 +431,19 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
         if "message" not in payload:
             return JSONResponse({"error": "message is required"}, status_code=400)
 
-        wh = rt.spec.webhook
-        url = (wh.get("url") or "").strip() or default_webhook_url()
-        if not url:
-            return JSONResponse({"error": "webhook url is empty"}, status_code=400)
-        if not url.startswith(("http://", "https://")):
-            return JSONResponse({"error": "webhook url must start with http:// or https://"}, status_code=400)
-
         try:
-            webhook_result = await asyncio.to_thread(_post_json_webhook, url, payload["message"], rt.spec.exchange)
+            script_title, _, _, _ = _load_script_source_info(rt.spec, rt.chart_info)
+            result = await asyncio.to_thread(
+                send_manual_alert_payload,
+                spec=rt.spec,
+                script_title=script_title,
+                payload=payload,
+            )
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
         except Exception as e:
             return JSONResponse({"error": f"webhook send failed: {e}"}, status_code=502)
-
-        token = (wh.get("telegram_token") or "").strip() or default_telegram_token()
-        chat_id = (wh.get("telegram_chat_id") or "").strip() or default_telegram_chat_id()
-        telegram_result: dict[str, Any] = {"sent": False}
-        if token and chat_id:
-            script_title, _, _, _ = _load_script_source_info(rt.spec, rt.chart_info)
-            text = _manual_alert_telegram_text(
-                script_title=script_title,
-                timeframe=rt.spec.timeframe,
-                ticker=rt.spec.symbol,
-                message=payload["message"],
-                webhook_status="Sent",
-            )
-            try:
-                telegram_result = {
-                    "sent": True,
-                    **await asyncio.to_thread(_post_telegram_message, token, chat_id, text),
-                }
-            except Exception as e:
-                telegram_result = {"sent": False, "error": str(e)}
-        return JSONResponse({"ok": True, "webhook": webhook_result, "telegram": telegram_result})
+        return JSONResponse(result)
 
     return r
 

--- a/data_service/config.py
+++ b/data_service/config.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import tomllib
@@ -53,6 +54,29 @@ def sanitize_manual_alert_templates(raw: object) -> list[dict]:
     return templates
 
 
+def sanitize_manual_alert_trigger(raw: object) -> dict:
+    if not isinstance(raw, dict) or not bool(raw.get("enabled", False)):
+        return {"enabled": False}
+
+    try:
+        price = float(raw.get("price"))
+    except (TypeError, ValueError):
+        return {"enabled": False}
+    if not math.isfinite(price):
+        return {"enabled": False}
+
+    template = raw.get("template")
+    templates = sanitize_manual_alert_templates([template])
+    if len(templates) != 1:
+        return {"enabled": False}
+
+    return {
+        "enabled": True,
+        "price": price,
+        "template": templates[0],
+    }
+
+
 @dataclass(frozen=True)
 class SessionSpec:
     """Immutable per-session definition loaded from config / sessions.json."""
@@ -66,6 +90,7 @@ class SessionSpec:
     webhook: dict  # {"enabled": bool, "telegram_notification": bool}  (decision 8-1)
     autostart_runner: bool = False  # start the runner automatically on hub boot
     manual_alert_templates: list[dict] = field(default_factory=list)
+    manual_alert_trigger: dict = field(default_factory=lambda: {"enabled": False})
 
     @classmethod
     def from_dict(cls, d: dict) -> "SessionSpec":
@@ -97,6 +122,7 @@ class SessionSpec:
             },
             autostart_runner=bool(d.get("autostart_runner", False)),
             manual_alert_templates=sanitize_manual_alert_templates(d.get("manual_alert_templates")),
+            manual_alert_trigger=sanitize_manual_alert_trigger(d.get("manual_alert_trigger")),
         )
 
     def with_webhook(self, *, enabled: bool | None = None,
@@ -121,6 +147,7 @@ class SessionSpec:
             history_since=self.history_since, script_name=self.script_name,
             webhook=wh, autostart_runner=self.autostart_runner,
             manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
+            manual_alert_trigger=dict(self.manual_alert_trigger),
         )
 
     def with_manual_alert_templates(self, templates: list[dict]) -> "SessionSpec":
@@ -130,6 +157,17 @@ class SessionSpec:
             history_since=self.history_since, script_name=self.script_name,
             webhook=dict(self.webhook), autostart_runner=self.autostart_runner,
             manual_alert_templates=sanitize_manual_alert_templates(templates),
+            manual_alert_trigger=dict(self.manual_alert_trigger),
+        )
+
+    def with_manual_alert_trigger(self, trigger: object) -> "SessionSpec":
+        return SessionSpec(
+            id=self.id, provider=self.provider, exchange=self.exchange,
+            symbol=self.symbol, timeframe=self.timeframe,
+            history_since=self.history_since, script_name=self.script_name,
+            webhook=dict(self.webhook), autostart_runner=self.autostart_runner,
+            manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
+            manual_alert_trigger=sanitize_manual_alert_trigger(trigger),
         )
 
     def to_dict(self) -> dict:
@@ -144,6 +182,7 @@ class SessionSpec:
             "webhook": dict(self.webhook),
             "autostart_runner": self.autostart_runner,
             "manual_alert_templates": [dict(t) for t in self.manual_alert_templates],
+            "manual_alert_trigger": dict(self.manual_alert_trigger),
         }
 
     @property

--- a/data_service/manual_alerts.py
+++ b/data_service/manual_alerts.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime
+from typing import Any
+
+import requests
+
+from config import SessionSpec, default_telegram_chat_id, default_telegram_token, default_webhook_url
+from pynecore.core.exchange_policy import normalize_exchange_name
+
+
+DEFAULT_WEBHOOK_REQUEST_TIMEOUT = (5, 10)
+HYPERLIQUID_WEBHOOK_REQUEST_TIMEOUT = (5, 30)
+TELEGRAM_REQUEST_TIMEOUT = (5, 10)
+PLACEHOLDER_RE = re.compile(r"\{\{(price|market|time|symbol|ticker|exchange|timeframe|title)\}\}")
+
+
+def webhook_request_timeout(exchange: str | None) -> tuple[int, int]:
+    if normalize_exchange_name(exchange) == "HYPERLIQUID":
+        return HYPERLIQUID_WEBHOOK_REQUEST_TIMEOUT
+    return DEFAULT_WEBHOOK_REQUEST_TIMEOUT
+
+
+def post_json_webhook(url: str, payload: Any, exchange: str | None) -> dict:
+    try:
+        resp = requests.post(url, json=payload, timeout=webhook_request_timeout(exchange))
+        resp.raise_for_status()
+        return {"status": int(resp.status_code), "body": resp.text[:4096]}
+    except requests.HTTPError as e:
+        body = e.response.text[:4096] if e.response is not None else ""
+        status = e.response.status_code if e.response is not None else "?"
+        raise RuntimeError(f"HTTP {status}: {body}") from e
+    except requests.RequestException as e:
+        raise RuntimeError(type(e).__name__) from e
+
+
+def post_telegram_message(token: str, chat_id: str, text: str) -> dict:
+    payload = {
+        "chat_id": chat_id,
+        "text": text,
+    }
+    try:
+        resp = requests.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            data=payload,
+            timeout=TELEGRAM_REQUEST_TIMEOUT,
+        )
+        resp.raise_for_status()
+        return {"status": int(resp.status_code), "body": resp.text[:4096]}
+    except requests.HTTPError as e:
+        body = e.response.text[:4096] if e.response is not None else ""
+        status = e.response.status_code if e.response is not None else "?"
+        raise RuntimeError(f"HTTP {status}: {body}") from e
+    except requests.RequestException as e:
+        raise RuntimeError(type(e).__name__) from e
+
+
+def manual_alert_signal_text(message: Any) -> str:
+    if isinstance(message, str):
+        return message
+    try:
+        return json.dumps(message, ensure_ascii=False).replace('"', '')
+    except Exception:
+        return str(message)
+
+
+def manual_alert_telegram_text(*, script_title: str | None, timeframe: str,
+                               ticker: str, message: Any,
+                               webhook_status: str) -> str:
+    time_str = datetime.now().strftime("%H:%M:%S")
+    return (
+        f"🚨 [Manual][{script_title or 'No title'}]\n"
+        f"Webhook: {webhook_status}\n"
+        f"Time: {time_str}\n"
+        f"Timeframe: {timeframe or ''}\n"
+        f"Ticker: {ticker or ''}\n"
+        f"Signal: {manual_alert_signal_text(message)}"
+    )
+
+
+def send_manual_alert_payload(*, spec: SessionSpec, script_title: str | None,
+                              payload: dict) -> dict[str, Any]:
+    if "message" not in payload:
+        raise ValueError("message is required")
+
+    wh = spec.webhook
+    url = (wh.get("url") or "").strip() or default_webhook_url()
+    if not url:
+        raise ValueError("webhook url is empty")
+    if not url.startswith(("http://", "https://")):
+        raise ValueError("webhook url must start with http:// or https://")
+
+    webhook_result = post_json_webhook(url, payload["message"], spec.exchange)
+
+    token = (wh.get("telegram_token") or "").strip() or default_telegram_token()
+    chat_id = (wh.get("telegram_chat_id") or "").strip() or default_telegram_chat_id()
+    telegram_result: dict[str, Any] = {"sent": False}
+    if token and chat_id:
+        text = manual_alert_telegram_text(
+            script_title=script_title,
+            timeframe=spec.timeframe,
+            ticker=spec.symbol,
+            message=payload["message"],
+            webhook_status="Sent",
+        )
+        try:
+            telegram_result = {
+                "sent": True,
+                **post_telegram_message(token, chat_id, text),
+            }
+        except Exception as e:
+            telegram_result = {"sent": False, "error": str(e)}
+
+    return {"ok": True, "webhook": webhook_result, "telegram": telegram_result}
+
+
+def alert_template_replacements(spec: SessionSpec, context: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "{{price}}": context.get("price"),
+        "{{market}}": context.get("market"),
+        "{{time}}": context.get("time"),
+        "{{symbol}}": spec.symbol or "",
+        "{{ticker}}": spec.symbol or "",
+        "{{exchange}}": spec.exchange or "",
+        "{{timeframe}}": spec.timeframe or "",
+        "{{title}}": context.get("title") or "",
+    }
+
+
+def is_inside_json_string(text: str, offset: int) -> bool:
+    in_string = False
+    escaped = False
+    for ch in text[:offset]:
+        if escaped:
+            escaped = False
+        elif ch == "\\":
+            escaped = True
+        elif ch == '"':
+            in_string = not in_string
+    return in_string
+
+
+def render_raw_alert_template_json(text: str, spec: SessionSpec, context: dict[str, Any]) -> str:
+    replacements = alert_template_replacements(spec, context)
+
+    def replace(match: re.Match[str]) -> str:
+        if is_inside_json_string(text, match.start()):
+            return match.group(0)
+        return json.dumps(replacements.get(match.group(0), ""), ensure_ascii=False)
+
+    return PLACEHOLDER_RE.sub(replace, text)
+
+
+def parse_alert_template_message(template_text: str, spec: SessionSpec,
+                                 context: dict[str, Any]) -> Any:
+    try:
+        return json.loads(template_text)
+    except Exception as initial_error:
+        try:
+            return json.loads(render_raw_alert_template_json(template_text, spec, context))
+        except Exception:
+            raise initial_error
+
+
+def replace_alert_template_value(value: Any, spec: SessionSpec, context: dict[str, Any]) -> Any:
+    if isinstance(value, str):
+        replacements = alert_template_replacements(spec, context)
+        if value in replacements:
+            return replacements[value]
+
+        def replace(match: re.Match[str]) -> str:
+            replacement = replacements.get(match.group(0))
+            return "" if replacement is None else str(replacement)
+
+        return PLACEHOLDER_RE.sub(replace, value)
+    if isinstance(value, list):
+        return [replace_alert_template_value(item, spec, context) for item in value]
+    if isinstance(value, dict):
+        return {
+            key: replace_alert_template_value(item, spec, context)
+            for key, item in value.items()
+        }
+    return value
+
+
+def build_manual_alert_message(template: dict, spec: SessionSpec,
+                               context: dict[str, Any]) -> Any:
+    title = str(template.get("title") or "")
+    template_text = str(template.get("message") or "")
+    full_context = {**context, "title": title}
+    parsed = parse_alert_template_message(template_text, spec, full_context)
+    return replace_alert_template_value(parsed, spec, full_context)
+
+
+def build_manual_alert_payload(*, template: dict, spec: SessionSpec,
+                               price: float, market: float | None,
+                               time: int | None) -> dict[str, Any]:
+    context = {
+        "price": price,
+        "market": market,
+        "time": time,
+        "title": template.get("title") or "",
+    }
+    return {
+        "title": template.get("title") or "",
+        "price": price,
+        "market": market,
+        "time": time,
+        "message": build_manual_alert_message(template, spec, context),
+    }

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -156,6 +156,7 @@ class SessionRegistry:
         feed = self._get_or_create_feed(spec)
         session = Session(spec, feed)
         session.on_status_change = self.notify_hub
+        session.on_spec_change = self._persist_and_notify
         feed.subscribers[spec.id] = session
         self.sessions[spec.id] = session
         self._schedule_logo_resolution(session)
@@ -210,6 +211,17 @@ class SessionRegistry:
         session.spec = session.spec.with_manual_alert_templates(templates)
         self._persist()
         return [dict(t) for t in session.spec.manual_alert_templates]
+
+    async def update_manual_alert_trigger(self, session_id: str, trigger: object) -> dict:
+        session = self.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFoundError(session_id)
+        session.spec = session.spec.with_manual_alert_trigger(trigger)
+        session.reset_manual_alert_trigger_gate()
+        self._persist()
+        await session.push_manual_alert_trigger()
+        await self.notify_hub()
+        return dict(session.spec.manual_alert_trigger)
 
     # ------------------------------------------------------------------
     # Runner control
@@ -276,6 +288,10 @@ class SessionRegistry:
         # Raises on failure so mutating API calls surface a 500 instead of
         # returning ok=true while sessions.json silently fails to update.
         save_sessions([s.spec for s in self.sessions.values()])
+
+    async def _persist_and_notify(self) -> None:
+        self._persist()
+        await self.notify_hub()
 
     async def notify_hub(self) -> None:
         await self.hub_ws.broadcast_json({"type": "sessions", "sessions": self.snapshots()})

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 from dataclasses import dataclass
 from pathlib import Path
@@ -8,6 +9,7 @@ from typing import Any, Awaitable, Callable, Dict, List, Optional
 from fastapi import WebSocket
 
 from config import FeedSpec, SessionSpec
+from manual_alerts import build_manual_alert_payload, send_manual_alert_payload
 from ohlcv_paths import make_ohlcv_paths, runtime_output_dir
 from state import DataState
 from tv_logos import static_logo_info
@@ -60,10 +62,12 @@ class Feed:
         self.collector_error: Optional[str] = None
         self._history_start_mtime: Optional[float] = None
         self._history_start_time: Optional[int] = None
+        self._last_broadcast_close: Optional[float] = None
         # session_id -> Session
         self.subscribers: Dict[str, "Session"] = {}
 
     async def broadcast_bar(self, bar: list) -> None:
+        prev_price = self._last_broadcast_close
         payload = {
             "type": "bar",
             "data": {
@@ -75,7 +79,9 @@ class Feed:
                 "volume": float(bar[5]),
             },
         }
+        self._last_broadcast_close = payload["data"]["close"]
         for session in list(self.subscribers.values()):
+            await session.maybe_fire_manual_alert_trigger(payload["data"], prev_price)
             await session.send_to_charts(payload)
 
     async def emit_event(self, payload: dict) -> None:
@@ -161,6 +167,9 @@ class Session:
         self.logo_info: Dict[str, str] = static_logo_info(spec.exchange, spec.symbol)
         # registry wires this to push /ws/hub status when runner connect/disconnect.
         self.on_status_change: Optional[Callable[[], Awaitable[None]]] = None
+        self.on_spec_change: Optional[Callable[[], Awaitable[None]]] = None
+        self._manual_alert_trigger_sending = False
+        self._manual_alert_trigger_last_bar_time: Optional[int] = None
 
     @property
     def ohlcv_path(self) -> Path:
@@ -170,6 +179,13 @@ class Session:
         if self.on_status_change is not None:
             try:
                 await self.on_status_change()
+            except Exception:
+                pass
+
+    async def _notify_spec_change(self) -> None:
+        if self.on_spec_change is not None:
+            try:
+                await self.on_spec_change()
             except Exception:
                 pass
 
@@ -233,6 +249,10 @@ class Session:
                 self.client_roles[ws] = role
                 if self.runner_count > 0:
                     await ws_manager.send(ws, {"type": "runner_connected"})
+                await ws_manager.send(ws, {
+                    "type": "manual_alert_trigger",
+                    "trigger": self.manual_alert_trigger_payload(),
+                })
             else:
                 self.client_roles[ws] = None
 
@@ -365,9 +385,108 @@ class Session:
             if role == "runner":
                 await self.ws_manager.send(ws, payload)
 
+    def manual_alert_trigger_payload(self) -> dict:
+        return dict(self.spec.manual_alert_trigger or {"enabled": False})
+
+    def reset_manual_alert_trigger_gate(self) -> None:
+        self._manual_alert_trigger_last_bar_time = None
+
+    async def push_manual_alert_trigger(self) -> None:
+        await self.send_to_charts({
+            "type": "manual_alert_trigger",
+            "trigger": self.manual_alert_trigger_payload(),
+        })
+
     async def push_webhook_config(self) -> None:
         # Runner-only (contains url/token); never broadcast to chart browsers.
         await self.send_to_runners(self._webhook_config_payload())
+
+    def _manual_alert_script_title(self) -> str | None:
+        title = self.chart_info.get("script_title")
+        if title:
+            return str(title)
+        if self.spec.script_name:
+            return Path(self.spec.script_name).stem
+        return None
+
+    def _manual_alert_trigger_touched(self, bar: dict, prev_price: float | None,
+                                      trigger_price: float) -> bool:
+        close = float(bar.get("close"))
+        if prev_price is None:
+            prev_price = float(bar.get("open", close))
+        low = min(float(prev_price), close)
+        high = max(float(prev_price), close)
+        return low <= trigger_price <= high
+
+    def _manual_alert_trigger_matches(self, trigger: dict) -> bool:
+        current = self.spec.manual_alert_trigger or {}
+        if not current.get("enabled"):
+            return False
+        current_template = current.get("template") or {}
+        trigger_template = trigger.get("template") or {}
+        try:
+            if float(current.get("price")) != float(trigger.get("price")):
+                return False
+        except (TypeError, ValueError):
+            return False
+        return (
+            current_template.get("title") == trigger_template.get("title")
+            and current_template.get("message") == trigger_template.get("message")
+        )
+
+    async def _send_manual_alert_trigger(self, trigger: dict, trigger_price: float,
+                                         market_price: float, bar_time: int) -> None:
+        template = trigger.get("template") or {}
+        try:
+            payload = build_manual_alert_payload(
+                template=template,
+                spec=self.spec,
+                price=trigger_price,
+                market=market_price,
+                time=bar_time,
+            )
+            result = await asyncio.to_thread(
+                send_manual_alert_payload,
+                spec=self.spec,
+                script_title=self._manual_alert_script_title(),
+                payload=payload,
+            )
+        except Exception as e:
+            await self.send_to_charts({
+                "type": "manual_alert_trigger_error",
+                "error": str(e)[:240],
+                "trigger": self.manual_alert_trigger_payload(),
+            })
+        else:
+            if self._manual_alert_trigger_matches(trigger):
+                self.spec = self.spec.with_manual_alert_trigger({"enabled": False})
+                await self._notify_spec_change()
+                await self.push_manual_alert_trigger()
+            await self.send_to_charts({
+                "type": "manual_alert_trigger_fired",
+                "result": result,
+            })
+        finally:
+            self._manual_alert_trigger_sending = False
+
+    async def maybe_fire_manual_alert_trigger(self, bar: dict, prev_price: float | None) -> None:
+        trigger = self.spec.manual_alert_trigger or {}
+        if not trigger.get("enabled") or self._manual_alert_trigger_sending:
+            return
+        try:
+            trigger_price = float(trigger.get("price"))
+            bar_time = int(bar.get("time"))
+            market_price = float(bar.get("close"))
+        except (TypeError, ValueError):
+            return
+        if self._manual_alert_trigger_last_bar_time == bar_time:
+            return
+        if not self._manual_alert_trigger_touched(bar, prev_price, trigger_price):
+            return
+
+        self._manual_alert_trigger_last_bar_time = bar_time
+        self._manual_alert_trigger_sending = True
+        asyncio.create_task(self._send_manual_alert_trigger(dict(trigger), trigger_price, market_price, bar_time))
 
     # ------------------------------------------------------------------
     # Status snapshot (merges feed data-plane state)

--- a/data_service/templates/chart.js
+++ b/data_service/templates/chart.js
@@ -12,6 +12,16 @@ App.chart = {
   resizeObserver: null,
   touchGuardsAttached: false,
   manualAlertLastTap: null,
+  manualAlertLineDrag: null,
+  manualAlertLineSuppressTapUntil: 0,
+  manualAlertLineChartInputFrozen: false,
+  manualAlertChip: null,
+  manualAlertChipXSeg: null,
+  manualAlertChipVisible: false,
+  manualAlertUnsetPending: null,
+  manualAlertChipRafId: null,
+  manualAlertChipState: { price: null, armed: false },
+  manualAlertChipPos: { top: null, right: null },
   isMobileViewport() {
     return window.matchMedia("(max-width: 640px), (hover: none) and (pointer: coarse)").matches;
   },
@@ -61,29 +71,156 @@ App.chart = {
   restoreMagnetMode() {
     this.setMagnetMode(true);
   },
+  freezeManualAlertLineChartInput() {
+    if (!this.chart || this.manualAlertLineChartInputFrozen) return;
+    this.manualAlertLineChartInputFrozen = true;
+    this.chart.applyOptions({
+      handleScroll: false,
+      handleScale: false
+    });
+  },
+  restoreManualAlertLineChartInput() {
+    if (!this.chart || !this.manualAlertLineChartInputFrozen) return;
+    this.manualAlertLineChartInputFrozen = false;
+    this.chart.applyOptions({
+      handleScroll: true,
+      handleScale: true
+    });
+  },
   removeManualAlertPriceGuide() {
     if (this.manualAlertPriceLine && this.candleSeries && this.candleSeries.removePriceLine) {
       this.candleSeries.removePriceLine(this.manualAlertPriceLine);
     }
     this.manualAlertPriceLine = null;
+    this.hideManualAlertChip();
   },
-  updateManualAlertPriceGuide(price) {
+  updateManualAlertPriceGuide(price, optionsOverride = {}) {
     if (!this.candleSeries || !Number.isFinite(Number(price))) return;
     const dottedLineStyle = (LightweightCharts.LineStyle && LightweightCharts.LineStyle.Dotted != null)
       ? LightweightCharts.LineStyle.Dotted
       : 1;
+    const armed = !!optionsOverride.armed;
+    const color = armed ? "#d32f2f" : "#111111";
     const options = {
       price: Number(price),
-      color: "#111111",
+      color,
       lineWidth: 1,
       lineStyle: dottedLineStyle,
       axisLabelVisible: true,
-      title: "Alert"
+      axisLabelColor: color,
+      axisLabelTextColor: "#ffffff",
+      // 타이틀 라벨은 라이브러리 대신 HTML 칩(#manual-alert-chip)으로 그린다.
+      title: ""
     };
     if (this.manualAlertPriceLine) {
       this.manualAlertPriceLine.applyOptions(options);
     } else {
       this.manualAlertPriceLine = this.candleSeries.createPriceLine(options);
+    }
+    this.showManualAlertChip(Number(price), armed);
+  },
+  ensureManualAlertChip() {
+    if (this.manualAlertChip) return this.manualAlertChip;
+    const chip = document.createElement("div");
+    chip.id = "manual-alert-chip";
+    chip.style.display = "none";
+    const xSeg = document.createElement("span");
+    xSeg.className = "chip-x";
+    xSeg.innerHTML =
+      '<svg width="8" height="8" viewBox="0 0 8 8" aria-hidden="true">' +
+      '<path d="M1 1l6 6M7 1l-6 6" stroke="#ffffff" stroke-width="1.4" stroke-linecap="round"/></svg>';
+    const divider = document.createElement("span");
+    divider.className = "chip-divider";
+    const label = document.createElement("span");
+    label.className = "chip-label";
+    label.textContent = "Alert";
+    chip.append(xSeg, divider, label);
+    this.container.appendChild(chip);
+    this.manualAlertChip = chip;
+    this.manualAlertChipXSeg = xSeg;
+    return chip;
+  },
+  showManualAlertChip(price, armed) {
+    const chip = this.ensureManualAlertChip();
+    this.manualAlertChipState.price = Number(price);
+    this.manualAlertChipState.armed = !!armed;
+    chip.classList.toggle("armed", !!armed);
+    this.manualAlertChipVisible = true;
+    this.syncManualAlertChipPosition();
+    this.startManualAlertChipLoop();
+  },
+  hideManualAlertChip() {
+    this.manualAlertChipVisible = false;
+    if (this.manualAlertChipRafId != null) {
+      cancelAnimationFrame(this.manualAlertChipRafId);
+      this.manualAlertChipRafId = null;
+    }
+    this.clearManualAlertChipHover();
+    if (this.manualAlertChip) {
+      this.manualAlertChip.style.display = "none";
+    }
+  },
+  syncManualAlertChipPosition() {
+    const chip = this.manualAlertChip;
+    if (!chip || !this.manualAlertChipVisible || !this.chart || !this.candleSeries || !this.container) return;
+    const y = this.candleSeries.priceToCoordinate(Number(this.manualAlertChipState.price));
+    let timeScaleHeight = 28;
+    try {
+      timeScaleHeight = this.chart.timeScale().height() || timeScaleHeight;
+    } catch {}
+    const paneBottom = Math.max(0, this.container.clientHeight - timeScaleHeight);
+    if (!Number.isFinite(Number(y)) || y < 0 || y > paneBottom) {
+      if (chip.style.display !== "none") chip.style.display = "none";
+      return;
+    }
+    let priceScaleWidth = 76;
+    try {
+      priceScaleWidth = this.chart.priceScale("right").width() || priceScaleWidth;
+    } catch {}
+    if (chip.style.display === "none") chip.style.display = "";
+    // 네이티브 축 라벨(높이 17px)과 같은 픽셀 정렬: 중심 = round(y), top = 중심 - floor(높이/2).
+    const top = Math.round(y) - Math.floor(chip.offsetHeight / 2);
+    const right = Math.round(priceScaleWidth + 1);
+    if (this.manualAlertChipPos.top !== top) {
+      chip.style.top = top + "px";
+      this.manualAlertChipPos.top = top;
+    }
+    if (this.manualAlertChipPos.right !== right) {
+      chip.style.right = right + "px";
+      this.manualAlertChipPos.right = right;
+    }
+  },
+  startManualAlertChipLoop() {
+    // 가격축 스케일 변경(오토스케일, 축 드래그)은 구독 이벤트가 없어 rAF로 위치를 동기화한다.
+    if (this.manualAlertChipRafId != null) return;
+    const step = () => {
+      if (!this.manualAlertChipVisible) {
+        this.manualAlertChipRafId = null;
+        return;
+      }
+      this.syncManualAlertChipPosition();
+      this.manualAlertChipRafId = requestAnimationFrame(step);
+    };
+    this.manualAlertChipRafId = requestAnimationFrame(step);
+  },
+  updateManualAlertChipHover(pointer) {
+    const chip = this.manualAlertChip;
+    if (!chip || !this.manualAlertChipVisible || this.manualAlertLineDrag) {
+      this.clearManualAlertChipHover();
+      return;
+    }
+    const hit = this.manualAlertLabelHitInfo(pointer);
+    const overClose = !!(hit && hit.x <= hit.closeRight);
+    chip.classList.toggle("x-hover", overClose);
+    this.container.classList.toggle("manual-alert-x-hover", overClose);
+    this.container.classList.toggle("manual-alert-grab-hover", !!hit && !overClose);
+  },
+  clearManualAlertChipHover() {
+    if (this.manualAlertChip) {
+      this.manualAlertChip.classList.remove("x-hover");
+    }
+    if (this.container) {
+      this.container.classList.remove("manual-alert-x-hover", "manual-alert-grab-hover");
     }
   },
   priceFromClientY(clientY) {
@@ -91,6 +228,159 @@ App.chart = {
     const rect = this.container.getBoundingClientRect();
     const price = this.candleSeries.coordinateToPrice(clientY - rect.top);
     return Number.isFinite(Number(price)) ? Number(price) : null;
+  },
+  clientYFromPrice(price) {
+    if (!this.candleSeries || !this.container || !Number.isFinite(Number(price))) return null;
+    const coordinate = this.candleSeries.priceToCoordinate(Number(price));
+    if (!Number.isFinite(Number(coordinate))) return null;
+    const rect = this.container.getBoundingClientRect();
+    return rect.top + coordinate;
+  },
+  manualAlertLineDragEnabled() {
+    if (!App.ui || !App.ui.manualAlertTriggerActive || !App.ui.manualAlertTriggerActive()) return false;
+    if (App.state.manualAlertMenuOpen || App.state.manualAlertConfirmOpen) return false;
+    if (App.state.measureToolActive || App.state.sourcePanelOpen) return false;
+    const modal = App.ui.elements && App.ui.elements.alertTemplateModal;
+    if (modal && !modal.classList.contains("hidden")) return false;
+    return true;
+  },
+  manualAlertLabelHitInfo(pointer) {
+    if (!this.manualAlertLineDragEnabled() || !this.chart || !this.container) return false;
+    const trigger = App.state.manualAlertTrigger || {};
+    const lineY = this.clientYFromPrice(trigger.price);
+    if (lineY == null) return false;
+    const rect = this.container.getBoundingClientRect();
+    const x = pointer.clientX - rect.left;
+    const y = pointer.clientY - rect.top;
+    if (x < 0 || x > rect.width || y < 0 || y > rect.height) return false;
+
+    const lineDistance = Math.abs(pointer.clientY - lineY);
+    const isTouch = pointer.pointerType !== "mouse";
+    const labelTolerance = isTouch ? 24 : 16;
+    if (lineDistance > labelTolerance) return false;
+
+    const chip = this.manualAlertChip;
+    if (chip && this.manualAlertChipVisible) {
+      // 칩이 페인 밖으로 벗어나 숨겨진 동안에는 히트 대상이 아니다.
+      if (chip.style.display === "none") return false;
+      const chipRect = chip.getBoundingClientRect();
+      const xSegRect = this.manualAlertChipXSeg.getBoundingClientRect();
+      const labelLeft = chipRect.left - rect.left - (isTouch ? 8 : 0);
+      if (x < labelLeft) return false;
+      return {
+        x,
+        labelLeft,
+        closeRight: xSegRect.right - rect.left + (isTouch ? 4 : 0)
+      };
+    }
+
+    // 칩이 아직 생성되지 않은 경우의 안전망: 기존 고정 폭 히트 존.
+    let priceScaleWidth = 76;
+    try {
+      priceScaleWidth = this.chart.priceScale("right").width() || priceScaleWidth;
+    } catch {}
+    const titleLabelHitWidth = isTouch ? 72 : 58;
+    const labelLeft = rect.width - priceScaleWidth - titleLabelHitWidth;
+    if (x < labelLeft) return false;
+    return {
+      x,
+      labelLeft,
+      closeRight: labelLeft + (isTouch ? 28 : 22)
+    };
+  },
+  manualAlertUnsetHitTest(pointer) {
+    const hit = this.manualAlertLabelHitInfo(pointer);
+    return !!(hit && hit.x <= hit.closeRight);
+  },
+  manualAlertLineHitTest(pointer) {
+    return !!this.manualAlertLabelHitInfo(pointer);
+  },
+  updateManualAlertLineDrag(pointer) {
+    if (!this.manualAlertLineDrag || this.manualAlertLineDrag.pointerId !== pointer.pointerId) return;
+    const price = this.priceFromClientY(pointer.clientY);
+    if (price == null) return;
+    this.manualAlertLineDrag.price = price;
+    if (App.ui && App.ui.previewManualAlertTriggerPrice) {
+      App.ui.previewManualAlertTriggerPrice(price);
+    }
+  },
+  startManualAlertLineDrag(e) {
+    if (this.manualAlertUnsetHitTest(e)) {
+      // 버튼처럼 동작: down에서는 눌림 표시만 하고, X 위에서 뗄 때 unset 한다.
+      this.manualAlertUnsetPending = { pointerId: e.pointerId };
+      if (this.manualAlertChip) this.manualAlertChip.classList.add("x-pressed");
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+      return true;
+    }
+    if (!this.manualAlertLineHitTest(e)) return false;
+    const price = this.priceFromClientY(e.clientY);
+    if (price == null) return false;
+    this.manualAlertLineDrag = {
+      pointerId: e.pointerId,
+      price
+    };
+    document.body.classList.add("manual-alert-line-dragging");
+    try {
+      this.container.setPointerCapture(e.pointerId);
+    } catch {}
+    this.freezeManualAlertLineChartInput();
+    this.setMagnetMode(false);
+    this.updateManualAlertLineDrag(e);
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+    return true;
+  },
+  moveManualAlertLineDrag(e) {
+    if (this.manualAlertUnsetPending && this.manualAlertUnsetPending.pointerId === e.pointerId) {
+      if (this.manualAlertChip) {
+        this.manualAlertChip.classList.toggle("x-pressed", !!this.manualAlertUnsetHitTest(e));
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+      return;
+    }
+    if (!this.manualAlertLineDrag || this.manualAlertLineDrag.pointerId !== e.pointerId) return;
+    this.updateManualAlertLineDrag(e);
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+  },
+  endManualAlertLineDrag(e) {
+    if (this.manualAlertUnsetPending && this.manualAlertUnsetPending.pointerId === e.pointerId) {
+      this.manualAlertUnsetPending = null;
+      if (this.manualAlertChip) this.manualAlertChip.classList.remove("x-pressed");
+      if (e.type !== "pointercancel" && this.manualAlertUnsetHitTest(e)) {
+        this.manualAlertLineSuppressTapUntil = performance.now() + 500;
+        if (App.ui && App.ui.unsetManualAlertTriggerFromLine) {
+          App.ui.unsetManualAlertTriggerFromLine();
+        }
+      }
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.stopImmediatePropagation) e.stopImmediatePropagation();
+      return;
+    }
+    const drag = this.manualAlertLineDrag;
+    if (!drag || drag.pointerId !== e.pointerId) return;
+    this.updateManualAlertLineDrag(e);
+    this.manualAlertLineDrag = null;
+    this.manualAlertLineSuppressTapUntil = performance.now() + 500;
+    document.body.classList.remove("manual-alert-line-dragging");
+    try {
+      this.container.releasePointerCapture(e.pointerId);
+    } catch {}
+    this.restoreManualAlertLineChartInput();
+    this.restoreMagnetMode();
+    if (App.ui && App.ui.saveManualAlertTriggerPriceFromLine) {
+      App.ui.saveManualAlertTriggerPriceFromLine(drag.price);
+    }
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.stopImmediatePropagation) e.stopImmediatePropagation();
   },
   normalizeAlertTime(time) {
     if (typeof time === "number") return time;
@@ -151,8 +441,31 @@ App.chart = {
     this.setMagnetMode(false);
   },
   attachManualAlertGesture() {
+    document.addEventListener("pointerdown", (e) => {
+      if (!(e.target instanceof Node) || !this.container.contains(e.target)) return;
+      this.startManualAlertLineDrag(e);
+    }, { capture: true, passive: false });
+    window.addEventListener("pointermove", (e) => {
+      this.moveManualAlertLineDrag(e);
+    }, { capture: true, passive: false });
+    window.addEventListener("pointerup", (e) => {
+      this.endManualAlertLineDrag(e);
+    }, { capture: true, passive: false });
+    window.addEventListener("pointercancel", (e) => {
+      this.endManualAlertLineDrag(e);
+    }, { capture: true, passive: false });
+
+    this.container.addEventListener("pointermove", (e) => {
+      if (e.pointerType !== "mouse") return;
+      this.updateManualAlertChipHover(e);
+    }, { passive: true });
+    this.container.addEventListener("pointerleave", () => {
+      this.clearManualAlertChipHover();
+    }, { passive: true });
+
     this.container.addEventListener("dblclick", (e) => {
       if (e.button !== 0) return;
+      if (performance.now() < this.manualAlertLineSuppressTapUntil) return;
       e.preventDefault();
       App.ui.closeManualAlertMenu();
       this.openManualAlertMenuFromPointer({ clientX: e.clientX, clientY: e.clientY });
@@ -160,6 +473,7 @@ App.chart = {
 
     this.container.addEventListener("pointerup", (e) => {
       if (e.pointerType === "mouse") return;
+      if (performance.now() < this.manualAlertLineSuppressTapUntil) return;
       const now = performance.now();
       const previous = this.manualAlertLastTap;
       this.manualAlertLastTap = { time: now, clientX: e.clientX, clientY: e.clientY };

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -228,7 +228,12 @@ th, td { text-align: left; padding: 10px 8px; border-bottom: 1px solid var(--bor
 th { color: var(--muted); font-weight: 600; font-size: 12px; }
 tr:last-child td { border-bottom: none; }
 
-.runner-cell { display: flex; gap: 6px; }
+.runner-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
 
 .symbol-cell,
 .exchange-cell {
@@ -515,8 +520,13 @@ tr:last-child td { border-bottom: none; }
   }
   td.mono { word-break: break-all; }
   /* keep the "Runner" label left-aligned like other rows; push buttons right */
-  td.runner-cell { flex-wrap: wrap; justify-content: flex-start; gap: 6px; }
+  td.runner-cell { justify-content: flex-start; gap: 6px; }
   td.runner-cell::before { margin-right: auto; }
+  .runner-actions {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    white-space: normal;
+  }
   .symbol-cell,
   .exchange-cell {
     justify-content: flex-end;

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -383,7 +383,7 @@
     if (tr.dataset.runnerControlsKey !== runner) {
       setHTML(
         tr.querySelector('[data-field="runner-cell"]'),
-        `${runnerButtons(s)}<button class="btn" data-act="logs">Logs</button>`,
+        `<span class="runner-actions">${runnerButtons(s)}<button class="btn" data-act="logs">Logs</button></span>`,
       );
       tr.dataset.runnerControlsKey = runner;
     }

--- a/data_service/templates/data.js
+++ b/data_service/templates/data.js
@@ -417,6 +417,9 @@ App.data = {
           await this.loadTradeHistory();
           await this.loadPlotcharHistory();
           await this.loadPlotData();
+          if (App.ui && App.ui.applyManualAlertTriggerState) {
+            App.ui.applyManualAlertTriggerState(App.state.manualAlertTrigger);
+          }
           state.initialLoadDone = true;
           state.initialLoadInProgress = false;
           return;
@@ -611,6 +614,42 @@ App.data = {
       return { ok: true, data };
     } catch (e) {
       return { ok: false, error: "Send failed" };
+    }
+  },
+  async loadManualAlertTrigger() {
+    try {
+      const resp = await fetch(`${App.config.apiBase}/manual-alert-trigger`);
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        return { ok: false, error: data.error || `Load trigger failed (${resp.status})` };
+      }
+      const trigger = data && data.trigger && typeof data.trigger === "object"
+        ? data.trigger
+        : { enabled: false };
+      App.state.manualAlertTrigger = trigger;
+      return { ok: true, trigger };
+    } catch (e) {
+      return { ok: false, error: "Load trigger failed" };
+    }
+  },
+  async saveManualAlertTrigger(trigger) {
+    try {
+      const resp = await fetch(`${App.config.apiBase}/manual-alert-trigger`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(trigger || { enabled: false })
+      });
+      const data = await resp.json().catch(() => ({}));
+      if (!resp.ok) {
+        return { ok: false, error: data.error || `Save trigger failed (${resp.status})` };
+      }
+      const saved = data && data.trigger && typeof data.trigger === "object"
+        ? data.trigger
+        : { enabled: false };
+      App.state.manualAlertTrigger = saved;
+      return { ok: true, trigger: saved };
+    } catch (e) {
+      return { ok: false, error: "Save trigger failed" };
     }
   }
 };

--- a/data_service/templates/index.html
+++ b/data_service/templates/index.html
@@ -122,7 +122,9 @@
   <div id="alert-template-placeholder-tip" class="template-placeholder-tooltip hidden" role="tooltip"></div>
   <div id="manual-alert-menu" class="manual-alert-menu hidden">
     <div id="manual-alert-drag" class="manual-alert-drag">
-      <div id="manual-alert-price" class="manual-alert-price"></div>
+      <label class="manual-alert-price-label" for="manual-alert-price-input">Price</label>
+      <input id="manual-alert-price-input" class="manual-alert-price-input" type="text" inputmode="decimal" autocomplete="off" spellcheck="false">
+      <button id="manual-alert-set" class="template-btn manual-alert-set" type="button">Set</button>
     </div>
     <div class="manual-alert-controls">
       <div id="manual-alert-template-picker" class="manual-alert-template-picker">

--- a/data_service/templates/main.js
+++ b/data_service/templates/main.js
@@ -6,6 +6,7 @@ App.data.loadChartInfo();
 App.data.loadScriptSource();
 App.data.loadWebhookConfig();
 App.ui.loadManualAlertTemplates({ migrateLocal: true });
+App.ui.loadManualAlertTrigger();
 App.measure.init();
 App.chart.startJankMonitor();
 App.chart.attachResizeHandler();

--- a/data_service/templates/measure.js
+++ b/data_service/templates/measure.js
@@ -169,7 +169,7 @@ App.measure = {
     try {
       toolbar.setPointerCapture(e.pointerId);
     } catch {}
-    this.toolbarDragTimer = setTimeout(() => this.startToolbarDrag(), 1000);
+    this.toolbarDragTimer = setTimeout(() => this.startToolbarDrag(), 500);
   },
 
   onToolbarPointerMove(e) {

--- a/data_service/templates/state.js
+++ b/data_service/templates/state.js
@@ -55,6 +55,7 @@ window.App.state = {
   manualAlertConfirmOpen: false,
   manualAlertSelectedTemplateIndex: -1,
   manualAlertSuppressClickUntil: 0,
+  manualAlertTrigger: { enabled: false },
   measureToolActive: false,
   measureDraft: null,
   measureResult: null

--- a/data_service/templates/styles.css
+++ b/data_service/templates/styles.css
@@ -501,10 +501,72 @@ body.measure-active #chart {
 .manual-alert-status.error {
   color: #d32f2f;
 }
+body.manual-alert-line-dragging,
+body.manual-alert-line-dragging * {
+  cursor: ns-resize !important;
+  user-select: none;
+  -webkit-user-select: none;
+}
+#manual-alert-chip {
+  position: absolute;
+  z-index: 5;
+  display: flex;
+  align-items: stretch;
+  height: 17px; /* 네이티브 가격축 라벨 높이와 동일 */
+  border-radius: 2px 0 0 2px;
+  overflow: hidden;
+  color: #ffffff;
+  font-family: -apple-system, BlinkMacSystemFont, "Trebuchet MS", Roboto, Ubuntu, sans-serif;
+  font-size: 12px;
+  line-height: 1;
+  white-space: nowrap;
+  pointer-events: none;
+  user-select: none;
+  -webkit-user-select: none;
+}
+#manual-alert-chip .chip-x {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  background: #b71c1c;
+}
+#manual-alert-chip .chip-x svg {
+  display: block;
+}
+#manual-alert-chip.x-hover .chip-x {
+  background: #e04545;
+}
+#manual-alert-chip.x-pressed .chip-x {
+  background: #8e1515;
+}
+#manual-alert-chip .chip-divider {
+  width: 1px;
+  background: rgba(255, 255, 255, 0.4);
+}
+#manual-alert-chip .chip-label {
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  background: #d32f2f;
+}
+#manual-alert-chip:not(.armed) .chip-x,
+#manual-alert-chip:not(.armed) .chip-divider {
+  display: none;
+}
+#manual-alert-chip:not(.armed) .chip-label {
+  background: #111111;
+}
+#chart.manual-alert-x-hover * {
+  cursor: pointer !important;
+}
+#chart.manual-alert-grab-hover * {
+  cursor: ns-resize !important;
+}
 .manual-alert-menu {
   position: fixed;
   z-index: 18;
-  width: 160px;
+  width: 176px;
   box-sizing: border-box;
   padding: 0;
   background: rgba(255, 255, 255, 0.96);
@@ -515,25 +577,57 @@ body.measure-active #chart {
   overflow: visible;
 }
 .manual-alert-drag {
-  display: flex;
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) 46px;
   align-items: center;
   gap: 5px;
-  min-height: 23px;
-  padding: 3px 5px 3px 7px;
+  min-height: 28px;
+  padding: 4px 7px 4px 7px;
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   cursor: move;
   touch-action: none;
   user-select: none;
   -webkit-user-select: none;
 }
-.manual-alert-price {
-  flex: 1 1 auto;
+.manual-alert-price-label {
+  flex: 0 0 auto;
   min-width: 0;
   font-size: 10.5px;
   font-weight: 700;
 }
-.manual-alert-controls {
+.manual-alert-price-input {
+  min-width: 0;
+  width: 100%;
+  height: 24px;
+  box-sizing: border-box;
+  padding: 0 5px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  border-radius: 5px;
+  background: #ffffff;
+  color: #111;
+  font-size: 11px;
+  line-height: 1.25;
+}
+.manual-alert-drag .manual-alert-set {
   display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 46px;
+  height: 24px;
+  box-sizing: border-box;
+  margin-left: 0;
+  padding: 0;
+  font-size: 11px;
+  line-height: 1;
+  white-space: nowrap;
+}
+.manual-alert-drag .manual-alert-set.armed {
+  background: #d32f2f;
+  color: #ffffff;
+}
+.manual-alert-controls {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 46px;
   align-items: center;
   gap: 5px;
   padding: 4px 7px 0;
@@ -608,9 +702,9 @@ body.measure-active #chart {
   color: #fff;
 }
 .manual-alert-controls .template-btn.primary {
-  flex: 0 0 auto;
+  width: 46px;
   margin-left: 0;
-  padding: 3px 7px;
+  padding: 3px 0;
   font-size: 11px;
 }
 .manual-alert-status {
@@ -1069,7 +1163,7 @@ body.source-open .source-panel {
   }
 
   .manual-alert-menu {
-    width: min(160px, calc(100vw - 24px));
+    width: min(176px, calc(100vw - 24px));
   }
 
   #chart-info {

--- a/data_service/templates/ui.js
+++ b/data_service/templates/ui.js
@@ -20,7 +20,8 @@ App.ui = {
     alertTemplateStatus: document.getElementById("alert-template-status"),
     manualAlertMenu: document.getElementById("manual-alert-menu"),
     manualAlertDrag: document.getElementById("manual-alert-drag"),
-    manualAlertPrice: document.getElementById("manual-alert-price"),
+    manualAlertPriceInput: document.getElementById("manual-alert-price-input"),
+    manualAlertSet: document.getElementById("manual-alert-set"),
     manualAlertTemplatePicker: document.getElementById("manual-alert-template-picker"),
     manualAlertTemplateButton: document.getElementById("manual-alert-template-button"),
     manualAlertTemplateLabel: document.getElementById("manual-alert-template-label"),
@@ -48,6 +49,8 @@ App.ui = {
   manualAlertDragState: null,
   manualAlertPendingSend: null,
   manualAlertStatusClearTimer: null,
+  manualAlertTriggerSyncTimer: null,
+  manualAlertArmedInputDirty: false,
   activeTemplatePlaceholder: null,
   setChartInfo(ohlcvText = null) {
     const state = App.state;
@@ -370,6 +373,214 @@ App.ui = {
     const lastClose = App.state.lastOhlcv ? Number(App.state.lastOhlcv.close) : NaN;
     return Number.isFinite(lastClose) ? lastClose : null;
   },
+  formatPriceInput(value) {
+    const n = Number(value);
+    if (!Number.isFinite(n)) return "";
+    return n.toFixed(8).replace(/\.?0+$/, "");
+  },
+  parseManualAlertPriceInput() {
+    const raw = String(this.elements.manualAlertPriceInput.value || "").replace(/,/g, "").trim();
+    if (!raw) return null;
+    const price = Number(raw);
+    return Number.isFinite(price) ? price : null;
+  },
+  manualAlertSelectedTemplate() {
+    const templates = App.state.manualAlertTemplates;
+    const index = App.state.manualAlertSelectedTemplateIndex;
+    return Number.isInteger(index) && index >= 0 && index < templates.length ? templates[index] : null;
+  },
+  manualAlertTriggerActive() {
+    const trigger = App.state.manualAlertTrigger;
+    return !!(trigger && trigger.enabled && Number.isFinite(Number(trigger.price)));
+  },
+  setManualAlertPriceValue(price, { updateInput = true } = {}) {
+    const context = App.state.manualAlertContext;
+    const n = Number(price);
+    if (!Number.isFinite(n)) return false;
+    if (context) context.price = n;
+    if (updateInput) {
+      this.elements.manualAlertPriceInput.value = this.formatPriceInput(n);
+    }
+    if (this.manualAlertTriggerActive() && updateInput) {
+      this.manualAlertArmedInputDirty = false;
+    }
+    App.chart.updateManualAlertPriceGuide(n, { armed: this.manualAlertTriggerActive() });
+    return true;
+  },
+  moveManualAlertMenuToPrice(price) {
+    if (!App.state.manualAlertMenuOpen || !App.chart || !App.chart.clientYFromPrice) return false;
+    const n = Number(price);
+    if (!Number.isFinite(n)) return false;
+    const targetY = App.chart.clientYFromPrice(n);
+    if (targetY == null) return false;
+    const menu = this.elements.manualAlertMenu;
+    const menuRect = menu.getBoundingClientRect();
+    const priceRect = this.elements.manualAlertPriceInput.getBoundingClientRect();
+    const priceOffsetY = (priceRect.top - menuRect.top) + priceRect.height / 2;
+    this.setManualAlertMenuPosition(menuRect.left, targetY - priceOffsetY);
+    return true;
+  },
+  updateManualAlertSetButtonState() {
+    const active = this.manualAlertTriggerActive();
+    const template = this.manualAlertSelectedTemplate();
+    const button = this.elements.manualAlertSet;
+    button.textContent = active ? "Unset" : "Set";
+    button.disabled = !active && !template;
+    button.classList.toggle("armed", active);
+  },
+  clearManualAlertTriggerSyncTimer() {
+    if (this.manualAlertTriggerSyncTimer !== null) {
+      clearTimeout(this.manualAlertTriggerSyncTimer);
+      this.manualAlertTriggerSyncTimer = null;
+    }
+  },
+  restoreManualAlertActiveTriggerPrice() {
+    const trigger = App.state.manualAlertTrigger || {};
+    if (!trigger.enabled || !Number.isFinite(Number(trigger.price))) return false;
+    this.manualAlertArmedInputDirty = false;
+    return this.setManualAlertPriceValue(Number(trigger.price));
+  },
+  previewManualAlertTriggerPrice(price) {
+    const trigger = App.state.manualAlertTrigger || {};
+    const n = Number(price);
+    if (!trigger.enabled || !Number.isFinite(n)) return false;
+    trigger.price = n;
+    this.manualAlertArmedInputDirty = false;
+    if (App.state.manualAlertMenuOpen) {
+      this.elements.manualAlertPriceInput.value = this.formatPriceInput(n);
+    }
+    App.chart.updateManualAlertPriceGuide(n, { armed: true });
+    return true;
+  },
+  applyManualAlertTriggerState(trigger) {
+    const normalized = trigger && trigger.enabled ? trigger : { enabled: false };
+    App.state.manualAlertTrigger = normalized;
+    const context = App.state.manualAlertContext;
+    if (normalized.enabled && Number.isFinite(Number(normalized.price))) {
+      this.manualAlertArmedInputDirty = false;
+      this.setManualAlertPriceValue(Number(normalized.price));
+      App.chart.updateManualAlertPriceGuide(Number(normalized.price), { armed: true });
+    } else {
+      this.clearManualAlertTriggerSyncTimer();
+      this.manualAlertArmedInputDirty = false;
+      if (context && App.state.manualAlertMenuOpen) {
+        App.chart.updateManualAlertPriceGuide(context.price, { armed: false });
+      } else if (App.chart && App.chart.removeManualAlertPriceGuide) {
+        App.chart.removeManualAlertPriceGuide();
+      }
+    }
+    this.updateManualAlertSetButtonState();
+  },
+  async loadManualAlertTrigger() {
+    const result = await App.data.loadManualAlertTrigger();
+    if (result && result.ok) {
+      this.applyManualAlertTriggerState(result.trigger);
+    }
+    return result;
+  },
+  buildManualAlertTriggerPayload() {
+    const activeTrigger = App.state.manualAlertTrigger || {};
+    const template = this.manualAlertSelectedTemplate() || (activeTrigger.enabled ? activeTrigger.template : null);
+    const price = this.parseManualAlertPriceInput();
+    if (!template || price == null) return null;
+    return {
+      enabled: true,
+      price,
+      template: {
+        title: template.title,
+        message: template.message
+      }
+    };
+  },
+  async saveManualAlertTrigger(trigger, { quiet = false } = {}) {
+    const status = this.elements.manualAlertStatus;
+    const result = await App.data.saveManualAlertTrigger(trigger);
+    if (!result || !result.ok) {
+      if (!quiet) {
+        status.textContent = (result && result.error) || "Set failed";
+        status.classList.add("error");
+      }
+      this.updateManualAlertSetButtonState();
+      return false;
+    }
+    this.applyManualAlertTriggerState(result.trigger);
+    if (!quiet) {
+      status.textContent = result.trigger.enabled ? "Set" : "Unset";
+      status.classList.remove("error");
+    }
+    return true;
+  },
+  async setManualAlertTriggerFromInput({ moveMenu = false } = {}) {
+    const status = this.elements.manualAlertStatus;
+    this.clearManualAlertTriggerSyncTimer();
+    const trigger = this.buildManualAlertTriggerPayload();
+    if (!trigger) {
+      status.textContent = "Select template and price";
+      status.classList.add("error");
+      this.updateManualAlertSetButtonState();
+      return false;
+    }
+    status.textContent = "Setting...";
+    status.classList.remove("error");
+    this.elements.manualAlertSet.disabled = true;
+    const saved = await this.saveManualAlertTrigger(trigger);
+    if (saved && moveMenu) {
+      this.moveManualAlertMenuToPrice(trigger.price);
+    }
+    this.updateManualAlertSetButtonState();
+    return saved;
+  },
+  async saveManualAlertTriggerPriceFromLine(price) {
+    const trigger = App.state.manualAlertTrigger || {};
+    const n = Number(price);
+    if (!trigger.enabled || !Number.isFinite(n)) return false;
+    const template = trigger.template || {};
+    if (!template.title || !template.message) return false;
+    return await this.saveManualAlertTrigger({
+      enabled: true,
+      price: n,
+      template: {
+        title: template.title,
+        message: template.message
+      }
+    }, { quiet: true });
+  },
+  async unsetManualAlertTriggerFromLine() {
+    if (!this.manualAlertTriggerActive()) return false;
+    this.clearManualAlertTriggerSyncTimer();
+    return await this.saveManualAlertTrigger({ enabled: false }, { quiet: true });
+  },
+  scheduleManualAlertTriggerSync() {
+    if (!this.manualAlertTriggerActive()) return;
+    if (this.manualAlertArmedInputDirty) return;
+    if (this.manualAlertTriggerSyncTimer !== null) {
+      clearTimeout(this.manualAlertTriggerSyncTimer);
+    }
+    this.manualAlertTriggerSyncTimer = setTimeout(() => {
+      this.manualAlertTriggerSyncTimer = null;
+      if (!this.manualAlertTriggerActive()) return;
+      const trigger = this.buildManualAlertTriggerPayload();
+      if (trigger) this.saveManualAlertTrigger(trigger, { quiet: true });
+    }, 250);
+  },
+  flushManualAlertTriggerSync() {
+    this.clearManualAlertTriggerSyncTimer();
+    if (!this.manualAlertTriggerActive()) return;
+    if (this.manualAlertArmedInputDirty) {
+      this.restoreManualAlertActiveTriggerPrice();
+      return;
+    }
+    const trigger = this.buildManualAlertTriggerPayload();
+    if (trigger) this.saveManualAlertTrigger(trigger, { quiet: true });
+  },
+  async toggleManualAlertTrigger() {
+    if (this.manualAlertTriggerActive()) {
+      this.clearManualAlertTriggerSyncTimer();
+      await this.saveManualAlertTrigger({ enabled: false });
+      return;
+    }
+    await this.setManualAlertTriggerFromInput({ moveMenu: true });
+  },
   buildManualAlertPayload(pending) {
     if (pending && pending.message !== undefined) return pending;
     const template = pending.template;
@@ -401,7 +612,7 @@ App.ui = {
     return pos;
   },
   manualAlertPriceCenterY() {
-    const rect = this.elements.manualAlertPrice.getBoundingClientRect();
+    const rect = this.elements.manualAlertPriceInput.getBoundingClientRect();
     return rect.top + rect.height / 2;
   },
   updateManualAlertPriceFromMenu() {
@@ -409,20 +620,21 @@ App.ui = {
     if (!context || !App.chart || !App.chart.priceFromClientY) return;
     const price = App.chart.priceFromClientY(this.manualAlertPriceCenterY());
     if (price == null) return;
-    context.price = price;
-    this.elements.manualAlertPrice.textContent = `Price ${this.formatNumber(price, 2)}`;
-    App.chart.updateManualAlertPriceGuide(price);
+    this.setManualAlertPriceValue(price);
+    this.scheduleManualAlertTriggerSync();
   },
-  positionManualAlertMenu(x, y) {
+  positionManualAlertMenu(x, y, { updatePrice = true } = {}) {
     const menu = this.elements.manualAlertMenu;
     menu.classList.remove("hidden");
     menu.style.left = "8px";
     menu.style.top = "8px";
     const menuRect = menu.getBoundingClientRect();
-    const priceRect = this.elements.manualAlertPrice.getBoundingClientRect();
+    const priceRect = this.elements.manualAlertPriceInput.getBoundingClientRect();
     const priceOffsetY = (priceRect.top - menuRect.top) + priceRect.height / 2;
     this.setManualAlertMenuPosition(x + 10, y - priceOffsetY);
-    this.updateManualAlertPriceFromMenu();
+    if (updatePrice) {
+      this.updateManualAlertPriceFromMenu();
+    }
   },
   closeManualAlertTemplateList() {
     App.state.manualAlertTemplateOpen = false;
@@ -512,6 +724,8 @@ App.ui = {
       option.setAttribute("aria-selected", active ? "true" : "false");
     });
     this.closeManualAlertTemplateList();
+    this.updateManualAlertSetButtonState();
+    this.scheduleManualAlertTriggerSync();
   },
   renderManualAlertTemplatePicker(templates) {
     const button = this.elements.manualAlertTemplateButton;
@@ -543,44 +757,77 @@ App.ui = {
     if (options.firstElementChild) {
       options.firstElementChild.classList.add("active");
     }
+    this.updateManualAlertSetButtonState();
   },
   async showManualAlertMenu(context) {
     const status = this.elements.manualAlertStatus;
+    const trigger = App.state.manualAlertTrigger || { enabled: false };
+    const triggerActive = trigger.enabled && Number.isFinite(Number(trigger.price));
+    if (triggerActive) {
+      context.price = Number(trigger.price);
+    }
     App.state.manualAlertContext = context;
     App.state.manualAlertMenuOpen = true;
+    this.refreshMobileViewportLock();
     App.state.manualAlertSuppressClickUntil = Date.now() + 500;
-    this.elements.manualAlertPrice.textContent = `Price ${this.formatNumber(context.price, 2)}`;
+    this.elements.manualAlertPriceInput.value = this.formatPriceInput(context.price);
     this.elements.manualAlertTemplateLabel.textContent = "Loading...";
     this.elements.manualAlertTemplateButton.disabled = true;
     this.elements.manualAlertTemplateOptions.innerHTML = "";
     this.closeManualAlertTemplateList();
     this.elements.manualAlertSend.disabled = true;
+    this.updateManualAlertSetButtonState();
     status.textContent = "Loading...";
     status.classList.remove("error");
-    this.positionManualAlertMenu(context.clientX, context.clientY);
+    let anchorY = context.clientY;
+    let updatePrice = true;
+    if (triggerActive && App.chart && App.chart.clientYFromPrice) {
+      const triggerY = App.chart.clientYFromPrice(context.price);
+      if (triggerY != null) {
+        anchorY = triggerY;
+      } else {
+        updatePrice = false;
+      }
+    }
+    this.positionManualAlertMenu(context.clientX, anchorY, { updatePrice });
+    if (triggerActive) {
+      this.applyManualAlertTriggerState(trigger);
+    }
 
     const templates = await this.loadManualAlertTemplates({ migrateLocal: true });
     if (App.state.manualAlertContext !== context) return;
     this.renderManualAlertTemplatePicker(templates);
+    if (triggerActive && trigger.template && trigger.template.title) {
+      const index = templates.findIndex(t => t.title === trigger.template.title && t.message === trigger.template.message);
+      if (index >= 0) this.selectManualAlertTemplate(index);
+    }
     this.elements.manualAlertSend.disabled = templates.length === 0;
     status.textContent = templates.length ? "" : "No templates";
     status.classList.toggle("error", templates.length === 0);
+    this.updateManualAlertSetButtonState();
   },
   closeManualAlertMenu() {
     this.manualAlertDragState = null;
+    this.flushManualAlertTriggerSync();
+    if (this.elements.manualAlertMenu.contains(document.activeElement)) {
+      document.activeElement.blur();
+    }
     if (this.manualAlertStatusClearTimer !== null) {
       clearTimeout(this.manualAlertStatusClearTimer);
       this.manualAlertStatusClearTimer = null;
     }
     App.state.manualAlertContext = null;
     App.state.manualAlertMenuOpen = false;
+    this.refreshMobileViewportLock();
     this.elements.manualAlertMenu.classList.add("hidden");
     this.elements.manualAlertStatus.textContent = "";
     this.elements.manualAlertStatus.classList.remove("error");
     this.closeManualAlertTemplateList();
     this.closeManualAlertConfirm();
     App.state.manualAlertSelectedTemplateIndex = -1;
-    if (App.chart && App.chart.removeManualAlertPriceGuide) {
+    if (this.manualAlertTriggerActive()) {
+      this.applyManualAlertTriggerState(App.state.manualAlertTrigger);
+    } else if (App.chart && App.chart.removeManualAlertPriceGuide) {
       App.chart.removeManualAlertPriceGuide();
     }
     if (App.chart && App.chart.restoreMagnetMode) {
@@ -589,6 +836,7 @@ App.ui = {
   },
   startManualAlertDrag(e) {
     if (e.pointerType === "mouse" && e.button !== 0) return;
+    if (e.target && e.target.closest && e.target.closest("input, button, textarea, select")) return;
     this.closeManualAlertTemplateList();
     const menu = this.elements.manualAlertMenu;
     const rect = menu.getBoundingClientRect();
@@ -612,6 +860,7 @@ App.ui = {
   endManualAlertDrag(e) {
     if (this.manualAlertDragState && this.manualAlertDragState.pointerId === e.pointerId) {
       this.manualAlertDragState = null;
+      this.flushManualAlertTriggerSync();
     }
   },
   async sendManualAlertFromMenu() {
@@ -621,7 +870,13 @@ App.ui = {
     const template = templates[index];
     const status = this.elements.manualAlertStatus;
     if (!context || !template) return;
-    this.updateManualAlertPriceFromMenu();
+    const inputPrice = this.parseManualAlertPriceInput();
+    if (inputPrice == null) {
+      status.textContent = "Invalid price";
+      status.classList.add("error");
+      return;
+    }
+    this.setManualAlertPriceValue(inputPrice, { updateInput: false });
     try {
       this.buildManualAlertMessage(template, {
         ...context,
@@ -891,7 +1146,7 @@ App.ui = {
   },
   refreshMobileViewportLock() {
     const templateOpen = !this.elements.alertTemplateModal.classList.contains("hidden");
-    this.setMobileViewportLock(App.state.sourcePanelOpen || templateOpen);
+    this.setMobileViewportLock(App.state.sourcePanelOpen || templateOpen || App.state.manualAlertMenuOpen);
   },
   getSourcePaneBounds() {
     const viewportWidth = Math.max(1, window.innerWidth || document.documentElement.clientWidth || 1);
@@ -977,6 +1232,8 @@ App.ui = {
       alertTemplateAdd,
       alertTemplateSave,
       manualAlertDrag,
+      manualAlertPriceInput,
+      manualAlertSet,
       manualAlertTemplateButton,
       manualAlertSend,
       manualAlertConfirm,
@@ -1033,6 +1290,57 @@ App.ui = {
 
     manualAlertSend.addEventListener("click", () => {
       this.sendManualAlertFromMenu();
+    });
+
+    manualAlertSet.addEventListener("click", () => {
+      this.toggleManualAlertTrigger();
+    });
+
+    manualAlertPriceInput.addEventListener("keydown", (e) => {
+      if (e.key !== "Enter") return;
+      e.preventDefault();
+      e.stopPropagation();
+      if (this.manualAlertTriggerActive()) {
+        this.clearManualAlertTriggerSyncTimer();
+        this.restoreManualAlertActiveTriggerPrice();
+        return;
+      }
+      const price = this.parseManualAlertPriceInput();
+      if (price != null) {
+        this.elements.manualAlertPriceInput.value = this.formatPriceInput(price);
+        this.setManualAlertPriceValue(price, { updateInput: false });
+      }
+      this.setManualAlertTriggerFromInput({ moveMenu: true });
+    });
+
+    manualAlertPriceInput.addEventListener("input", () => {
+      const price = this.parseManualAlertPriceInput();
+      if (this.manualAlertTriggerActive()) {
+        this.manualAlertArmedInputDirty = true;
+        this.clearManualAlertTriggerSyncTimer();
+        this.updateManualAlertSetButtonState();
+        return;
+      }
+      if (price == null) {
+        this.updateManualAlertSetButtonState();
+        return;
+      }
+      this.setManualAlertPriceValue(price, { updateInput: false });
+      this.scheduleManualAlertTriggerSync();
+      this.updateManualAlertSetButtonState();
+    });
+
+    manualAlertPriceInput.addEventListener("change", () => {
+      if (this.manualAlertTriggerActive()) {
+        this.clearManualAlertTriggerSyncTimer();
+        this.restoreManualAlertActiveTriggerPrice();
+        return;
+      }
+      const price = this.parseManualAlertPriceInput();
+      if (price != null) {
+        this.elements.manualAlertPriceInput.value = this.formatPriceInput(price);
+      }
+      this.flushManualAlertTriggerSync();
     });
 
     manualAlertTemplateButton.addEventListener("click", (e) => {

--- a/data_service/templates/ws.js
+++ b/data_service/templates/ws.js
@@ -67,6 +67,23 @@ App.ws = {
           if (msg.data && msg.data.close !== undefined) {
             state.lastPrice = msg.data.close;
           }
+        } else if (msg.type === "manual_alert_trigger") {
+          if (App.ui && App.ui.applyManualAlertTriggerState) {
+            App.ui.applyManualAlertTriggerState(msg.trigger || { enabled: false });
+          }
+        } else if (msg.type === "manual_alert_trigger_fired") {
+          if (App.ui && App.ui.applyManualAlertTriggerState) {
+            App.ui.applyManualAlertTriggerState({ enabled: false });
+          }
+          if (App.ui && App.ui.elements && App.ui.elements.manualAlertStatus) {
+            App.ui.elements.manualAlertStatus.textContent = "Triggered";
+            App.ui.elements.manualAlertStatus.classList.remove("error");
+          }
+        } else if (msg.type === "manual_alert_trigger_error") {
+          if (App.ui && App.ui.elements && App.ui.elements.manualAlertStatus) {
+            App.ui.elements.manualAlertStatus.textContent = msg.error ? `Trigger failed: ${msg.error}` : "Trigger failed";
+            App.ui.elements.manualAlertStatus.classList.add("error");
+          }
         } else if (msg.type === "last_bar_open_fix") {
           if (!msg.data || msg.data.time == null || msg.data.open == null) {
             return;

--- a/workdir/config/realtime_trade.toml
+++ b/workdir/config/realtime_trade.toml
@@ -10,7 +10,7 @@ exchange = "bitget"                         # Exchange name
 symbol = "BTC/USDT:USDT"                    # pyne data download ccxt --list-symbols --symbol BITGET
 timeframe = "1m"                            # 1m, 5m, 1h, 1D, 1W, 1M
 history_since = ""                # "2025-09-01", Download history bar since when? If it's empty, 2 months history for 5m, 1 month for 1m timeframe will be downloaded
-script_name = "demo_1m.py"                  # PyneCore strategy name
+script_name = "demo/demo_1m.py"                  # PyneCore strategy name
 data_service_addr = "0.0.0.0:9001"          # Data && chart servcie address
 
 [webhook]


### PR DESCRIPTION
## 요약
- Manual Alert 모달에서 가격 입력과 Set/Unset 버튼으로 가격 트리거를 저장/해제하도록 추가
- 저장된 트리거를 세션 설정에 유지하고 브라우저 재접속 후에도 차트의 빨간 점선/라벨을 복원
- 실시간 가격이 트리거 라인을 터치하면 선택한 템플릿으로 웹훅/텔레그램 전송 후 자동 해제
- Alert 라벨 드래그와 X 터치 해제, 모바일 입력/버튼/툴 long press 사용성 개선
- 수동 알림 전송 로직을 공통 모듈로 분리하고 기존 거래소별 timeout 정책 유지
- Dashboard Runner 셀 구분선 정렬 문제 수정
- README에 수동 알림 가격 트리거 설명 추가

## 테스트
- node --check data_service/templates/chart.js
- node --check data_service/templates/ui.js
- node --check data_service/templates/data.js
- node --check data_service/templates/ws.js
- node --check data_service/templates/main.js
- node --check data_service/templates/measure.js
- node --check data_service/templates/dashboard.js
- venv/bin/python -m py_compile data_service/config.py data_service/manual_alerts.py data_service/runtime.py data_service/registry.py data_service/api.py
- venv/bin/python data_service/test_manual_alert_trigger.py
- venv/bin/python data_service/test_ws_manager.py