### PR TITLE
로그 모달 SSE 스트리밍 적용

### DIFF
--- a/data_service/api.py
+++ b/data_service/api.py
@@ -2,12 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import ast
+import json
 from datetime import datetime, UTC
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, AsyncIterator, Dict, List, Optional
 
-from fastapi import APIRouter, Body
-from fastapi.responses import JSONResponse
+from fastapi import APIRouter, Body, Request
+from fastapi.responses import JSONResponse, StreamingResponse
 
 from pynecore.cli.app import app_state
 from pynecore.core.exchange_policy import tradingview_hides_zero_volume
@@ -30,6 +31,18 @@ from ohlcv_io import make_ccxt_pro_client
 # Cache of exchange -> set(symbols) so symbol validation hits the network at most
 # once per exchange for the hub's lifetime.
 _markets_cache: dict[str, set] = {}
+
+
+def _tail_log_text(log_path: Path, lines: int) -> tuple[str, int]:
+    data = log_path.read_bytes()
+    text = data.decode("utf-8", errors="replace")
+    tail = "\n".join(text.splitlines()[-lines:])
+    return tail, len(data)
+
+
+def _sse_event(event: str, payload: dict[str, Any]) -> str:
+    data = json.dumps(payload, ensure_ascii=False)
+    return f"event: {event}\ndata: {data}\n\n"
 
 
 async def _load_exchange_symbols(exchange: str) -> set:
@@ -517,11 +530,73 @@ def build_control_router(registry: SessionRegistry) -> APIRouter:
         if not log_path.exists():
             return JSONResponse({"log": ""})
         try:
-            content = log_path.read_text(encoding="utf-8", errors="replace")
-            tail = "\n".join(content.splitlines()[-lines:])
+            tail, _ = _tail_log_text(log_path, lines)
         except Exception as e:
             return JSONResponse({"error": f"failed to read log: {e}"}, status_code=500)
         return JSONResponse({"log": tail})
+
+    @r.get("/api/sessions/{session_id}/runner/logs/stream", response_model=None)
+    async def runner_logs_stream(
+        request: Request,
+        session_id: str,
+        lines: int = 500,
+    ):
+        rt = registry.get(session_id)
+        if rt is None:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        log_path = rt.paths.log_path
+        lines = max(1, min(int(lines or 500), 5000))
+
+        async def events() -> AsyncIterator[str]:
+            offset = 0
+            try:
+                if log_path.exists():
+                    tail, offset = await asyncio.to_thread(_tail_log_text, log_path, lines)
+                else:
+                    tail = ""
+                yield _sse_event("snapshot", {"log": tail})
+            except Exception as e:
+                yield _sse_event("stream_error", {"error": f"failed to read log: {e}"})
+
+            heartbeat_after = 0
+            while not await request.is_disconnected():
+                try:
+                    if not log_path.exists():
+                        if offset != 0:
+                            offset = 0
+                            yield _sse_event("snapshot", {"log": ""})
+                    else:
+                        size = log_path.stat().st_size
+                        if size < offset:
+                            tail, offset = await asyncio.to_thread(_tail_log_text, log_path, lines)
+                            yield _sse_event("snapshot", {"log": tail})
+                        elif size > offset:
+                            def read_chunk() -> tuple[str, int]:
+                                with log_path.open("rb") as fh:
+                                    fh.seek(offset)
+                                    chunk = fh.read(size - offset)
+                                return chunk.decode("utf-8", errors="replace"), size
+
+                            chunk_text, offset = await asyncio.to_thread(read_chunk)
+                            if chunk_text:
+                                yield _sse_event("append", {"chunk": chunk_text})
+                except Exception as e:
+                    yield _sse_event("stream_error", {"error": f"failed to stream log: {e}"})
+
+                heartbeat_after += 1
+                if heartbeat_after >= 30:
+                    heartbeat_after = 0
+                    yield ": heartbeat\n\n"
+                await asyncio.sleep(0.5)
+
+        return StreamingResponse(
+            events(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache",
+                "X-Accel-Buffering": "no",
+            },
+        )
 
     @r.delete("/api/sessions/{session_id}/runner/logs")
     def clear_runner_logs(session_id: str) -> JSONResponse:

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -529,7 +529,10 @@
   let logSession = null;
   let logRequestSeq = 0;
   let logAbort = null;
+  let logSource = null;
+  let logShowingPlaceholder = false;
   let savedScrollY = 0;
+  const MAX_LOG_CHARS = 600000;
 
   // Lock the page behind the modal (iOS-safe position:fixed technique) so
   // scrolling inside the log panel doesn't bleed through to the dashboard.
@@ -566,6 +569,49 @@
     }
   }
 
+  function closeLogStream() {
+    if (logSource) {
+      logSource.close();
+      logSource = null;
+    }
+  }
+
+  function logSelectionInside(pre) {
+    const selection = window.getSelection && window.getSelection();
+    if (!selection || selection.isCollapsed) return false;
+    return pre.contains(selection.anchorNode) || pre.contains(selection.focusNode);
+  }
+
+  function shouldFollowLogTail(pre) {
+    if (logSelectionInside(pre)) return false;
+    return pre.scrollTop + pre.clientHeight >= pre.scrollHeight - 30;
+  }
+
+  function setLogContent(text) {
+    const pre = el("log-content");
+    const log = text && text.length ? text : "(no log output yet)";
+    logShowingPlaceholder = !text || !text.length;
+    pre.textContent = log;
+    pre.scrollTop = pre.scrollHeight;
+  }
+
+  function appendLogContent(chunk) {
+    if (!chunk) return;
+    const pre = el("log-content");
+    const followTail = shouldFollowLogTail(pre);
+    if (logShowingPlaceholder) {
+      pre.textContent = "";
+      logShowingPlaceholder = false;
+    } else if (pre.textContent && !pre.textContent.endsWith("\n") && !chunk.startsWith("\n")) {
+      chunk = `\n${chunk}`;
+    }
+    pre.appendChild(document.createTextNode(chunk));
+    if (!logSelectionInside(pre) && pre.textContent.length > MAX_LOG_CHARS) {
+      pre.textContent = pre.textContent.slice(-MAX_LOG_CHARS);
+    }
+    if (followTail) pre.scrollTop = pre.scrollHeight;
+  }
+
   async function fetchLogs(sessionId, seq) {
     if (!sessionId || seq !== logRequestSeq) return;
     const controller = new AbortController();
@@ -578,9 +624,10 @@
       if (logAbort === controller) logAbort = null;
       if (seq !== logRequestSeq || logSession !== sessionId) return;
       const pre = el("log-content");
-      const atBottom = pre.scrollTop + pre.clientHeight >= pre.scrollHeight - 30;
-      pre.textContent = data.log && data.log.length ? data.log : "(no log output yet)";
-      if (atBottom) pre.scrollTop = pre.scrollHeight;  // follow tail unless user scrolled up
+      const followTail = shouldFollowLogTail(pre);
+      logShowingPlaceholder = !(data.log && data.log.length);
+      pre.textContent = logShowingPlaceholder ? "(no log output yet)" : data.log;
+      if (followTail) pre.scrollTop = pre.scrollHeight;  // follow tail unless user scrolled up
     } catch (e) {
       if (logAbort === controller) logAbort = null;
       if (e.name === "AbortError" || seq !== logRequestSeq || logSession !== sessionId) return;
@@ -594,17 +641,62 @@
     logTimer = setTimeout(() => pollLogs(sessionId, seq), 1500);
   }
 
+  function streamLogs(sessionId, seq) {
+    if (!window.EventSource) {
+      pollLogs(sessionId, seq);
+      return;
+    }
+    const url = `/api/sessions/${encodeURIComponent(sessionId)}/runner/logs/stream?lines=500`;
+    const source = new EventSource(url);
+    logSource = source;
+
+    source.addEventListener("snapshot", (ev) => {
+      if (seq !== logRequestSeq || logSession !== sessionId || logSource !== source) return;
+      try {
+        const data = JSON.parse(ev.data || "{}");
+        setLogContent(data.log || "");
+      } catch {
+        setLogContent("");
+      }
+    });
+
+    source.addEventListener("append", (ev) => {
+      if (seq !== logRequestSeq || logSession !== sessionId || logSource !== source) return;
+      try {
+        const data = JSON.parse(ev.data || "{}");
+        appendLogContent(data.chunk || "");
+      } catch {}
+    });
+
+    source.addEventListener("stream_error", (ev) => {
+      if (seq !== logRequestSeq || logSession !== sessionId || logSource !== source) return;
+      try {
+        const data = JSON.parse(ev.data || "{}");
+        appendLogContent(`\n[log stream] ${data.error || "stream error"}\n`);
+      } catch {
+        appendLogContent("\n[log stream] stream error\n");
+      }
+    });
+
+    source.onerror = () => {
+      // EventSource reconnects automatically. Keep the current log content so
+      // text selection and scroll position are not disturbed by transient errors.
+    };
+  }
+
   function openLogs(id) {
     clearLogTimer();
     cancelLogFetch();
+    closeLogStream();
     logSession = id;
     logRequestSeq += 1;
     const seq = logRequestSeq;
     el("log-title").textContent = id;
     el("log-content").textContent = "loading…";
+    logShowingPlaceholder = true;
     el("log-modal").classList.remove("hidden");
     lockBodyScroll();
-    pollLogs(id, seq);
+    streamLogs(id, seq);
   }
 
   function closeLogs() {
@@ -612,9 +704,11 @@
     logRequestSeq += 1;
     clearLogTimer();
     cancelLogFetch();
+    closeLogStream();
     el("log-modal").classList.add("hidden");
     unlockBodyScroll();
     logSession = null;
+    logShowingPlaceholder = false;
   }
 
   async function clearLogs() {
@@ -622,14 +716,16 @@
     if (!sessionId) return;
     clearLogTimer();
     cancelLogFetch();
+    closeLogStream();
     logRequestSeq += 1;
     const seq = logRequestSeq;
     try {
       await api(`/api/sessions/${encodeURIComponent(sessionId)}/runner/logs`, { method: "DELETE" });
       if (seq !== logRequestSeq || logSession !== sessionId) return;
       el("log-content").textContent = "(cleared)";
+      logShowingPlaceholder = true;
       logRequestSeq += 1;
-      pollLogs(sessionId, logRequestSeq);
+      streamLogs(sessionId, logRequestSeq);
     } catch (e) {
       alert(`clear failed: ${e.message}`);
     }


### PR DESCRIPTION
## 변경 사항
- 로그 모달을 열 때 runner.log를 SSE(EventSource)로 구독하도록 변경했습니다.
- 최초 로딩은 snapshot 이벤트로 최근 로그를 받고, 이후 새 로그는 append 이벤트로 추가합니다.
- EventSource를 지원하지 않는 브라우저에서는 기존 polling 방식으로 fallback합니다.
- 로그 truncate/clear 상황에서는 snapshot을 다시 전송하고, stream_error 및 heartbeat 처리를 추가했습니다.
- append chunk 경계에서 줄바꿈이 누락되지 않도록 보정했습니다.

## 영향 범위
- 변경 범위는 로그 조회 API와 대시보드 로그 모달 UI입니다.
- 전략 계산, pre_run, run_ready 계산, 캔들 갱신 로직에는 관여하지 않습니다.
- SSE 스트림은 로그 모달을 열었을 때만 runner.log를 읽고, 닫으면 EventSource를 종료합니다.