### PR TITLE
Codex 기반 AI 통합 및 전략 자동 지시 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@ tests
 __pycache__
 .claude
 test*.py
+ai/scripts/*_test.py
 .env
+/tmp/
 workdir/scripts/*.toml
 workdir/config/providers.toml
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ workdir/config/providers.toml
 
 # Ignore runtime session state and per-session output (hub)
 workdir/config/sessions.json
+workdir/config/ai_chat.json
 workdir/output/realtime/
 
 # Ignore SQLite cache files but keep the directory

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Repository AI Instructions
+
+For AI-driven position evaluation, account inspection, market analysis, or
+session analysis tasks, read and follow `ai/INSTRUCTIONS.md` first.
+
+Prefer the dedicated tools under `ai/scripts/` over ad hoc API calls. Keep data
+collection read-only unless the user explicitly requests an action, and never
+print credentials or secrets from configuration files.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,66 @@
 # PyneReal
+
+<p align="center">
+  <a href="https://www.python.org/"><img src="https://img.shields.io/badge/python-3.11%2B-blue" alt="Python 3.11+"></a>
+  <a href="LICENSE.txt"><img src="https://img.shields.io/badge/license-Apache--2.0-green" alt="License: Apache-2.0"></a>
+</p>
+
 <p align="center">
   <img src="docs/images/dashboard-desktop.png" alt="PyneReal dashboard" width="900">
 </p>
 
 Run your crypto trading strategy in real time without TradingView.
+
+## ✨ Highlights
+
+- 🤖 **AI copilot** — chat with your running strategies, inspect balances and
+  positions across every exchange account, and set price alerts in plain
+  language
+- ⚡ Realtime [PyneCore](https://github.com/PyneSys/pynecore) strategy runner —
+  signal to exchange in under a second after candle confirmation
+- 📊 Bitget, Hyperliquid, OKX, Binance, and Bybit supported
+- 🔔 Webhook, Telegram, and draggable manual price alerts on the chart
+- 📱 Full mobile dashboard
+
+## 🤖 AI Copilot
+
+<!-- TODO: record a 10-15s GIF of the AI chat setting a price trigger
+     (red trigger line appearing on the chart), save it as
+     docs/images/ai-chat.gif, then uncomment:
+<p align="center">
+  <img src="docs/images/ai-chat.gif" alt="PyneReal AI chat" width="900">
+</p>
+-->
+
+Ask the dashboard chat things like:
+
+> "Show my assets and positions across all Binance accounts"
+>
+> "Set a take-profit alert on the BTC 1m session at 3% above entry"
+
+The AI copilot can:
+
+- inspect exchange assets and derivative positions — every configured account
+  at once when you don't name one;
+- set or remove persisted Manual Alert price triggers straight from chat;
+- analyze repository files, running sessions, and public market information;
+- send a finished result to Telegram when you ask for it.
+
+And the unique part — **your strategy can talk to the AI too**. When an order
+fills, its `ai` instruction runs automatically:
+
+```python
+strategy.entry(
+    "Long 3",
+    strategy.long,
+    alert_message=f'{{"signal": "Long 3", "price": {close}}}',
+    ai=f"Set the close2 and close3 manual alerts at {avgEntry * 1.003}",
+)
+```
+
+All account tools are **read-only** — the AI never places or cancels orders,
+changes leverage, or mutates account state.
+See [AI Setup & Details](#ai-setup--details) for configuration.
 
 ## Requirements
 
@@ -280,6 +337,101 @@ values:
 ```json
 {"signal":"CLOSE TP3","ticker":"{{ticker}}","timeframe":"{{timeframe}}"}
 ```
+
+## AI Setup & Details
+
+PyneReal currently integrates OpenAI Codex through a local Codex app-server and
+the dashboard AI chat. It uses the current local Codex login rather than an
+OpenAI API key. The `codex` executable must be available on the host. When no
+authenticated account is found in an interactive terminal, data-service asks
+whether to enable AI and can start device-code login. Run `codex login` before
+starting data-service on a non-interactive server.
+
+Dashboard AI can:
+
+- inspect exchange assets and derivative positions with the read-only scripts
+  under `ai/scripts`;
+- query every configured account when no exchange or account is specified;
+- analyze repository files, running sessions, and publicly available market
+  information;
+- set or remove persisted Manual Alert price triggers, including adding a
+  missing template when its title and JSON message are explicitly supplied;
+- send a completed result to the fixed Telegram destination when explicitly
+  requested; and
+- edit existing files only under `workdir/`, `modules/`, and
+  `data_service/templates/` when explicitly requested, or create new files
+  under `tmp/`.
+
+### Exchange Account Access
+
+Put exchange credentials in the local file below if AI should inspect account
+balances or positions:
+
+```text
+workdir/config/providers.toml
+```
+
+The file is created from `providers.example.toml` when missing and is excluded
+from Git. Do not commit or print its contents. Grant API keys only the minimum
+read permissions required for the intended lookup.
+
+```toml
+[ccxt.binance]
+apiKey = "your_binance_api_key"
+secret = "your_binance_secret"
+
+[ccxt.bitget]
+apiKey = "your_bitget_api_key"
+secret = "your_bitget_secret"
+password = "your_bitget_passphrase"
+```
+
+Multiple accounts on the same exchange can be configured with named account
+tables:
+
+```toml
+[ccxt_accounts.binance_main]
+exchange = "binance"
+apiKey = "your_main_api_key"
+secret = "your_main_secret"
+
+[ccxt_accounts.binance_sub1]
+exchange = "binance"
+apiKey = "your_subaccount_api_key"
+secret = "your_subaccount_secret"
+```
+
+A general asset request checks spot, futures, margin, funding, and supported
+earn balances. A general position request checks the supported derivative
+markets for every selected account. Unsupported account types and partial API
+failures are reported without exposing credentials. These AI account tools are
+read-only and do not place or cancel exchange orders.
+
+### Strategy AI Instructions
+
+Realtime `strategy.entry` and `strategy.close` orders can provide an `ai`
+instruction. The instruction runs only after the order fills on the latest
+confirmed bar and is restricted to the originating session.
+
+```python
+strategy.entry(
+    "Long 3",
+    strategy.long,
+    alert_message=f'{{"signal": "Long 3", "price": {close}}}',
+    ai=f"Set the close2 and close3 manual alerts at {avgEntry * 1.003}",
+)
+```
+
+The runner does not wait for the AI response. Strategy instructions run
+independently from dashboard chat and from other sessions, while instructions
+from the same session run in event order. The instruction and final result are
+stored in shared dashboard chat history. Automated instructions are ignored
+during historical backtests and skipped when the AI service is disabled.
+
+Values such as `avgEntry` or `close` are not automatically included. Put values
+required by the instruction in the `ai` string, usually with an f-string. AI
+never invents a missing Manual Alert title or JSON message, but it can create a
+missing template when both are explicitly included in the instruction.
 
 ## Backtesting
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ See [AI Setup & Details](#ai-setup--details) for configuration.
 
 - Python 3.11+ (3.14+ recommended)
 - **[PyneCore](https://github.com/PyneSys/pynecore)** strategy file under `workdir/scripts`
+- Optional AI Copilot: an OpenAI account with Codex access
 
 ## Supported Exchanges
 
@@ -342,10 +343,12 @@ values:
 
 PyneReal currently integrates OpenAI Codex through a local Codex app-server and
 the dashboard AI chat. It uses the current local Codex login rather than an
-OpenAI API key. The `codex` executable must be available on the host. When no
-authenticated account is found in an interactive terminal, data-service asks
-whether to enable AI and can start device-code login. Run `codex login` before
-starting data-service on a non-interactive server.
+OpenAI API key. The Codex runtime is installed automatically by `setup.sh`
+through the `openai-codex` dependency, so no separate Codex CLI installation is
+required. When no authenticated account is found in an interactive terminal,
+data-service asks whether to enable AI and can start device-code login. Before
+running data-service non-interactively, start it once in an interactive terminal
+and complete that login.
 
 Dashboard AI can:
 

--- a/ai/INSTRUCTIONS.md
+++ b/ai/INSTRUCTIONS.md
@@ -70,6 +70,13 @@ internals when an existing script already provides the required data.
 
 - Change Manual Alert state only when the user explicitly asks to set or delete
   price triggers.
+- A server-verified instruction generated from the `ai` parameter of
+  `strategy.entry` or `strategy.close` is an explicit user request authored in
+  the strategy. Execute only its stated scope and use the exact session ID
+  supplied by the server.
+- Do not ask the user to identify the session for an automated strategy
+  instruction. If another required value or template is missing, report the
+  missing requirement instead of guessing.
 - Call `get_manual_alert_context` first and use only the exact active session ID,
   template index, and current state returned by the tool.
 - The user identifies a session with a symbol, company or asset name, exchange,

--- a/ai/INSTRUCTIONS.md
+++ b/ai/INSTRUCTIONS.md
@@ -1,0 +1,70 @@
+# Shared AI Instructions
+
+## Purpose
+
+Use deterministic local scripts to collect session, account, position, and
+market data, then evaluate that evidence. Do not rediscover APIs or application
+internals when an existing script already provides the required data.
+
+## Required Process
+
+1. Select the workflow under `ai/workflows/` that matches the request.
+2. Run only the scripts required by that workflow.
+3. Treat script JSON output as the factual input to the evaluation.
+4. Clearly distinguish observed facts from interpretation and uncertainty.
+5. Return the final evaluation without exposing internal credentials or secret
+   configuration values.
+
+## Account Selection
+
+- When an asset or position request does not name an account or exchange, query
+  every account configured in `workdir/config/providers.toml` by running the
+  relevant script without `--account` or `--exchange`.
+- When only an exchange is named, use `--exchange <exchange>` to query every
+  configured account for that exchange.
+- When a configured account name is given, use `--account <account>` to query
+  only that account.
+- Do not ask the user to select an account when neither an account nor an
+  exchange was specified; the default is all configured accounts.
+
+## Safety
+
+- Data collection is read-only by default.
+- Never place API keys, secrets, passphrases, tokens, or private keys in prompts,
+  command arguments, logs, or output.
+- Scripts that can trade, transfer, withdraw, or mutate server state must be
+  separate from read-only scripts and require explicit execution confirmation.
+- Do not execute a state-changing script unless the user explicitly requests
+  that exact action.
+- Redact sensitive fields if an upstream API unexpectedly returns them.
+
+## Script Contract
+
+- Put reusable Python tools in `ai/scripts/`.
+- Write machine-readable results as JSON to standard output.
+- Write progress messages and diagnostics to standard error.
+- Exit with a non-zero status when required data cannot be collected reliably.
+- Include the schema version, collection time, source, and relevant session or
+  account identifiers in the result.
+- Keep exchange-specific normalization inside the script so workflows receive a
+  stable data shape.
+
+## Evaluation Rules
+
+- Do not infer a current position, balance, order, or price from stale context.
+- Include the observation time when evaluating live account or market state.
+- State missing or stale evidence explicitly.
+- Do not present a trading interpretation as guaranteed future performance.
+
+## User-visible Progress
+
+- Keep intermediate commentary useful and concrete. Report the account or
+  exchange currently being queried, meaningful collection progress, partial
+  failures, retries, or missing evidence.
+- Do not expose internal preparation such as reading instruction files,
+  exploring the repository, selecting a workflow, checking script options, or
+  planning how the result will be organized.
+- Do not announce that instructions or execution options will be checked before
+  the lookup. Start the required lookup and report only material progress.
+- For asset and position lookups, begin the final response with the observation
+  time and collected result. Omit workflow narration and generic preambles.

--- a/ai/INSTRUCTIONS.md
+++ b/ai/INSTRUCTIONS.md
@@ -36,7 +36,71 @@ internals when an existing script already provides the required data.
   separate from read-only scripts and require explicit execution confirmation.
 - Do not execute a state-changing script unless the user explicitly requests
   that exact action.
+- Manual Alert trigger changes must use the dedicated dynamic tools and follow
+  the confirmation rules below; do not edit session configuration files.
 - Redact sensitive fields if an upstream API unexpectedly returns them.
+
+## File Access And Editing
+
+- Read files outside this repository only when required by the user's request.
+- Do not modify files unless the user explicitly requests a file change.
+- Modify only existing regular files under `workdir/`, `modules/`, or
+  `data_service/templates/`.
+- Create new files and directories only under the repository's `tmp/` directory.
+- Use `edit_existing_file` for existing-file changes and `write_tmp_file` for
+  files under `tmp/`. Do not write files through shell commands, `apply_patch`,
+  Python scripts, or any other tool.
+- Do not create files in the editable source directories, and do not delete,
+  rename, or move files or directories outside `tmp/`.
+- After an edit, report the paths that were actually changed.
+
+## Telegram Delivery
+
+- Call `send_telegram_message` only when the user explicitly asks to send the
+  current result to Telegram.
+- Complete the requested lookup first, then send a concise plain-text version
+  of the result. Avoid Markdown tables because Telegram receives plain text.
+- Never read, pass, print, or report `BOT_TOKEN` or `CHAT_ID`; the server loads
+  both values and fixes the destination.
+- Report Telegram delivery as successful only when the tool returns success.
+- A normal asset, position, or analysis request without an explicit Telegram
+  instruction must remain a browser-chat response only.
+
+## Manual Alert Triggers
+
+- Change Manual Alert state only when the user explicitly asks to set or delete
+  price triggers.
+- Call `get_manual_alert_context` first and use only the exact active session ID,
+  template index, and current state returned by the tool.
+- The user identifies a session with a symbol, company or asset name, exchange,
+  timeframe, or strategy name. Resolve that description to the internal session
+  ID yourself. Never ask the user to type a session ID.
+- If the requested session, price, or alert template is missing or can match
+  more than one option, ask about a human-readable distinction such as exchange,
+  timeframe, or strategy name. Do not select one by guessing.
+- When the requested Manual Alert template is not configured in the selected
+  session, ask the user for both its title and message format. Then pass both
+  custom template fields so the tool adds the template and trigger together.
+  Do not tell the user to add it in the dashboard, and do not invent either
+  value.
+- For a session that has configured templates, use the exact selected template
+  index when the requested template already exists.
+- Call `set_manual_alert_trigger` only after all required values are explicit.
+  Report success only when the tool returns `set: true`.
+- For selected deletion, resolve the user's description to exact active trigger
+  IDs and call `delete_manual_alert_triggers`. If multiple triggers match and the
+  user did not say all, ask for a human-readable distinction.
+- Set `delete_all=true` with one session ID only when the user explicitly asks to
+  delete every trigger in that session. Omit the session ID only when the user
+  explicitly asks to delete every Manual Alert across all sessions.
+- When one instruction says to delete every trigger in a session and then set a
+  new trigger in that same session, call `set_manual_alert_trigger` once with
+  `replace_existing_triggers=true`. Do not perform separate delete and set calls.
+- Trigger deletion and replacement must preserve every configured Manual Alert
+  template. Never delete a template without a separate, explicit template
+  deletion request and dedicated tool.
+- Setting a trigger does not send an alert immediately. The existing data
+  service fires and removes it when market price touches the persisted line.
 
 ## Script Contract
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -51,3 +51,13 @@ trigger. When the requested template is missing, a user-supplied title and
 message format are persisted as a new session template together with the price
 trigger. A combined "delete all in this session, then set this trigger" request
 uses the setting tool's atomic replacement option.
+
+## Strategy Instructions
+
+Realtime `strategy.entry` and `strategy.close` orders can provide an `ai`
+instruction. PyneReal sends it to the enabled AI service only when that order
+fills on the latest confirmed bar. The runner queues the event without waiting
+for the AI response; data-service executes it for the exact originating session
+and records the instruction and result in shared dashboard chat history.
+Strategy instructions run independently from dashboard chat and from other
+sessions, while instructions from the same session run in event order.

--- a/ai/README.md
+++ b/ai/README.md
@@ -6,10 +6,48 @@ contracts used when an LLM CLI evaluates a running PyneReal session.
 ## Layout
 
 - `INSTRUCTIONS.md`: common rules for every supported LLM CLI
+- `provider/`: provider-specific chat runtimes and streaming adapters
 - `workflows/`: task-specific procedures and required evidence
-- `scripts/`: deterministic data collection tools
+- `scripts/`: deterministic data collectors and shared dynamic tools
 - `schemas/`: JSON contracts produced by the scripts
 
 CLI-specific entry files such as the repository `AGENTS.md` should stay small
 and point to `INSTRUCTIONS.md`. Do not duplicate the common rules in multiple
 CLI-specific files.
+
+## File Editing
+
+Dashboard Codex threads have read-only filesystem access. Explicit file-change
+requests use the dynamic tools implemented in `ai/scripts/file_tools.py`:
+
+- `edit_existing_file` performs validated exact-text replacements in existing
+  files under `workdir/`, `modules/`, or `data_service/templates/`.
+- `write_tmp_file` creates files and directories only under `tmp/`.
+
+The tool handler validates paths and symbolic links in the data-service process;
+the Codex command sandbox itself never receives filesystem write access.
+
+## Telegram Delivery
+
+`send_telegram_message` sends an explicitly requested AI result to the fixed
+Telegram destination configured by `BOT_TOKEN` and `CHAT_ID` in `.env`. The AI
+supplies only plain-text message content; credentials and the destination are
+loaded and kept inside the data-service process. Long results are split into
+messages of at most 3,900 characters.
+
+## Manual Alert Triggers
+
+Dashboard Codex threads use three server-controlled dynamic tools:
+
+- `get_manual_alert_context` lists active sessions, configured templates,
+  current prices, and existing triggers without exposing webhook credentials.
+- `set_manual_alert_trigger` appends a validated trigger through the existing
+  session registry, which persists it and pushes the updated state to charts.
+- `delete_manual_alert_triggers` removes selected, session-wide, or globally
+  scoped active triggers while preserving configured templates.
+
+The AI must resolve the exact session, price, and template before setting a
+trigger. When the requested template is missing, a user-supplied title and
+message format are persisted as a new session template together with the price
+trigger. A combined "delete all in this session, then set this trigger" request
+uses the setting tool's atomic replacement option.

--- a/ai/README.md
+++ b/ai/README.md
@@ -1,0 +1,15 @@
+# AI Integration
+
+This directory contains the shared instructions, workflows, scripts, and data
+contracts used when an LLM CLI evaluates a running PyneReal session.
+
+## Layout
+
+- `INSTRUCTIONS.md`: common rules for every supported LLM CLI
+- `workflows/`: task-specific procedures and required evidence
+- `scripts/`: deterministic data collection tools
+- `schemas/`: JSON contracts produced by the scripts
+
+CLI-specific entry files such as the repository `AGENTS.md` should stay small
+and point to `INSTRUCTIONS.md`. Do not duplicate the common rules in multiple
+CLI-specific files.

--- a/ai/__init__.py
+++ b/ai/__init__.py
@@ -1,0 +1,1 @@
+"""PyneReal AI integration package."""

--- a/ai/provider/README.md
+++ b/ai/provider/README.md
@@ -10,6 +10,9 @@ Future providers should remain separate modules rather than adding
 provider-specific branches to the Codex implementation.
 
 When the data service starts without a saved Codex login in an interactive
-terminal, the Codex provider starts device-code authentication and waits for it
-to complete. Non-interactive services must authenticate with `codex login`
-before startup.
+terminal, it asks whether to enable the Codex AI service with an Up/Down and
+Enter selector. Selecting `Yes` starts device-code authentication and waits for
+it to complete. Selecting `No` disables AI for that data-service process
+without affecting the remaining services. Unsupported terminals fall back to a
+text prompt. An unauthenticated non-interactive process also leaves AI
+disabled; run `codex login` before startup to enable it there.

--- a/ai/provider/README.md
+++ b/ai/provider/README.md
@@ -8,3 +8,8 @@ while reusing shared tools from `ai/scripts/`.
 
 Future providers should remain separate modules rather than adding
 provider-specific branches to the Codex implementation.
+
+When the data service starts without a saved Codex login in an interactive
+terminal, the Codex provider starts device-code authentication and waits for it
+to complete. Non-interactive services must authenticate with `codex login`
+before startup.

--- a/ai/provider/README.md
+++ b/ai/provider/README.md
@@ -1,0 +1,10 @@
+# AI Providers
+
+Provider-specific chat runtimes live in this directory. Each implementation
+owns its provider lifecycle, conversation state, and streaming response mapping
+while reusing shared tools from `ai/scripts/`.
+
+- `codex_service.py`: OpenAI Codex app-server provider
+
+Future providers should remain separate modules rather than adding
+provider-specific branches to the Codex implementation.

--- a/ai/provider/__init__.py
+++ b/ai/provider/__init__.py
@@ -1,0 +1,1 @@
+"""AI provider implementations used by the PyneReal dashboard."""

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -531,7 +531,10 @@ class CodexService:
             "user request and execute it now. For any session state change, use only the exact "
             "session_id below; do not ask the user to identify the session and do not apply the "
             "instruction to another session. Do not broaden the requested action. If a required "
-            "template or value is missing, report what is missing instead of inventing it.\n\n"
+            "template or value is missing, report what is missing instead of inventing it. "
+            "Respond in the same language as the instruction unless the instruction explicitly "
+            "requests another language. Use that same language for any requested Telegram "
+            "delivery.\n\n"
             f"Exact session and fill context:\n{json.dumps(context, ensure_ascii=False)}\n\n"
             f"Instruction:\n{str(event.get('instruction') or '').strip()}"
         )

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -9,7 +9,7 @@ import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from openai_codex import ApprovalMode, AsyncCodex, AsyncThread, CodexConfig
 from openai_codex.errors import TransportClosedError
@@ -79,6 +79,7 @@ class CodexStreamEvent:
 
 _CHAT_STREAM_END = object()
 ChatStateCallback = Callable[[], Awaitable[None]]
+CodexAuthenticationResult = Literal["ready", "login_completed", "disabled"]
 
 
 class CodexChatRun:
@@ -135,6 +136,7 @@ class CodexService:
             chat_state_path or self.project_root / "workdir" / "config" / "ai_chat.json"
         ).resolve()
         self._codex: AsyncCodex | None = None
+        self._disabled = False
         self._lifecycle_lock = asyncio.Lock()
         self._conversations_lock = asyncio.Lock()
         self._shared_chat_lock = asyncio.Lock()
@@ -150,7 +152,7 @@ class CodexService:
 
     async def start(self) -> None:
         async with self._lifecycle_lock:
-            if self._codex is not None:
+            if self._codex is not None or self._disabled:
                 return
 
             self.dynamic_tools.bind_loop(asyncio.get_running_loop())
@@ -167,7 +169,32 @@ class CodexService:
                 ))
                 self._install_dynamic_tool_handler(codex)
                 await codex.__aenter__()
-                await self._ensure_authenticated(codex)
+                authentication = await self._ensure_authenticated(codex)
+                if authentication == "disabled":
+                    await codex.close()
+                    codex = None
+                    self._disabled = True
+                    self.dynamic_tools.unbind_loop()
+                    print("[ai] Codex AI service disabled")
+                    return
+                if authentication == "login_completed":
+                    print("[ai] Reloading Codex app-server after login...")
+                    await codex.close()
+                    codex = AsyncCodex(CodexConfig(
+                        codex_bin=codex_bin,
+                        cwd=str(self.project_root),
+                        config_overrides=(
+                            'web_search="live"',
+                        ),
+                    ))
+                    self._install_dynamic_tool_handler(codex)
+                    await codex.__aenter__()
+                    account = await codex.account(refresh_token=True)
+                    if account.account is None:
+                        raise RuntimeError(
+                            "Codex login was saved but the restarted app-server "
+                            "did not load an authenticated account"
+                        )
             except Exception:
                 try:
                     if codex is not None:
@@ -184,16 +211,19 @@ class CodexService:
                 f"in {elapsed_ms:.0f}ms"
             )
 
-    async def _ensure_authenticated(self, codex: AsyncCodex) -> None:
+    async def _ensure_authenticated(self, codex: AsyncCodex) -> CodexAuthenticationResult:
         account = await codex.account()
         if account.account is not None:
-            return
+            return "ready"
 
         if not self._interactive_terminal_available():
-            raise RuntimeError(
-                "Codex is not authenticated and interactive login is unavailable; "
-                "start data_service/main.py from a terminal or run `codex login` first"
+            print(
+                "[ai] Codex is not authenticated and no interactive terminal is available"
             )
+            return "disabled"
+
+        if not self._confirm_ai_service_use():
+            return "disabled"
 
         print("[ai] Codex login is required. Starting device-code login...")
         login = await codex.login_chatgpt_device_code()
@@ -202,22 +232,97 @@ class CodexService:
         print("[ai] Waiting for Codex login to complete...")
         try:
             async with asyncio.timeout(_CODEX_LOGIN_TIMEOUT_SECONDS):
-                await login.wait()
+                completion = await login.wait()
         except TimeoutError:
-            await login.cancel()
+            await self._cancel_login(login)
             raise RuntimeError("Codex interactive login timed out") from None
         except asyncio.CancelledError:
-            await login.cancel()
+            await self._cancel_login(login)
             raise
 
-        account = await codex.account(refresh_token=True)
-        if account.account is None:
-            raise RuntimeError("Codex login completed without an authenticated account")
+        if not completion.success:
+            detail = completion.error or "unknown authentication error"
+            raise RuntimeError(f"Codex interactive login failed: {detail}")
         print("[ai] Codex login completed")
+        return "login_completed"
+
+    @staticmethod
+    async def _cancel_login(login: Any) -> None:
+        try:
+            await login.cancel()
+        except Exception:
+            pass
 
     @staticmethod
     def _interactive_terminal_available() -> bool:
         return sys.stdin.isatty() and sys.stdout.isatty()
+
+    @staticmethod
+    def _confirm_ai_service_use() -> bool:
+        try:
+            import termios
+            import tty
+
+            fd = sys.stdin.fileno()
+            previous_settings = termios.tcgetattr(fd)
+        except (ImportError, OSError, AttributeError):
+            return CodexService._confirm_ai_service_use_with_text()
+
+        selected_yes = False
+        rendered = False
+
+        def render() -> None:
+            nonlocal rendered
+            if rendered:
+                sys.stdout.write("\x1b[4A")
+            lines = (
+                "[ai] Enable Codex AI service?",
+                f"  {'>' if selected_yes else ' '} Yes",
+                f"  {' ' if selected_yes else '>'} No",
+                "  Use Up/Down and Enter.",
+            )
+            for line in lines:
+                sys.stdout.write(f"\r\x1b[2K{line}\n")
+            sys.stdout.flush()
+            rendered = True
+
+        try:
+            tty.setraw(fd)
+            sys.stdout.write("\x1b[?25l")
+            render()
+            while True:
+                key = sys.stdin.read(1)
+                if key == "\x1b":
+                    sequence = sys.stdin.read(2)
+                    if sequence in ("[A", "[B", "OA", "OB"):
+                        selected_yes = not selected_yes
+                        render()
+                    continue
+                if key in ("\r", "\n"):
+                    return selected_yes
+                if key.lower() == "y":
+                    return True
+                if key.lower() in ("n", "q") or key == "\x04":
+                    return False
+                if key == "\x03":
+                    raise KeyboardInterrupt
+        finally:
+            termios.tcsetattr(fd, termios.TCSADRAIN, previous_settings)
+            sys.stdout.write("\x1b[?25h")
+            sys.stdout.flush()
+
+    @staticmethod
+    def _confirm_ai_service_use_with_text() -> bool:
+        while True:
+            try:
+                answer = input("[ai] Enable Codex AI service? [y/N]: ").strip().lower()
+            except EOFError:
+                return False
+            if answer in ("y", "yes"):
+                return True
+            if answer in ("", "n", "no"):
+                return False
+            print("[ai] Please enter yes or no")
 
     async def close(self) -> None:
         async with self._lifecycle_lock:
@@ -519,6 +624,8 @@ class CodexService:
         if self._codex is None:
             await self.start()
         if self._codex is None:
+            if self._disabled:
+                raise RuntimeError("Codex AI service was disabled at data-service startup")
             raise RuntimeError("Codex app-server is unavailable")
         return self._codex
 

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -17,6 +17,7 @@ from openai_codex.generated.v2_all import (
     AgentMessageDeltaNotification,
     AgentMessageThreadItem,
     CommandExecutionThreadItem,
+    ConfigReadResponse,
     DynamicToolCallThreadItem,
     ItemCompletedNotification,
     ItemStartedNotification,
@@ -27,6 +28,7 @@ from openai_codex.generated.v2_all import (
     TurnStatus,
     WebSearchThreadItem,
 )
+from pydantic import BaseModel, ConfigDict, Field
 
 from ai.scripts.dynamic_tools import AIDynamicTools
 
@@ -70,8 +72,31 @@ DEFAULT_DEVELOPER_INSTRUCTIONS = (
 _MAX_PERSISTED_MESSAGES = 200
 _MAX_CONTEXT_MESSAGES = 12
 _MAX_PERSISTED_CONTENT_CHARS = 40_000
+# dashboard chat defaults when the user has not picked anything yet
+_PREFERRED_DEFAULT_MODEL = "gpt-5.6-sol"
+_PREFERRED_DEFAULT_EFFORT = ReasoningEffort.medium.value
 _AI_PERMISSION_PROFILE = "pynereal-ai-read-only"
 _CODEX_LOGIN_TIMEOUT_SECONDS = 10 * 60
+
+
+class _CodexModelInfo(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    model: str
+    display_name: str = Field(alias="displayName")
+    description: str = ""
+    hidden: bool = False
+    is_default: bool = Field(default=False, alias="isDefault")
+    supported_reasoning_efforts: list[dict[str, Any]] = Field(
+        default_factory=list,
+        alias="supportedReasoningEfforts",
+    )
+
+
+class _CodexModelListResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="ignore")
+
+    data: list[_CodexModelInfo]
 
 
 @dataclass(frozen=True)
@@ -143,16 +168,22 @@ class CodexService:
         self._disabled = False
         self._lifecycle_lock = asyncio.Lock()
         self._conversations_lock = asyncio.Lock()
+        self._models_lock = asyncio.Lock()
         self._shared_chat_lock = asyncio.Lock()
         self._strategy_instruction_locks: dict[str, asyncio.Lock] = {}
         self._chat_state_lock = asyncio.Lock()
         self._conversations: dict[str, AsyncThread] = {}
         self._turn_locks: dict[str, asyncio.Lock] = {}
+        self._model_options: list[dict[str, Any]] | None = None
         self._shared_chat_tasks: set[asyncio.Task[None]] = set()
         self._pending_shared_chats = 0
         self._warm_thread_task: asyncio.Task[AsyncThread | None] | None = None
         self._chat_messages: list[dict[str, Any]] = []
         self._chat_conversation_id: str | None = None
+        # model/effort picked in the dashboard; persisted so every browser
+        # shares the same selection
+        self._chat_model: str | None = None
+        self._chat_effort: str | None = None
         self._load_chat_state()
 
     @property
@@ -370,6 +401,8 @@ class CodexService:
         conversation_id: str | None = None,
         initial_context: str | None = None,
         history_messages: int = 0,
+        model: str | None = None,
+        effort: str | None = None,
     ) -> AsyncIterator[CodexStreamEvent]:
         request_started_at = time.perf_counter()
         trace_id = uuid.uuid4().hex[:8]
@@ -389,6 +422,8 @@ class CodexService:
                 prompt,
                 trace_id=trace_id,
                 request_started_at=request_started_at,
+                model=model,
+                effort=effort,
             ):
                 yield event
 
@@ -399,6 +434,8 @@ class CodexService:
         client_history: list[dict[str, Any]] | None = None,
         client_conversation_id: str | None = None,
         on_state_changed: ChatStateCallback | None = None,
+        model: str | None = None,
+        effort: str | None = None,
     ) -> CodexChatRun:
         run = CodexChatRun()
         self._pending_shared_chats += 1
@@ -409,6 +446,8 @@ class CodexService:
                 client_history=client_history,
                 client_conversation_id=client_conversation_id,
                 on_state_changed=on_state_changed,
+                model=model,
+                effort=effort,
             ),
             name=f"codex-shared-chat-{run.id}",
         )
@@ -546,12 +585,16 @@ class CodexService:
         client_history: list[dict[str, Any]] | None = None,
         client_conversation_id: str | None = None,
         on_state_changed: ChatStateCallback | None = None,
+        model: str | None = None,
+        effort: str | None = None,
     ) -> AsyncIterator[CodexStreamEvent]:
         run = self.start_shared_chat(
             message,
             client_history=client_history,
             client_conversation_id=client_conversation_id,
             on_state_changed=on_state_changed,
+            model=model,
+            effort=effort,
         )
         async for event in run.events():
             yield event
@@ -564,6 +607,8 @@ class CodexService:
         client_history: list[dict[str, Any]] | None,
         client_conversation_id: str | None,
         on_state_changed: ChatStateCallback | None,
+        model: str | None,
+        effort: str | None,
     ) -> None:
         try:
             async with self._shared_chat_lock:
@@ -579,6 +624,8 @@ class CodexService:
                         conversation_id=conversation_id,
                         initial_context=self._build_initial_context(message, history),
                         history_messages=len(history),
+                        model=model,
+                        effort=effort,
                     ):
                         if event.event == "conversation":
                             await self._set_chat_conversation_id(
@@ -615,6 +662,166 @@ class CodexService:
     async def chat_state(self) -> dict[str, Any]:
         async with self._chat_state_lock:
             return self._chat_state_payload()
+
+    async def model_options(self) -> list[dict[str, Any]]:
+        async with self._models_lock:
+            if self._model_options is not None:
+                return [dict(item) for item in self._model_options]
+            codex = await self._get_codex()
+            client = getattr(codex, "_client", None)
+            if client is None:
+                raise RuntimeError("Installed openai-codex SDK cannot list models")
+            response = await client.request(
+                "model/list",
+                {"includeHidden": False},
+                response_model=_CodexModelListResponse,
+            )
+            options = [
+                {
+                    "value": item.model,
+                    "label": item.display_name,
+                    "description": item.description,
+                    "is_default": item.is_default,
+                    "efforts": [
+                        str(effort["reasoningEffort"])
+                        for effort in item.supported_reasoning_efforts
+                        if effort.get("reasoningEffort")
+                    ],
+                }
+                for item in response.data
+                if not item.hidden
+                and any(
+                    effort.get("reasoningEffort") == ReasoningEffort.xhigh.value
+                    for effort in item.supported_reasoning_efforts
+                )
+            ]
+            configured_model = await self._configured_model(codex)
+            if configured_model:
+                for option in options:
+                    option["is_default"] = option["value"] == configured_model
+                if configured_model not in {str(option["value"]) for option in options}:
+                    options.insert(0, {
+                        "value": configured_model,
+                        "label": self._model_display_name(configured_model),
+                        "description": "Current Codex default model.",
+                        "is_default": True,
+                        # supported efforts unknown for a model outside model/list;
+                        # an empty list means "accept any known effort"
+                        "efforts": [],
+                    })
+            self._model_options = options
+            return [dict(item) for item in self._model_options]
+
+    async def _configured_model(self, codex: AsyncCodex) -> str | None:
+        client = getattr(codex, "_client", None)
+        if client is None:
+            return None
+        try:
+            response = await client.request(
+                "config/read",
+                {"cwd": str(self.project_root), "includeLayers": False},
+                response_model=ConfigReadResponse,
+            )
+        except Exception as e:
+            print(f"[ai] configured model lookup failed: {e}")
+            return None
+        return response.config.model
+
+    @staticmethod
+    def _model_display_name(model: str) -> str:
+        parts = model.split("-")
+        if len(parts) >= 2 and parts[0].lower() == "gpt":
+            suffix = " ".join(part.capitalize() for part in parts[2:])
+            return f"GPT-{parts[1]}" + (f" {suffix}" if suffix else "")
+        return " ".join(part.upper() if len(part) <= 3 else part.capitalize() for part in parts)
+
+    async def validate_model(self, model: str | None) -> str | None:
+        if model is None:
+            return None
+        requested = model.strip()
+        if not requested:
+            return None
+        options = await self.model_options()
+        if requested not in {str(item["value"]) for item in options}:
+            raise ValueError(f"unsupported AI model: {requested}")
+        return requested
+
+    async def chat_preferences(self) -> dict[str, str | None]:
+        """Resolve the shared dashboard model/effort selection against the
+        current model options, falling back to the preferred defaults."""
+        options = await self.model_options()
+        async with self._chat_state_lock:
+            stored_model = self._chat_model
+            stored_effort = self._chat_effort
+        model = self._resolve_preferred_model(options, stored_model)
+        effort = self._resolve_preferred_effort(options, model, stored_effort)
+        return {"model": model, "effort": effort}
+
+    async def set_chat_preferences(
+        self,
+        model: str | None,
+        effort: str | None,
+    ) -> dict[str, str | None]:
+        validated_model = await self.validate_model(model)
+        target_model = validated_model or (await self.chat_preferences())["model"]
+        validated_effort = await self.validate_effort(effort, target_model)
+        async with self._chat_state_lock:
+            if validated_model:
+                self._chat_model = validated_model
+            if validated_effort:
+                self._chat_effort = validated_effort
+            self._save_chat_state()
+        return await self.chat_preferences()
+
+    @staticmethod
+    def _resolve_preferred_model(
+        options: list[dict[str, Any]],
+        stored: str | None,
+    ) -> str | None:
+        values = {str(item["value"]) for item in options}
+        if stored and stored in values:
+            return stored
+        if _PREFERRED_DEFAULT_MODEL in values:
+            return _PREFERRED_DEFAULT_MODEL
+        for item in options:
+            if item.get("is_default"):
+                return str(item["value"])
+        return str(options[0]["value"]) if options else None
+
+    @staticmethod
+    def _resolve_preferred_effort(
+        options: list[dict[str, Any]],
+        model: str | None,
+        stored: str | None,
+    ) -> str | None:
+        selected = next((item for item in options if str(item["value"]) == model), None)
+        supported = [str(value) for value in (selected or {}).get("efforts") or []]
+        # an empty supported list means the efforts are unknown; accept anything known
+        if stored and (not supported or stored in supported):
+            return stored
+        if not supported or _PREFERRED_DEFAULT_EFFORT in supported:
+            return _PREFERRED_DEFAULT_EFFORT
+        return supported[-1]
+
+    async def validate_effort(self, effort: str | None, model: str | None) -> str | None:
+        if effort is None:
+            return None
+        requested = effort.strip().lower()
+        if not requested:
+            return None
+        try:
+            ReasoningEffort(requested)
+        except ValueError:
+            raise ValueError(f"unsupported reasoning effort: {requested}") from None
+        options = await self.model_options()
+        if model:
+            selected = next((item for item in options if str(item["value"]) == model), None)
+        else:
+            selected = next((item for item in options if item.get("is_default")), None)
+        supported = [str(value) for value in (selected or {}).get("efforts") or []]
+        if supported and requested not in supported:
+            raise ValueError(f"model does not support reasoning effort: {requested}")
+        return requested
 
     async def import_chat_state(
         self,
@@ -697,6 +904,10 @@ class CodexService:
             self._chat_conversation_id = (
                 conversation_id if isinstance(conversation_id, str) and conversation_id else None
             )
+            model = payload.get("model")
+            self._chat_model = model if isinstance(model, str) and model else None
+            effort = payload.get("effort")
+            self._chat_effort = effort if isinstance(effort, str) and effort else None
         except Exception as e:
             print(f"[ai] chat state load failed: {e}")
 
@@ -716,6 +927,10 @@ class CodexService:
             "conversation_id": self._chat_conversation_id,
             "messages": [dict(item) for item in self._chat_messages],
             "pending": self._pending_shared_chats > 0,
+            # raw stored selection (unresolved): lets clients that reconnect
+            # after missing an ai_prefs_updated broadcast catch up
+            "model": self._chat_model,
+            "effort": self._chat_effort,
         }
 
     @staticmethod
@@ -896,6 +1111,8 @@ class CodexService:
         *,
         trace_id: str,
         request_started_at: float,
+        model: str | None = None,
+        effort: str | None = None,
     ) -> AsyncIterator[CodexStreamEvent]:
         turn = None
         first_event_ms: float | None = None
@@ -905,7 +1122,8 @@ class CodexService:
             turn = await thread.turn(
                 prompt,
                 approval_mode=ApprovalMode.deny_all,
-                effort=ReasoningEffort.xhigh,
+                effort=ReasoningEffort(effort) if effort else ReasoningEffort.xhigh,
+                model=model,
             )
             turn_start_ms = (time.perf_counter() - turn_start_requested_at) * 1000
             request_to_turn_ms = (time.perf_counter() - request_started_at) * 1000

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import shutil
+import sys
 import time
 import uuid
 from collections.abc import AsyncIterator, Awaitable, Callable
@@ -67,6 +68,7 @@ _MAX_PERSISTED_MESSAGES = 200
 _MAX_CONTEXT_MESSAGES = 12
 _MAX_PERSISTED_CONTENT_CHARS = 40_000
 _AI_PERMISSION_PROFILE = "pynereal-ai-read-only"
+_CODEX_LOGIN_TIMEOUT_SECONDS = 10 * 60
 
 
 @dataclass(frozen=True)
@@ -165,9 +167,7 @@ class CodexService:
                 ))
                 self._install_dynamic_tool_handler(codex)
                 await codex.__aenter__()
-                account = await codex.account()
-                if account.account is None:
-                    raise RuntimeError("Codex is not authenticated; run `codex login` first")
+                await self._ensure_authenticated(codex)
             except Exception:
                 try:
                     if codex is not None:
@@ -183,6 +183,41 @@ class CodexService:
                 "[ai] Codex app-server started with the current local login "
                 f"in {elapsed_ms:.0f}ms"
             )
+
+    async def _ensure_authenticated(self, codex: AsyncCodex) -> None:
+        account = await codex.account()
+        if account.account is not None:
+            return
+
+        if not self._interactive_terminal_available():
+            raise RuntimeError(
+                "Codex is not authenticated and interactive login is unavailable; "
+                "start data_service/main.py from a terminal or run `codex login` first"
+            )
+
+        print("[ai] Codex login is required. Starting device-code login...")
+        login = await codex.login_chatgpt_device_code()
+        print(f"[ai] Open {login.verification_url}")
+        print(f"[ai] Enter code: {login.user_code}")
+        print("[ai] Waiting for Codex login to complete...")
+        try:
+            async with asyncio.timeout(_CODEX_LOGIN_TIMEOUT_SECONDS):
+                await login.wait()
+        except TimeoutError:
+            await login.cancel()
+            raise RuntimeError("Codex interactive login timed out") from None
+        except asyncio.CancelledError:
+            await login.cancel()
+            raise
+
+        account = await codex.account(refresh_token=True)
+        if account.account is None:
+            raise RuntimeError("Codex login completed without an authenticated account")
+        print("[ai] Codex login completed")
+
+    @staticmethod
+    def _interactive_terminal_available() -> bool:
+        return sys.stdin.isatty() and sys.stdout.isatty()
 
     async def close(self) -> None:
         async with self._lifecycle_lock:

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -150,6 +150,10 @@ class CodexService:
         self._chat_conversation_id: str | None = None
         self._load_chat_state()
 
+    @property
+    def enabled(self) -> bool:
+        return not self._disabled
+
     async def start(self) -> None:
         async with self._lifecycle_lock:
             if self._codex is not None or self._disabled:

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -36,6 +36,9 @@ DEFAULT_DEVELOPER_INSTRUCTIONS = (
     "change leverage, or perform any other account state mutation. "
     "You may change session state only through the dedicated tools when the user "
     "explicitly requests setting or deleting Manual Alert price triggers. For any Manual Alert request, "
+    "A server-verified automated strategy instruction configured through the ai parameter of "
+    "strategy.entry or strategy.close is an explicit user request. Execute only its stated scope "
+    "and use the exact session context supplied by the server. "
     "first call get_manual_alert_context to inspect the active sessions and templates. "
     "If the session, price, alert template, deletion target, or deletion scope is unclear or "
     "could match more than one option, do not call a mutation tool. Ask for a human-readable distinction "
@@ -123,6 +126,7 @@ class CodexService:
         chat_state_path: Path | None = None,
     ) -> None:
         self.project_root = project_root.resolve()
+        self.session_registry = session_registry
         self.dynamic_tools = AIDynamicTools(
             self.project_root,
             session_registry=session_registry,
@@ -140,6 +144,7 @@ class CodexService:
         self._lifecycle_lock = asyncio.Lock()
         self._conversations_lock = asyncio.Lock()
         self._shared_chat_lock = asyncio.Lock()
+        self._strategy_instruction_locks: dict[str, asyncio.Lock] = {}
         self._chat_state_lock = asyncio.Lock()
         self._conversations: dict[str, AsyncThread] = {}
         self._turn_locks: dict[str, asyncio.Lock] = {}
@@ -347,6 +352,7 @@ class CodexService:
                 await asyncio.gather(*shared_chat_tasks, return_exceptions=True)
             self._conversations.clear()
             self._turn_locks.clear()
+            self._strategy_instruction_locks.clear()
             if warm_thread_task is not None:
                 warm_thread_task.cancel()
                 await asyncio.gather(warm_thread_task, return_exceptions=True)
@@ -409,6 +415,126 @@ class CodexService:
         self._shared_chat_tasks.add(task)
         task.add_done_callback(self._shared_chat_tasks.discard)
         return run
+
+    async def handle_strategy_instruction(self, session: Any, event: dict[str, Any]) -> None:
+        instruction = str(event.get("instruction") or "").strip()
+        event_id = str(event.get("event_id") or "").strip()
+        if not instruction or not event_id:
+            return
+        if self._disabled:
+            print(
+                f"[ai] strategy instruction skipped session={session.spec.id} "
+                "reason=AI service disabled"
+            )
+            return
+
+        self._pending_shared_chats += 1
+        task = asyncio.create_task(
+            self._run_strategy_instruction(session, event),
+            name=f"codex-strategy-{event_id[:8]}",
+        )
+        self._shared_chat_tasks.add(task)
+        task.add_done_callback(self._shared_chat_tasks.discard)
+        await self._notify_strategy_chat_changed()
+        print(
+            f"[ai] strategy instruction queued session={session.spec.id} "
+            f"event={event_id[:8]} action={event.get('action') or 'order'}"
+        )
+
+    async def _run_strategy_instruction(self, session: Any, event: dict[str, Any]) -> None:
+        conversation_id: str | None = None
+        instruction = str(event.get("instruction") or "").strip()
+        label = self._strategy_instruction_label(session, event)
+        session_lock = self._strategy_instruction_locks.setdefault(
+            str(session.spec.id),
+            asyncio.Lock(),
+        )
+        try:
+            async with session_lock:
+                await self._append_chat_message("user", f"[Strategy AI] {label}\n{instruction}")
+                await self._notify_strategy_chat_changed()
+
+                answer = ""
+                async for stream_event in self.stream_chat(
+                    instruction,
+                    conversation_id=None,
+                    initial_context=self._build_strategy_instruction_prompt(
+                        session,
+                        event,
+                    ),
+                ):
+                    if stream_event.event == "conversation":
+                        conversation_id = (
+                            str(stream_event.payload.get("conversation_id") or "") or None
+                        )
+                    elif stream_event.event == "done":
+                        answer = str(stream_event.payload.get("answer") or "").strip()
+                if answer:
+                    await self._append_chat_message(
+                        "assistant",
+                        f"[Strategy AI] {label}\n{answer}",
+                    )
+                print(
+                    f"[ai] strategy instruction completed session={session.spec.id} "
+                    f"event={str(event.get('event_id') or '')[:8]}"
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            await self._append_chat_message(
+                "assistant",
+                f"Strategy AI failed for {label}: {e}",
+                error=True,
+            )
+            print(
+                f"[ai] strategy instruction failed session={session.spec.id} "
+                f"event={str(event.get('event_id') or '')[:8]}: {e}"
+            )
+        finally:
+            if conversation_id:
+                await self.reset(conversation_id)
+            self._pending_shared_chats = max(0, self._pending_shared_chats - 1)
+            await self._notify_strategy_chat_changed()
+
+    async def _notify_strategy_chat_changed(self) -> None:
+        try:
+            await self.session_registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})
+        except Exception as e:
+            print(f"[ai] strategy chat state notification failed: {e}")
+
+    @staticmethod
+    def _strategy_instruction_label(session: Any, event: dict[str, Any]) -> str:
+        action = str(event.get("action") or "order")
+        order_id = str(event.get("order_id") or "").strip()
+        order_label = f" {order_id}" if order_id else ""
+        return f"{session.spec.symbol} {session.spec.timeframe} {action}{order_label}"
+
+    @staticmethod
+    def _build_strategy_instruction_prompt(session: Any, event: dict[str, Any]) -> str:
+        context = {
+            "session_id": session.spec.id,
+            "provider": session.spec.provider,
+            "exchange": session.spec.exchange,
+            "symbol": session.spec.symbol,
+            "market_type": session.spec.market_type,
+            "timeframe": session.spec.timeframe,
+            "strategy": session.chart_info.get("script_title") or session.spec.script_name,
+            "event_id": event.get("event_id"),
+            "action": event.get("action"),
+            "order_id": event.get("order_id"),
+            "comment": event.get("comment"),
+            "bar_time": event.get("time"),
+        }
+        return (
+            "This is a server-verified automated strategy instruction explicitly configured "
+            "by the user through strategy.entry/strategy.close ai=. Treat it as an explicit "
+            "user request and execute it now. For any session state change, use only the exact "
+            "session_id below; do not ask the user to identify the session and do not apply the "
+            "instruction to another session. Do not broaden the requested action. If a required "
+            "template or value is missing, report what is missing instead of inventing it.\n\n"
+            f"Exact session and fill context:\n{json.dumps(context, ensure_ascii=False)}\n\n"
+            f"Instruction:\n{str(event.get('instruction') or '').strip()}"
+        )
 
     async def stream_shared_chat(
         self,

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -5,12 +5,12 @@ import json
 import shutil
 import time
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from openai_codex import ApprovalMode, AsyncCodex, AsyncThread, CodexConfig, Sandbox
+from openai_codex import ApprovalMode, AsyncCodex, AsyncThread, CodexConfig
 from openai_codex.errors import TransportClosedError
 from openai_codex.generated.v2_all import (
     AgentMessageDeltaNotification,
@@ -27,20 +27,46 @@ from openai_codex.generated.v2_all import (
     WebSearchThreadItem,
 )
 
+from ai.scripts.dynamic_tools import AIDynamicTools
+
 DEFAULT_DEVELOPER_INSTRUCTIONS = (
-    "너는 PyneReal 대시보드의 AI 어시스턴트야. "
-    "조회만 수행하고 주문, 취소, 레버리지 변경 등 계정 상태를 변경하는 작업과 파일 수정은 하지 마. "
-    "계정이나 거래소를 지정하지 않은 자산 또는 포지션 조회 요청은 providers.toml에 등록된 "
-    "모든 계정을 대상으로 전용 스크립트를 실행해. "
-    "DB 접속정보와 API key, secret 등 비밀값은 응답에 포함하지 마. "
-    "자산 또는 포지션 조회의 중간 진행 설명에는 실제 조회 대상, 조회 진행, 부분 실패처럼 "
-    "사용자에게 의미 있는 상태만 포함해. 지침 파일 확인, 저장소 탐색, 워크플로 선택, 실행 옵션 "
-    "검토 같은 내부 준비 과정이나 결과를 나중에 정리하겠다는 설명은 출력하지 마. "
-    "최종 답변도 작업 절차를 나열하지 말고 조회 결과부터 바로 제시해."
+    "You are the AI assistant for the PyneReal dashboard. "
+    "Treat exchanges and accounts as read-only. Do not place or cancel orders, "
+    "change leverage, or perform any other account state mutation. "
+    "You may change session state only through the dedicated tools when the user "
+    "explicitly requests setting or deleting Manual Alert price triggers. For any Manual Alert request, "
+    "first call get_manual_alert_context to inspect the active sessions and templates. "
+    "If the session, price, alert template, deletion target, or deletion scope is unclear or "
+    "could match more than one option, do not call a mutation tool. Ask for a human-readable distinction "
+    "such as the exchange, timeframe, or strategy name. Never ask the user to provide a "
+    "session_id. Resolve the user's symbol, company or asset name, or strategy description "
+    "to a session from the context and use its ID internally. If the requested alert "
+    "template does not exist in that session, ask the user for both the alert title and "
+    "message format, then pass the custom template fields to set_manual_alert_trigger so "
+    "the template and trigger are added together. Do not tell the user to add the template "
+    "through the dashboard, and never guess or invent missing values. For an explicit trigger "
+    "deletion request, map the user's description to active trigger IDs and call "
+    "delete_manual_alert_triggers. If the user explicitly asks to delete all triggers in one "
+    "session and then set a new trigger in that same session, call set_manual_alert_trigger once "
+    "with replace_existing_triggers=true instead of performing separate delete and set calls. "
+    "Deleting or replacing triggers must always preserve configured alert templates. Never delete "
+    "a template unless the user explicitly requests template deletion through a dedicated tool. "
+    "When an asset or position request does not specify an account or exchange, run the "
+    "dedicated script for every account configured in providers.toml. Never include database "
+    "connection details, API keys, secrets, or other credentials in a response. Intermediate "
+    "progress for asset or position lookups must contain only user-relevant information such "
+    "as the actual lookup target, meaningful progress, partial failures, or retries. Do not "
+    "describe internal preparation such as reading instruction files, exploring the repository, "
+    "selecting a workflow, reviewing execution options, or planning how to summarize the result. "
+    "In the final response, do not list the procedure; present the lookup result immediately. "
+    "Only when the user explicitly asks to send the result to Telegram, complete the lookup and "
+    "then call send_telegram_message with a concise plain-text result. Report successful Telegram "
+    "delivery only when the tool returns success."
 )
 _MAX_PERSISTED_MESSAGES = 200
 _MAX_CONTEXT_MESSAGES = 12
 _MAX_PERSISTED_CONTENT_CHARS = 40_000
+_AI_PERMISSION_PROFILE = "pynereal-ai-read-only"
 
 
 @dataclass(frozen=True)
@@ -49,18 +75,59 @@ class CodexStreamEvent:
     payload: dict[str, Any]
 
 
+_CHAT_STREAM_END = object()
+ChatStateCallback = Callable[[], Awaitable[None]]
+
+
+class CodexChatRun:
+    """One server-owned chat turn with an optional live SSE subscriber."""
+
+    def __init__(self) -> None:
+        self.id = uuid.uuid4().hex[:8]
+        self._events: asyncio.Queue[CodexStreamEvent | object] = asyncio.Queue()
+        self._subscribed = True
+
+    def publish(self, event: CodexStreamEvent) -> None:
+        if self._subscribed:
+            self._events.put_nowait(event)
+
+    def finish(self) -> None:
+        if self._subscribed:
+            self._events.put_nowait(_CHAT_STREAM_END)
+
+    async def events(self) -> AsyncIterator[CodexStreamEvent]:
+        try:
+            while True:
+                event = await self._events.get()
+                if event is _CHAT_STREAM_END:
+                    return
+                yield event
+        finally:
+            self._subscribed = False
+            while not self._events.empty():
+                self._events.get_nowait()
+
+
 class CodexService:
     """Own one long-running Codex app-server and its dashboard chat threads."""
 
     def __init__(
         self,
         project_root: Path,
+        session_registry: Any,
         developer_instructions: str = DEFAULT_DEVELOPER_INSTRUCTIONS,
         timeout_seconds: float = 180,
         chat_state_path: Path | None = None,
     ) -> None:
         self.project_root = project_root.resolve()
-        self.developer_instructions = developer_instructions
+        self.dynamic_tools = AIDynamicTools(
+            self.project_root,
+            session_registry=session_registry,
+        )
+        self.file_tools = self.dynamic_tools.file_tools
+        self.developer_instructions = (
+            developer_instructions.rstrip() + " " + self._file_access_instructions()
+        )
         self.timeout_seconds = timeout_seconds
         self.chat_state_path = (
             chat_state_path or self.project_root / "workdir" / "config" / "ai_chat.json"
@@ -72,6 +139,8 @@ class CodexService:
         self._chat_state_lock = asyncio.Lock()
         self._conversations: dict[str, AsyncThread] = {}
         self._turn_locks: dict[str, asyncio.Lock] = {}
+        self._shared_chat_tasks: set[asyncio.Task[None]] = set()
+        self._pending_shared_chats = 0
         self._warm_thread_task: asyncio.Task[AsyncThread | None] | None = None
         self._chat_messages: list[dict[str, Any]] = []
         self._chat_conversation_id: str | None = None
@@ -82,23 +151,29 @@ class CodexService:
             if self._codex is not None:
                 return
 
+            self.dynamic_tools.bind_loop(asyncio.get_running_loop())
             started_at = time.perf_counter()
             codex_bin = shutil.which("codex")
-            codex = AsyncCodex(CodexConfig(
-                codex_bin=codex_bin,
-                cwd=str(self.project_root),
-                config_overrides=(
-                    "sandbox_workspace_write.network_access=true",
-                    'web_search="live"',
-                ),
-            ))
+            codex: AsyncCodex | None = None
             try:
+                codex = AsyncCodex(CodexConfig(
+                    codex_bin=codex_bin,
+                    cwd=str(self.project_root),
+                    config_overrides=(
+                        'web_search="live"',
+                    ),
+                ))
+                self._install_dynamic_tool_handler(codex)
                 await codex.__aenter__()
                 account = await codex.account()
                 if account.account is None:
                     raise RuntimeError("Codex is not authenticated; run `codex login` first")
             except Exception:
-                await codex.close()
+                try:
+                    if codex is not None:
+                        await codex.close()
+                finally:
+                    self.dynamic_tools.unbind_loop()
                 raise
 
             self._codex = codex
@@ -115,14 +190,27 @@ class CodexService:
             self._codex = None
             warm_thread_task = self._warm_thread_task
             self._warm_thread_task = None
+            current_task = asyncio.current_task()
+            shared_chat_tasks = [
+                task
+                for task in self._shared_chat_tasks
+                if task is not current_task and not task.done()
+            ]
+            for task in shared_chat_tasks:
+                task.cancel()
+            if shared_chat_tasks:
+                await asyncio.gather(*shared_chat_tasks, return_exceptions=True)
             self._conversations.clear()
             self._turn_locks.clear()
             if warm_thread_task is not None:
                 warm_thread_task.cancel()
                 await asyncio.gather(warm_thread_task, return_exceptions=True)
-            if codex is not None:
-                await codex.close()
-                print("[ai] Codex app-server stopped")
+            try:
+                if codex is not None:
+                    await codex.close()
+                    print("[ai] Codex app-server stopped")
+            finally:
+                self.dynamic_tools.unbind_loop()
 
     async def stream_chat(
         self,
@@ -153,44 +241,102 @@ class CodexService:
             ):
                 yield event
 
+    def start_shared_chat(
+        self,
+        message: str,
+        *,
+        client_history: list[dict[str, Any]] | None = None,
+        client_conversation_id: str | None = None,
+        on_state_changed: ChatStateCallback | None = None,
+    ) -> CodexChatRun:
+        run = CodexChatRun()
+        self._pending_shared_chats += 1
+        task = asyncio.create_task(
+            self._run_shared_chat(
+                run,
+                message,
+                client_history=client_history,
+                client_conversation_id=client_conversation_id,
+                on_state_changed=on_state_changed,
+            ),
+            name=f"codex-shared-chat-{run.id}",
+        )
+        self._shared_chat_tasks.add(task)
+        task.add_done_callback(self._shared_chat_tasks.discard)
+        return run
+
     async def stream_shared_chat(
         self,
         message: str,
         *,
         client_history: list[dict[str, Any]] | None = None,
         client_conversation_id: str | None = None,
+        on_state_changed: ChatStateCallback | None = None,
     ) -> AsyncIterator[CodexStreamEvent]:
-        async with self._shared_chat_lock:
-            history, conversation_id = await self._begin_shared_chat(
-                message,
-                client_history=client_history,
-                client_conversation_id=client_conversation_id,
-            )
-            try:
-                async for event in self.stream_chat(
-                    message,
-                    conversation_id=conversation_id,
-                    initial_context=self._build_initial_context(message, history),
-                    history_messages=len(history),
-                ):
-                    if event.event == "conversation":
-                        await self._set_chat_conversation_id(
-                            str(event.payload.get("conversation_id") or "") or None
-                        )
-                    elif event.event == "done":
-                        answer = str(event.payload.get("answer") or "").strip()
-                        if answer:
-                            await self._append_chat_message("assistant", answer)
-                    yield event
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                await self._append_chat_message(
-                    "assistant",
-                    f"AI call failed: {e}",
-                    error=True,
-                )
-                raise
+        run = self.start_shared_chat(
+            message,
+            client_history=client_history,
+            client_conversation_id=client_conversation_id,
+            on_state_changed=on_state_changed,
+        )
+        async for event in run.events():
+            yield event
+
+    async def _run_shared_chat(
+        self,
+        run: CodexChatRun,
+        message: str,
+        *,
+        client_history: list[dict[str, Any]] | None,
+        client_conversation_id: str | None,
+        on_state_changed: ChatStateCallback | None,
+    ) -> None:
+        try:
+            async with self._shared_chat_lock:
+                try:
+                    history, conversation_id = await self._begin_shared_chat(
+                        message,
+                        client_history=client_history,
+                        client_conversation_id=client_conversation_id,
+                    )
+                    await self._notify_chat_state_changed(on_state_changed)
+                    async for event in self.stream_chat(
+                        message,
+                        conversation_id=conversation_id,
+                        initial_context=self._build_initial_context(message, history),
+                        history_messages=len(history),
+                    ):
+                        if event.event == "conversation":
+                            await self._set_chat_conversation_id(
+                                str(event.payload.get("conversation_id") or "") or None
+                            )
+                        elif event.event == "done":
+                            answer = str(event.payload.get("answer") or "").strip()
+                            if answer:
+                                await self._append_chat_message("assistant", answer)
+                        run.publish(event)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    await self._append_chat_message(
+                        "assistant",
+                        f"AI call failed: {e}",
+                        error=True,
+                    )
+                    run.publish(CodexStreamEvent("stream_error", {"error": str(e)}))
+        finally:
+            self._pending_shared_chats = max(0, self._pending_shared_chats - 1)
+            await self._notify_chat_state_changed(on_state_changed)
+            run.finish()
+
+    @staticmethod
+    async def _notify_chat_state_changed(callback: ChatStateCallback | None) -> None:
+        if callback is None:
+            return
+        try:
+            await callback()
+        except Exception as e:
+            print(f"[ai] chat state notification failed: {e}")
 
     async def chat_state(self) -> dict[str, Any]:
         async with self._chat_state_lock:
@@ -283,8 +429,10 @@ class CodexService:
     def _save_chat_state(self) -> None:
         self.chat_state_path.parent.mkdir(parents=True, exist_ok=True)
         tmp = self.chat_state_path.with_name(self.chat_state_path.name + ".tmp")
+        payload = self._chat_state_payload()
+        payload.pop("pending", None)
         tmp.write_text(
-            json.dumps(self._chat_state_payload(), ensure_ascii=False, indent=2),
+            json.dumps(payload, ensure_ascii=False, indent=2),
             encoding="utf-8",
         )
         tmp.replace(self.chat_state_path)
@@ -293,6 +441,7 @@ class CodexService:
         return {
             "conversation_id": self._chat_conversation_id,
             "messages": [dict(item) for item in self._chat_messages],
+            "pending": self._pending_shared_chats > 0,
         }
 
     @staticmethod
@@ -323,12 +472,12 @@ class CodexService:
     def _build_initial_context(message: str, history: list[dict[str, str]]) -> str:
         lines: list[str] = []
         if history:
-            lines.append("서버에 저장된 이전 대화:")
+            lines.append("Previous conversation saved on the server:")
             for item in history:
-                role = "사용자" if item["role"] == "user" else "AI"
+                role = "User" if item["role"] == "user" else "Assistant"
                 lines.append(f"[{role}] {item['content']}")
             lines.append("")
-        lines.append(f"[현재 사용자 질문] {message}")
+        lines.append(f"[Current user request] {message}")
         return "\n".join(lines)
 
     async def _get_codex(self) -> AsyncCodex:
@@ -379,12 +528,51 @@ class CodexService:
         return thread
 
     async def _start_thread(self, codex: AsyncCodex) -> AsyncThread:
-        return await codex.thread_start(
-            approval_mode=ApprovalMode.deny_all,
-            cwd=str(self.project_root),
-            developer_instructions=self.developer_instructions,
-            ephemeral=True,
-            sandbox=Sandbox.workspace_write,
+        # openai-codex 0.1.0b3 generates dynamic tool models but does not yet
+        # expose dynamicTools on its high-level thread_start wrapper.
+        client = getattr(codex, "_client", None)
+        if client is None:
+            raise RuntimeError("Installed openai-codex SDK cannot register dynamic tools")
+        started = await client.thread_start({
+            "approvalPolicy": "never",
+            "config": self._permission_profile_config(),
+            "cwd": str(self.project_root),
+            "developerInstructions": self.developer_instructions,
+            "dynamicTools": self.dynamic_tools.specs,
+            "ephemeral": True,
+        })
+        return AsyncThread(codex, started.thread.id)
+
+    def _install_dynamic_tool_handler(self, codex: AsyncCodex) -> None:
+        client = getattr(codex, "_client", None)
+        sync_client = getattr(client, "_sync", None)
+        if sync_client is None or not hasattr(sync_client, "_approval_handler"):
+            raise RuntimeError("Installed openai-codex SDK cannot handle dynamic tools")
+        sync_client._approval_handler = self.dynamic_tools.handle_server_request
+
+    def _permission_profile_config(self) -> dict[str, Any]:
+        return {
+            "default_permissions": _AI_PERMISSION_PROFILE,
+            "permissions": {
+                _AI_PERMISSION_PROFILE: {
+                    "filesystem": {":root": "read"},
+                    "network": {"enabled": True},
+                },
+            },
+        }
+
+    def _file_access_instructions(self) -> str:
+        editable = ", ".join(str(path) for path in self.file_tools.edit_roots)
+        return (
+            "You may read files outside this repository only when required to fulfill the "
+            "user's request. Modify files only when the user explicitly requests a file change. "
+            f"You may modify only existing regular files under these paths: {editable}. "
+            f"Create new files and directories only under {self.file_tools.tmp_root}. "
+            "Use only edit_existing_file to modify an existing file and write_tmp_file to create "
+            "a file under tmp. Do not write files through shell commands, apply_patch, Python "
+            "scripts, or any other tool. Outside tmp, do not create, delete, rename, or move files "
+            "or directories. After completing a file change, identify the paths actually changed "
+            "in the final response."
         )
 
     @staticmethod

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -274,12 +274,11 @@ class CodexService:
         def render() -> None:
             nonlocal rendered
             if rendered:
-                sys.stdout.write("\x1b[4A")
+                sys.stdout.write("\x1b[3A")
             lines = (
                 "[ai] Enable Codex AI service?",
-                f"  {'>' if selected_yes else ' '} Yes",
-                f"  {' ' if selected_yes else '>'} No",
-                "  Use Up/Down and Enter.",
+                f"  ({'●' if selected_yes else ' '}) Yes",
+                f"  ({' ' if selected_yes else '●'}) No",
             )
             for line in lines:
                 sys.stdout.write(f"\r\x1b[2K{line}\n")
@@ -308,7 +307,9 @@ class CodexService:
                     raise KeyboardInterrupt
         finally:
             termios.tcsetattr(fd, termios.TCSADRAIN, previous_settings)
-            sys.stdout.write("\x1b[?25h")
+            # Raw-mode newlines leave the cursor mid-column; return to column 0
+            # so the caller's next print starts at the line beginning.
+            sys.stdout.write("\r\x1b[?25h")
             sys.stdout.flush()
 
     @staticmethod

--- a/ai/schemas/position_snapshot.schema.json
+++ b/ai/schemas/position_snapshot.schema.json
@@ -1,0 +1,72 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "position_snapshot.schema.json",
+  "title": "Position Snapshot",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "collected_at",
+    "exchange",
+    "symbol",
+    "positions"
+  ],
+  "properties": {
+    "schema_version": {
+      "type": "string"
+    },
+    "collected_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "exchange": {
+      "type": "string"
+    },
+    "account": {
+      "type": ["string", "null"]
+    },
+    "session_id": {
+      "type": ["string", "null"]
+    },
+    "symbol": {
+      "type": "string"
+    },
+    "positions": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["side", "quantity"],
+        "properties": {
+          "side": {
+            "enum": ["long", "short"]
+          },
+          "quantity": {
+            "type": "number"
+          },
+          "entry_price": {
+            "type": ["number", "null"]
+          },
+          "mark_price": {
+            "type": ["number", "null"]
+          },
+          "liquidation_price": {
+            "type": ["number", "null"]
+          },
+          "leverage": {
+            "type": ["number", "null"]
+          },
+          "unrealized_pnl": {
+            "type": ["number", "null"]
+          }
+        },
+        "additionalProperties": true
+      }
+    },
+    "warnings": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/ai/scripts/README.md
+++ b/ai/scripts/README.md
@@ -1,0 +1,133 @@
+# AI Data Scripts
+
+Scripts in this directory collect deterministic, read-only evidence for the
+workflows under `ai/workflows/`.
+
+## Interface
+
+New scripts should:
+
+- accept identifiers such as `--session-id`, `--provider`, and `--symbol`
+- support machine-readable JSON output
+- print diagnostics to standard error
+- return a non-zero exit status for incomplete required data
+- avoid accepting secrets as command-line arguments
+- load credentials through the project's local provider configuration
+- redact sensitive values from all output
+
+State-changing tools must use a separate filename and require both `--execute`
+and an explicit confirmation value.
+
+## Asset balances
+
+`asset.py` reads API credentials from `workdir/config/providers.toml` and uses
+CCXT plus supported exchange-specific read-only asset endpoints. It never
+prints the configured credentials or raw exchange responses.
+
+Use named account tables when the same exchange has multiple accounts:
+
+```toml
+[ccxt_accounts.binance_main]
+exchange = "binance"
+apiKey = "..."
+secret = "..."
+
+[ccxt_accounts.binance_sub1]
+exchange = "binance"
+apiKey = "..."
+secret = "..."
+```
+
+Exchange-nested tables are also accepted. The exchange ID is added to their
+account name, so these become `bitget_main` and `bitget_sub1`:
+
+```toml
+[ccxt.bitget.main]
+apiKey = "..."
+secret = "..."
+password = "..."
+
+[ccxt.bitget.sub1]
+apiKey = "..."
+secret = "..."
+password = "..."
+```
+
+Each named account must contain its own credentials. It inherits non-credential
+exchange options from `[ccxt.<exchange>]`, but never inherits that table's API
+key, secret, password, wallet address, or other account identity fields.
+
+```bash
+# One named account
+python ai/scripts/asset.py --account binance_sub1
+
+# Every configured account for one exchange
+python ai/scripts/asset.py --exchange binance
+
+# A specific account scope and currency
+python ai/scripts/asset.py --account binance_main --account-type swap --currency USDT
+
+# Every legacy and named account found in providers.toml
+python ai/scripts/asset.py
+```
+
+Without `--account-type`, each account is checked for `spot`, `swap`, `margin`,
+`funding`, and `earn` assets. Binance Simple Earn and Bitget Earn use their
+dedicated read-only APIs. Supplying one or more `--account-type` options limits
+the request to those types.
+
+Repeat `--account`, `--exchange`, `--account-type`, or `--currency` to query
+multiple values. Existing `[ccxt.<exchange>]` tables remain supported and use
+the exchange ID as their account name. If both a legacy table and named
+accounts exist for one exchange, `--exchange` queries all of them.
+Only non-zero balances are returned unless `--include-zero` is supplied. JSON is
+written to standard output and progress or sanitized errors go to standard
+error. Account types that do not exist are reported as `unavailable`; types the
+exchange does not expose are reported as `unsupported`. Neither condition makes
+otherwise successful collection fail. Hyperliquid balance lookup uses its
+public info endpoint and only needs `walletAddress` in the selected account
+table; do not add a private key solely for this script.
+
+## Open positions
+
+`position.py` reads the same provider configuration and uses read-only exchange
+position endpoints. Without `--account-type`, it queries every supported
+derivative scope described below and only returns non-zero positions.
+
+```bash
+# One account's complete derivative positions
+python ai/scripts/position.py --account binance_sub1
+
+# Every configured Binance account
+python ai/scripts/position.py --exchange binance
+
+# One symbol or a different derivative account type
+python ai/scripts/position.py --account bitget_sub1 --symbol BTC/USDT:USDT
+python ai/scripts/position.py --account binance_main --account-type delivery
+python ai/scripts/position.py --account bitget_sub1 --account-type usdc
+
+# Hyperliquid HIP-3 positions
+python ai/scripts/position.py --account hyperliquid_xyz --dex xyz
+
+# Every configured account
+python ai/scripts/position.py
+```
+
+Repeat `--account`, `--exchange`, `--account-type`, or `--symbol` to query
+multiple values. Every result includes both `account` and `exchange`, so output
+from multiple accounts remains distinguishable.
+The default Binance query combines USD-M (USDT-M and USDC-M) and COIN-M
+positions. The default Bitget query combines `USDT-FUTURES`, `USDC-FUTURES`,
+and `COIN-FUTURES`.
+Supplying `--account-type` intentionally limits these default scopes. Each
+position includes `market_scope` when the exchange has multiple derivative
+families, and each result lists every successfully queried scope in
+`queried_scopes`.
+When Hyperliquid is queried without `--dex` or `--symbol`, the script takes one
+`allDexsClearinghouseState` WebSocket snapshot. It returns positions from the
+default Perp DEX and every HIP-3 DEX included in that snapshot without issuing
+one REST request per DEX. Each Hyperliquid position includes its `dex`.
+Its `percentage` uses the signed exchange `returnOnEquity` value and falls back
+to signed unrealized PnL divided by initial margin when that value is missing.
+Supplying `--dex` limits the query to that DEX through CCXT's REST endpoint.
+Use `--include-closed` only when zero-size records are needed for diagnostics.

--- a/ai/scripts/README.md
+++ b/ai/scripts/README.md
@@ -1,7 +1,20 @@
-# AI Data Scripts
+# AI Scripts And Tools
 
-Scripts in this directory collect deterministic, read-only evidence for the
-workflows under `ai/workflows/`.
+This directory contains deterministic data collectors and the server-controlled
+tools used by Dashboard AI workflows under `ai/workflows/`.
+
+## Dashboard AI Runtime
+
+- `dynamic_tools.py` routes app-server tool calls.
+- `file_tools.py` restricts explicit file edits to approved repository paths.
+- `manual_alert_tool.py` manages persisted Manual Alert templates and triggers.
+- `telegram_tool.py` sends explicitly requested results through server-held
+  credentials.
+
+These shared modules are imported by provider implementations under
+`ai/provider/`; they are not standalone command-line scripts. Their
+corresponding `*_test.py` files keep tool behavior isolated from live accounts
+and destinations.
 
 ## Interface
 
@@ -15,8 +28,11 @@ New scripts should:
 - load credentials through the project's local provider configuration
 - redact sensitive values from all output
 
-State-changing tools must use a separate filename and require both `--execute`
-and an explicit confirmation value.
+Standalone command-line tools that change external state must use a separate
+filename and require both `--execute` and an explicit confirmation value.
+Server-controlled dynamic tools instead enforce explicit user intent and
+validate every mutation inside the data-service process; they do not expose a
+command-line execution switch.
 
 ## Asset balances
 

--- a/ai/scripts/__init__.py
+++ b/ai/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""AI data collectors and server-controlled dynamic tools."""

--- a/ai/scripts/asset.py
+++ b/ai/scripts/asset.py
@@ -1,0 +1,961 @@
+#!/usr/bin/env python3
+"""Collect normalized, read-only exchange balances through CCXT."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from collections.abc import Callable
+from typing import Any
+
+import ccxt
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
+
+ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = ROOT / "workdir" / "config" / "providers.toml"
+SCHEMA_VERSION = "1.2"
+_BALANCE_FIELDS = ("free", "used", "total", "debt")
+DEFAULT_ACCOUNT_TYPES = ("spot", "swap", "margin", "funding", "earn")
+_ACCOUNT_CREDENTIAL_FIELDS = {
+    "apiKey",
+    "privateKey",
+    "password",
+    "secret",
+    "token",
+    "uid",
+    "walletAddress",
+}
+_SENSITIVE_PATTERN = re.compile(
+    r"(?i)(api[-_ ]?key|secret|password|passphrase|signature|token)"
+    r"(\s*[=:]\s*|[\"']\s*:\s*[\"'])([^&\s,}\"']+)"
+)
+
+
+@dataclass(frozen=True)
+class ExchangeAccount:
+    name: str
+    exchange_id: str
+    config: dict[str, Any]
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def eprint(message: str) -> None:
+    print(message, file=sys.stderr, flush=True)
+
+
+def read_provider_config(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"provider config not found: {path}")
+    with path.open("rb") as handle:
+        data = tomllib.load(handle)
+    if not isinstance(data, dict):
+        raise ValueError("provider config must contain TOML tables")
+    return data
+
+
+def ccxt_root_config(data: dict[str, Any]) -> dict[str, Any]:
+    value = data.get("ccxt")
+    return value if isinstance(value, dict) else {}
+
+
+def is_account_table(value: Any) -> bool:
+    return isinstance(value, dict) and any(
+        key in value for key in _ACCOUNT_CREDENTIAL_FIELDS
+    )
+
+
+def configured_exchanges(data: dict[str, Any]) -> list[str]:
+    root = ccxt_root_config(data)
+    supported = set(ccxt.exchanges)
+    names = {
+        str(key).lower()
+        for key, value in root.items()
+        if isinstance(value, dict) and str(key).lower() in supported
+    }
+    for key, value in data.items():
+        exchange_id = key.split(".", 1)[1].lower() if key.startswith("ccxt.") else ""
+        if exchange_id in supported and isinstance(value, dict):
+            names.add(exchange_id)
+    return sorted(names)
+
+
+def merge_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    result = dict(base)
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(result.get(key), dict):
+            result[key] = merge_dicts(result[key], value)
+        else:
+            result[key] = value
+    return result
+
+
+def exchange_config(data: dict[str, Any], exchange_id: str) -> dict[str, Any]:
+    root = ccxt_root_config(data)
+    supported = set(ccxt.exchanges)
+    base = {
+        key: value
+        for key, value in root.items()
+        if not (isinstance(value, dict) and str(key).lower() in supported)
+    }
+    nested = root.get(exchange_id)
+    if not isinstance(nested, dict):
+        nested = {}
+    else:
+        nested = {
+            key: value for key, value in nested.items() if not is_account_table(value)
+        }
+    legacy = data.get(f"ccxt.{exchange_id}")
+    if not isinstance(legacy, dict):
+        legacy = {}
+    return merge_dicts(merge_dicts(base, nested), legacy)
+
+
+def configured_accounts(data: dict[str, Any]) -> list[ExchangeAccount]:
+    accounts: list[ExchangeAccount] = []
+    names: set[str] = set()
+    root = ccxt_root_config(data)
+
+    for exchange_id in configured_exchanges(data):
+        exchange_table = root.get(exchange_id)
+        exchange_table = exchange_table if isinstance(exchange_table, dict) else {}
+        nested_accounts = [
+            (str(raw_name), raw_config)
+            for raw_name, raw_config in exchange_table.items()
+            if is_account_table(raw_config)
+        ]
+        has_direct_credentials = any(
+            key in exchange_table for key in _ACCOUNT_CREDENTIAL_FIELDS
+        )
+        legacy = data.get(f"ccxt.{exchange_id}")
+        has_legacy_table = isinstance(legacy, dict)
+
+        if not nested_accounts or has_direct_credentials or has_legacy_table:
+            accounts.append(
+                ExchangeAccount(exchange_id, exchange_id, exchange_config(data, exchange_id))
+            )
+            names.add(exchange_id)
+
+        base = {
+            key: value
+            for key, value in exchange_config(data, exchange_id).items()
+            if key not in _ACCOUNT_CREDENTIAL_FIELDS
+        }
+        for raw_name, raw_config in nested_accounts:
+            suffix = raw_name.strip().lower()
+            name = f"{exchange_id}_{suffix}"
+            if not suffix or not re.fullmatch(r"[a-z0-9_-]+", suffix):
+                raise ValueError(
+                    f"invalid nested ccxt account name: {exchange_id}.{raw_name}"
+                )
+            if name in names:
+                raise ValueError(f"duplicate ccxt account name: {name}")
+            accounts.append(
+                ExchangeAccount(name, exchange_id, merge_dicts(base, raw_config))
+            )
+            names.add(name)
+
+    profile_root = data.get("ccxt_accounts", {})
+    if not isinstance(profile_root, dict):
+        raise ValueError("[ccxt_accounts] must contain account tables")
+
+    supported = set(ccxt.exchanges)
+    for raw_name, raw_config in profile_root.items():
+        name = str(raw_name).strip().lower()
+        if not name or not re.fullmatch(r"[a-z0-9_-]+", name):
+            raise ValueError(f"invalid ccxt account name: {raw_name!r}")
+        if name in names:
+            raise ValueError(f"duplicate ccxt account name: {name}")
+        if not isinstance(raw_config, dict):
+            raise ValueError(f"[ccxt_accounts.{name}] must be a TOML table")
+
+        exchange_id = str(raw_config.get("exchange", "")).strip().lower()
+        if exchange_id not in supported:
+            raise ValueError(
+                f"[ccxt_accounts.{name}] has unsupported exchange: {exchange_id or '<missing>'}"
+            )
+
+        # Profiles inherit exchange options, but credentials must be declared per account.
+        base = {
+            key: value
+            for key, value in exchange_config(data, exchange_id).items()
+            if key not in _ACCOUNT_CREDENTIAL_FIELDS
+        }
+        override = {key: value for key, value in raw_config.items() if key != "exchange"}
+        accounts.append(ExchangeAccount(name, exchange_id, merge_dicts(base, override)))
+        names.add(name)
+    return accounts
+
+
+def select_accounts(
+    data: dict[str, Any],
+    requested_accounts: list[str] | None,
+    requested_exchanges: list[str] | None,
+) -> list[ExchangeAccount]:
+    accounts = configured_accounts(data)
+    supported = set(ccxt.exchanges)
+    exchange_filters = list(
+        dict.fromkeys(
+            value.strip().lower()
+            for value in (requested_exchanges or [])
+            if value.strip()
+        )
+    )
+    unsupported = [exchange_id for exchange_id in exchange_filters if exchange_id not in supported]
+    if unsupported:
+        raise ValueError(f"unsupported CCXT exchange: {', '.join(unsupported)}")
+
+    if requested_accounts:
+        account_names = list(
+            dict.fromkeys(value.strip().lower() for value in requested_accounts if value.strip())
+        )
+        account_map = {account.name: account for account in accounts}
+        missing = [name for name in account_names if name not in account_map]
+        if missing:
+            available = ", ".join(account_map) or "none"
+            raise ValueError(
+                f"unknown ccxt account: {', '.join(missing)}; available accounts: {available}"
+            )
+        selected = [account_map[name] for name in account_names]
+        if exchange_filters:
+            selected = [
+                account for account in selected if account.exchange_id in exchange_filters
+            ]
+            if not selected:
+                raise ValueError("selected accounts do not match the requested exchanges")
+        return selected
+
+    if not exchange_filters:
+        return accounts
+
+    selected = [account for account in accounts if account.exchange_id in exchange_filters]
+    selected_exchanges = {account.exchange_id for account in selected}
+    for exchange_id in exchange_filters:
+        if exchange_id not in selected_exchanges:
+            selected.append(
+                ExchangeAccount(exchange_id, exchange_id, exchange_config(data, exchange_id))
+            )
+    return selected
+
+
+def redact_error(exc: Exception, secrets: list[str]) -> str:
+    text = str(exc).replace("\n", " ").strip()
+    for secret in sorted((value for value in secrets if value), key=len, reverse=True):
+        text = text.replace(secret, "***")
+    text = _SENSITIVE_PATTERN.sub(lambda match: f"{match.group(1)}{match.group(2)}***", text)
+    return text[:500] or type(exc).__name__
+
+
+def secret_values(config: dict[str, Any]) -> list[str]:
+    values: list[str] = []
+    for key in ("apiKey", "secret", "password", "privateKey", "token"):
+        value = config.get(key)
+        if isinstance(value, str) and value:
+            values.append(value)
+    return values
+
+
+def build_exchange(
+    exchange_id: str,
+    config: dict[str, Any],
+    timeout_ms: int,
+    account_type: str | None,
+) -> ccxt.Exchange:
+    exchange_class = getattr(ccxt, exchange_id, None)
+    if exchange_class is None or exchange_id not in ccxt.exchanges:
+        raise ValueError(f"unsupported CCXT exchange: {exchange_id}")
+
+    client_config = merge_dicts(
+        {"enableRateLimit": True, "timeout": timeout_ms},
+        config,
+    )
+    sandbox = bool(client_config.pop("isTestnet", False) or client_config.pop("sandbox", False))
+    if account_type:
+        options = client_config.get("options")
+        options = dict(options) if isinstance(options, dict) else {}
+        options["defaultType"] = account_type
+        client_config["options"] = options
+
+    exchange = exchange_class(client_config)
+    try:
+        if sandbox:
+            exchange.set_sandbox_mode(True)
+        if exchange_id == "hyperliquid":
+            if not exchange.walletAddress:
+                raise ccxt.ArgumentsRequired(
+                    "hyperliquid requires walletAddress in [ccxt.hyperliquid]"
+                )
+        else:
+            exchange.check_required_credentials()
+    except Exception:
+        try:
+            exchange.close()
+        except Exception:
+            pass
+        raise
+    return exchange
+
+
+def number_or_none(value: Any) -> int | float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        if isinstance(value, float) and not math.isfinite(value):
+            return None
+        return value
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def asset_codes(balance: dict[str, Any]) -> set[str]:
+    codes: set[str] = set()
+    for field in _BALANCE_FIELDS:
+        values = balance.get(field)
+        if isinstance(values, dict):
+            codes.update(str(code).upper() for code in values)
+    for code, value in balance.items():
+        if isinstance(value, dict) and any(field in value for field in _BALANCE_FIELDS):
+            codes.add(str(code).upper())
+    return codes
+
+
+def normalize_assets(
+    balance: dict[str, Any],
+    currencies: set[str],
+    include_zero: bool,
+) -> list[dict[str, Any]]:
+    assets: list[dict[str, Any]] = []
+    for code in sorted(asset_codes(balance)):
+        if currencies and code not in currencies:
+            continue
+        direct = balance.get(code)
+        direct = direct if isinstance(direct, dict) else {}
+        asset: dict[str, Any] = {"currency": code}
+        values: list[int | float] = []
+        for field in _BALANCE_FIELDS:
+            field_map = balance.get(field)
+            raw_value = field_map.get(code) if isinstance(field_map, dict) else direct.get(field)
+            value = number_or_none(raw_value)
+            asset[field] = value
+            if value is not None:
+                values.append(value)
+        if include_zero or any(value != 0 for value in values):
+            assets.append(asset)
+    return assets
+
+
+def add_balance_amount(
+    balance: dict[str, Any],
+    code: Any,
+    *,
+    free: Any = None,
+    used: Any = None,
+    total: Any = None,
+    debt: Any = None,
+) -> None:
+    currency = str(code or "").strip().upper()
+    if not currency:
+        return
+    account = balance.setdefault(currency, {})
+    for field, raw_value in (
+        ("free", free),
+        ("used", used),
+        ("total", total),
+        ("debt", debt),
+    ):
+        value = number_or_none(raw_value)
+        if value is None:
+            continue
+        previous = number_or_none(account.get(field)) or 0
+        account[field] = previous + value
+
+
+def retry_read(
+    exchange: ccxt.Exchange,
+    operation: str,
+    callback: Callable[[], Any],
+    attempts: int,
+    secrets: list[str],
+) -> Any:
+    for attempt in range(1, attempts + 1):
+        try:
+            return callback()
+        except (
+            ccxt.ArgumentsRequired,
+            ccxt.AuthenticationError,
+            ccxt.BadRequest,
+            ccxt.NotSupported,
+            ccxt.PermissionDenied,
+        ):
+            raise
+        except ccxt.BaseError as exc:
+            if attempt >= attempts:
+                raise
+            delay = min(2 ** (attempt - 1), 4)
+            eprint(
+                f"[asset] {exchange.id} {operation} failed ({attempt}/{attempts}): "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}; retrying in {delay}s"
+            )
+            time.sleep(delay)
+    raise RuntimeError(f"{operation} retry loop ended unexpectedly")
+
+
+def fetch_standard_balance(
+    exchange: ccxt.Exchange,
+    account_type: str,
+    attempts: int,
+    secrets: list[str],
+) -> dict[str, Any]:
+    params: dict[str, Any] = {"type": account_type}
+    if account_type == "margin":
+        params["marginMode"] = "cross"
+    return retry_read(
+        exchange,
+        f"fetch_balance({account_type})",
+        lambda: exchange.fetch_balance(params),
+        attempts,
+        secrets,
+    )
+
+
+def fetch_hyperliquid_balance(
+    exchange: ccxt.Exchange,
+    account_type: str,
+    attempts: int,
+    secrets: list[str],
+) -> dict[str, Any]:
+    params = {
+        "type": account_type,
+        "enableUnifiedMargin": False,
+    }
+    return retry_read(
+        exchange,
+        f"fetch_balance({account_type})",
+        lambda: exchange.fetch_balance(params),
+        attempts,
+        secrets,
+    )
+
+
+def fetch_bitget_funding_balance(
+    exchange: ccxt.Exchange,
+    attempts: int,
+    secrets: list[str],
+) -> dict[str, Any]:
+    response = retry_read(
+        exchange,
+        "fetch_funding_assets",
+        lambda: exchange.privateSpotGetV2AccountFundingAssets({}),
+        attempts,
+        secrets,
+    )
+    rows = response.get("data", []) if isinstance(response, dict) else []
+    if not isinstance(rows, list):
+        raise TypeError("Bitget funding assets returned invalid data")
+    balance: dict[str, Any] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        free = number_or_none(row.get("available"))
+        used = number_or_none(row.get("frozen"))
+        total = None
+        if free is not None or used is not None:
+            total = (free or 0) + (used or 0)
+        add_balance_amount(
+            balance,
+            row.get("coin"),
+            free=free,
+            used=used,
+            total=total,
+        )
+    return balance
+
+
+def fetch_bitget_earn_balance(
+    exchange: ccxt.Exchange,
+    attempts: int,
+    secrets: list[str],
+) -> dict[str, Any]:
+    response = retry_read(
+        exchange,
+        "fetch_earn_assets",
+        lambda: exchange.privateEarnGetV2EarnAccountAssets({}),
+        attempts,
+        secrets,
+    )
+    rows = response.get("data", []) if isinstance(response, dict) else []
+    if not isinstance(rows, list):
+        raise TypeError("Bitget earn assets returned invalid data")
+    balance: dict[str, Any] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        amount = number_or_none(row.get("amount"))
+        add_balance_amount(
+            balance,
+            row.get("coin"),
+            used=amount,
+            total=amount,
+        )
+    return balance
+
+
+def fetch_binance_earn_rows(
+    exchange: ccxt.Exchange,
+    method_name: str,
+    attempts: int,
+    secrets: list[str],
+) -> list[dict[str, Any]]:
+    method = getattr(exchange, method_name)
+    rows: list[dict[str, Any]] = []
+    current = 1
+    page_size = 100
+    while True:
+        response = retry_read(
+            exchange,
+            method_name,
+            lambda: method({"current": current, "size": page_size}),
+            attempts,
+            secrets,
+        )
+        page = response.get("rows", []) if isinstance(response, dict) else []
+        if not isinstance(page, list):
+            raise TypeError(f"Binance {method_name} returned invalid rows")
+        rows.extend(row for row in page if isinstance(row, dict))
+        total = number_or_none(response.get("total")) if isinstance(response, dict) else None
+        if len(page) < page_size or (total is not None and current * page_size >= total):
+            break
+        current += 1
+    return rows
+
+
+def fetch_binance_earn_balance(
+    exchange: ccxt.Exchange,
+    attempts: int,
+    secrets: list[str],
+) -> dict[str, Any]:
+    flexible = fetch_binance_earn_rows(
+        exchange,
+        "sapiGetSimpleEarnFlexiblePosition",
+        attempts,
+        secrets,
+    )
+    locked = fetch_binance_earn_rows(
+        exchange,
+        "sapiGetSimpleEarnLockedPosition",
+        attempts,
+        secrets,
+    )
+    balance: dict[str, Any] = {}
+    for row in flexible:
+        amount = number_or_none(row.get("totalAmount"))
+        add_balance_amount(balance, row.get("asset"), used=amount, total=amount)
+    for row in locked:
+        amount = number_or_none(row.get("amount"))
+        add_balance_amount(balance, row.get("asset"), used=amount, total=amount)
+    return balance
+
+
+def supports_account_type(exchange_id: str, account_type: str) -> bool:
+    if exchange_id == "hyperliquid":
+        return account_type in {"spot", "swap"}
+    if account_type == "earn":
+        return exchange_id in {"binance", "bitget"}
+    return True
+
+
+def unavailable_account_type_error(
+    exchange_id: str,
+    account_type: str,
+    exc: Exception,
+) -> bool:
+    if exchange_id != "bitget":
+        return False
+    message = str(exc).lower()
+    if account_type == "margin":
+        return "50021" in message and "margin trading account does not exist" in message
+    if account_type in {"funding", "earn"}:
+        return "40068" in message and "disable subaccount access" in message
+    return False
+
+
+def fetch_account_type_balance(
+    exchange: ccxt.Exchange,
+    exchange_id: str,
+    account_type: str,
+    attempts: int,
+    secrets: list[str],
+) -> tuple[dict[str, Any], str]:
+    if exchange_id == "hyperliquid" and account_type in {"spot", "swap"}:
+        return (
+            fetch_hyperliquid_balance(exchange, account_type, attempts, secrets),
+            "ccxt.fetch_balance",
+        )
+    if account_type == "earn":
+        if exchange_id == "binance":
+            return (
+                fetch_binance_earn_balance(exchange, attempts, secrets),
+                "binance.simple_earn",
+            )
+        if exchange_id == "bitget":
+            return fetch_bitget_earn_balance(exchange, attempts, secrets), "bitget.earn"
+        raise ccxt.NotSupported(f"{exchange_id} earn assets are not supported")
+    if account_type == "funding" and exchange_id == "bitget":
+        return fetch_bitget_funding_balance(exchange, attempts, secrets), "bitget.funding"
+    return (
+        fetch_standard_balance(exchange, account_type, attempts, secrets),
+        "ccxt.fetch_balance",
+    )
+
+
+def account_type_result(
+    account_name: str,
+    exchange_id: str,
+    account_type: str,
+    *,
+    status: str,
+    source: str | None = None,
+    error: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    if source is None:
+        if account_type == "earn" and exchange_id == "binance":
+            source = "binance.simple_earn"
+        elif account_type == "earn" and exchange_id == "bitget":
+            source = "bitget.earn"
+        elif account_type == "funding" and exchange_id == "bitget":
+            source = "bitget.funding"
+        else:
+            source = "ccxt.fetch_balance"
+    result: dict[str, Any] = {
+        "account": account_name,
+        "exchange": exchange_id,
+        "account_type": account_type,
+        "source": source,
+        "assets": [],
+        "asset_count": 0,
+        "status": status,
+    }
+    if error is not None:
+        result["error"] = error
+    return result
+
+
+def collect_account_type(
+    account_name: str,
+    exchange_id: str,
+    account_type: str,
+    exchange: ccxt.Exchange,
+    secrets: list[str],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    eprint(
+        f"[asset] collecting account={account_name} exchange={exchange_id} "
+        f"account_type={account_type}"
+    )
+    try:
+        balance, source = fetch_account_type_balance(
+            exchange,
+            exchange_id,
+            account_type,
+            args.attempts,
+            secrets,
+        )
+        assets = normalize_assets(balance, args.currencies, args.include_zero)
+        return {
+            "account": account_name,
+            "exchange": exchange_id,
+            "account_type": account_type,
+            "source": source,
+            "exchange_timestamp": balance.get("timestamp"),
+            "exchange_datetime": balance.get("datetime"),
+            "assets": assets,
+            "asset_count": len(assets),
+            "status": "ok",
+        }
+    except Exception as exc:
+        message = redact_error(exc, secrets)
+        if unavailable_account_type_error(exchange_id, account_type, exc):
+            eprint(
+                f"[asset] {account_name}/{exchange_id}/{account_type} unavailable: "
+                f"{message}"
+            )
+            return account_type_result(
+                account_name,
+                exchange_id,
+                account_type,
+                status="unavailable",
+                error={"type": type(exc).__name__, "message": message},
+            )
+        eprint(
+            f"[asset] {account_name}/{exchange_id}/{account_type} failed: "
+            f"{type(exc).__name__}: {message}"
+        )
+        return account_type_result(
+            account_name,
+            exchange_id,
+            account_type,
+            status="error",
+            error={"type": type(exc).__name__, "message": message},
+        )
+
+
+def collect_account(
+    account: ExchangeAccount,
+    account_types: list[str],
+    args: argparse.Namespace,
+) -> list[dict[str, Any]]:
+    secrets = secret_values(account.config)
+    supported = [
+        account_type
+        for account_type in account_types
+        if supports_account_type(account.exchange_id, account_type)
+    ]
+    unsupported = set(account_types) - set(supported)
+    exchange: ccxt.Exchange | None = None
+    build_error: Exception | None = None
+    if supported:
+        try:
+            exchange = build_exchange(
+                account.exchange_id,
+                account.config,
+                args.timeout_ms,
+                None,
+            )
+        except Exception as exc:
+            build_error = exc
+
+    results: list[dict[str, Any]] = []
+    try:
+        for account_type in account_types:
+            if account_type in unsupported:
+                results.append(
+                    account_type_result(
+                        account.name,
+                        account.exchange_id,
+                        account_type,
+                        status="unsupported",
+                        error={
+                            "type": "NotSupported",
+                            "message": (
+                                f"{account.exchange_id} does not expose {account_type} assets"
+                            ),
+                        },
+                    )
+                )
+                continue
+            if build_error is not None:
+                message = redact_error(build_error, secrets)
+                results.append(
+                    account_type_result(
+                        account.name,
+                        account.exchange_id,
+                        account_type,
+                        status="error",
+                        error={"type": type(build_error).__name__, "message": message},
+                    )
+                )
+                continue
+            if exchange is None:
+                raise RuntimeError("exchange client was not initialized")
+            results.append(
+                collect_account_type(
+                    account.name,
+                    account.exchange_id,
+                    account_type,
+                    exchange,
+                    secrets,
+                    args,
+                )
+            )
+        return results
+    finally:
+        if exchange is not None:
+            try:
+                exchange.close()
+            except Exception:
+                pass
+
+
+def remove_binance_earn_receipts(results: list[dict[str, Any]]) -> None:
+    by_account: dict[str, list[dict[str, Any]]] = {}
+    for result in results:
+        if result.get("exchange") == "binance":
+            by_account.setdefault(str(result.get("account")), []).append(result)
+
+    for account_results in by_account.values():
+        earn_codes = {
+            str(asset.get("currency"))
+            for result in account_results
+            if result.get("account_type") == "earn" and result.get("status") == "ok"
+            for asset in result.get("assets", [])
+            if isinstance(asset, dict)
+        }
+        if not earn_codes:
+            continue
+        for result in account_results:
+            if result.get("account_type") != "spot" or result.get("status") != "ok":
+                continue
+            assets = result.get("assets", [])
+            if not isinstance(assets, list):
+                continue
+            excluded = [
+                str(asset.get("currency"))
+                for asset in assets
+                if isinstance(asset, dict)
+                and str(asset.get("currency", "")).startswith("LD")
+                and str(asset.get("currency", ""))[2:] in earn_codes
+            ]
+            if excluded:
+                result["assets"] = [
+                    asset
+                    for asset in assets
+                    if not isinstance(asset, dict)
+                    or str(asset.get("currency")) not in excluded
+                ]
+                result["asset_count"] = len(result["assets"])
+                result["excluded_receipt_assets"] = excluded
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read normalized exchange balances from providers.toml via CCXT."
+    )
+    parser.add_argument(
+        "--account",
+        "--profile",
+        action="append",
+        dest="accounts",
+        help="Configured ccxt account name. Repeat for multiple accounts.",
+    )
+    parser.add_argument(
+        "--exchange",
+        action="append",
+        dest="exchanges",
+        help="CCXT exchange id. Selects every configured account for that exchange.",
+    )
+    parser.add_argument(
+        "--account-type",
+        action="append",
+        dest="account_types",
+        help=(
+            "Only query this balance type. Repeat as needed; defaults to spot, swap, "
+            "margin, funding, and earn."
+        ),
+    )
+    parser.add_argument(
+        "--currency",
+        action="append",
+        dest="currencies_raw",
+        help="Only return this currency. Repeat for multiple currencies.",
+    )
+    parser.add_argument("--include-zero", action="store_true", help="Include zero balances.")
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--timeout-ms", type=int, default=30_000)
+    parser.add_argument("--attempts", type=int, default=3)
+    args = parser.parse_args()
+    if args.timeout_ms <= 0:
+        parser.error("--timeout-ms must be greater than zero")
+    if args.attempts <= 0:
+        parser.error("--attempts must be greater than zero")
+    args.currencies = {
+        value.strip().upper() for value in (args.currencies_raw or []) if value.strip()
+    }
+    if args.account_types:
+        args.account_types = list(
+            dict.fromkeys(value.strip().lower() for value in args.account_types if value.strip())
+        )
+    return args
+
+
+def print_fatal_result(error_type: str, message: str) -> None:
+    output = {
+        "schema_version": SCHEMA_VERSION,
+        "collected_at": utc_now(),
+        "source": "exchange.account_assets",
+        "read_only": True,
+        "results": [],
+        "summary": {
+            "requested": 0,
+            "succeeded": 0,
+            "failed": 1,
+            "unsupported": 0,
+            "unavailable": 0,
+        },
+        "error": {"type": error_type, "message": message},
+    }
+    print(json.dumps(output, ensure_ascii=False, indent=2, allow_nan=False))
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        data = read_provider_config(args.config.resolve())
+    except Exception as exc:
+        message = str(exc).replace("\n", " ")[:500]
+        eprint(f"[asset] config error: {type(exc).__name__}: {message}")
+        print_fatal_result(type(exc).__name__, message)
+        return 2
+
+    try:
+        accounts = select_accounts(data, args.accounts, args.exchanges)
+    except Exception as exc:
+        message = str(exc).replace("\n", " ")[:500]
+        eprint(f"[asset] account config error: {type(exc).__name__}: {message}")
+        print_fatal_result(type(exc).__name__, message)
+        return 2
+    if not accounts:
+        eprint(
+            "[asset] no account selected; pass --account/--exchange or configure "
+            "[ccxt.<exchange>] or [ccxt_accounts.<name>]"
+        )
+        print_fatal_result("ConfigurationError", "no exchange account selected or configured")
+        return 2
+
+    account_types = args.account_types or list(DEFAULT_ACCOUNT_TYPES)
+    results = [
+        result
+        for account in accounts
+        for result in collect_account(account, account_types, args)
+    ]
+    if "earn" in account_types:
+        remove_binance_earn_receipts(results)
+    failed = sum(result["status"] == "error" for result in results)
+    unsupported = sum(result["status"] == "unsupported" for result in results)
+    unavailable = sum(result["status"] == "unavailable" for result in results)
+    output = {
+        "schema_version": SCHEMA_VERSION,
+        "collected_at": utc_now(),
+        "source": "exchange.account_assets",
+        "read_only": True,
+        "results": results,
+        "summary": {
+            "requested": len(results),
+            "succeeded": len(results) - failed - unsupported - unavailable,
+            "failed": failed,
+            "unsupported": unsupported,
+            "unavailable": unavailable,
+        },
+    }
+    print(json.dumps(output, ensure_ascii=False, indent=2, allow_nan=False))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ai/scripts/dynamic_tools.py
+++ b/ai/scripts/dynamic_tools.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .file_tools import RestrictedFileTools
+from .manual_alert_tool import ManualAlertTools
+from .telegram_tool import TelegramMessageTool
+
+
+class AIDynamicTools:
+    """Route app-server dynamic tool calls to server-controlled handlers."""
+
+    def __init__(self, project_root: Path, *, session_registry: Any) -> None:
+        self.file_tools = RestrictedFileTools(project_root)
+        self.manual_alert = ManualAlertTools(session_registry)
+        self.telegram = TelegramMessageTool()
+
+    @property
+    def specs(self) -> list[dict[str, Any]]:
+        return [*self.file_tools.specs, *self.manual_alert.specs, self.telegram.spec]
+
+    def bind_loop(self, loop: Any) -> None:
+        self.manual_alert.bind_loop(loop)
+
+    def unbind_loop(self) -> None:
+        self.manual_alert.unbind_loop()
+
+    def handle_server_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if method != "item/tool/call":
+            return {}
+        if not isinstance(params, dict):
+            return self._error_response("Tool call parameters must be an object")
+
+        tool = params.get("tool")
+        file_tool_names = {spec["name"] for spec in self.file_tools.specs}
+        if tool in file_tool_names:
+            return self.file_tools.handle_server_request(method, params)
+        if tool in self.manual_alert.names:
+            return self.manual_alert.handle_server_request(method, params)
+        if tool == self.telegram.name:
+            return self.telegram.handle_server_request(method, params)
+        return self._error_response(f"Unknown AI tool: {tool!r}")
+
+    @staticmethod
+    def _error_response(error: str) -> dict[str, Any]:
+        return {
+            "success": False,
+            "contentItems": [
+                {
+                    "type": "inputText",
+                    "text": json.dumps({"error": error}, ensure_ascii=False),
+                }
+            ],
+        }

--- a/ai/scripts/file_tools.py
+++ b/ai/scripts/file_tools.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import stat
+from pathlib import Path
+from typing import Any
+
+
+_EDIT_ROOTS = (
+    Path("workdir"),
+    Path("modules"),
+    Path("data_service/templates"),
+)
+_TMP_ROOT = Path("tmp")
+_MAX_FILE_BYTES = 5 * 1024 * 1024
+_MAX_REPLACEMENTS = 50
+
+
+class FileToolError(ValueError):
+    """A file operation rejected by the dashboard AI policy."""
+
+
+class RestrictedFileTools:
+    """Server-side file tools that enforce the dashboard AI write policy."""
+
+    def __init__(self, project_root: Path) -> None:
+        self.project_root = project_root.resolve()
+        self.edit_roots = tuple(
+            (self.project_root / relative_path).resolve()
+            for relative_path in _EDIT_ROOTS
+        )
+        self.tmp_root = (self.project_root / _TMP_ROOT).resolve()
+
+    @property
+    def specs(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "name": "edit_existing_file",
+                "description": (
+                    "Modify one existing UTF-8 regular file under workdir/, modules/, or "
+                    "data_service/templates/ using exact text replacements. The path must be "
+                    "repository-relative. All replacements are validated before the file is written."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Repository-relative path to an existing file.",
+                        },
+                        "replacements": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": _MAX_REPLACEMENTS,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "old_text": {"type": "string", "minLength": 1},
+                                    "new_text": {"type": "string"},
+                                    "expected_occurrences": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                    },
+                                },
+                                "required": [
+                                    "old_text",
+                                    "new_text",
+                                    "expected_occurrences",
+                                ],
+                                "additionalProperties": False,
+                            },
+                        },
+                    },
+                    "required": ["path", "replacements"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": "write_tmp_file",
+                "description": (
+                    "Create or overwrite one UTF-8 file under the repository tmp/ directory. "
+                    "The path must be relative to tmp/. Parent directories are created only "
+                    "inside tmp/."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Path relative to the repository tmp/ directory.",
+                        },
+                        "content": {"type": "string"},
+                        "overwrite": {
+                            "type": "boolean",
+                            "default": False,
+                        },
+                    },
+                    "required": ["path", "content"],
+                    "additionalProperties": False,
+                },
+            },
+        ]
+
+    def handle_server_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if method != "item/tool/call":
+            return {}
+
+        try:
+            if not isinstance(params, dict):
+                raise FileToolError("Tool call parameters must be an object")
+            tool = params.get("tool")
+            arguments = params.get("arguments")
+            if not isinstance(arguments, dict):
+                raise FileToolError("Tool arguments must be an object")
+            if tool == "edit_existing_file":
+                result = self.edit_existing_file(arguments)
+            elif tool == "write_tmp_file":
+                result = self.write_tmp_file(arguments)
+            else:
+                raise FileToolError(f"Unknown file tool: {tool!r}")
+        except (FileToolError, OSError, UnicodeError) as exc:
+            return self._tool_response(False, {"error": str(exc)})
+        except Exception as exc:
+            print(f"[ai] file tool internal error: {type(exc).__name__}: {exc}")
+            return self._tool_response(False, {"error": "File tool failed unexpectedly"})
+
+        print(f"[ai] file tool changed {result['path']}")
+        return self._tool_response(True, result)
+
+    def edit_existing_file(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        self._validate_keys(arguments, {"path", "replacements"}, label="arguments")
+        path = self._required_string(arguments, "path")
+        replacements = arguments.get("replacements")
+        if not isinstance(replacements, list) or not replacements:
+            raise FileToolError("replacements must be a non-empty array")
+        if len(replacements) > _MAX_REPLACEMENTS:
+            raise FileToolError(f"At most {_MAX_REPLACEMENTS} replacements are allowed")
+
+        target = self._editable_file(path)
+        original = self._read_regular_file(target)
+        updated = original
+        applied = 0
+        for index, replacement in enumerate(replacements, start=1):
+            if not isinstance(replacement, dict):
+                raise FileToolError(f"Replacement {index} must be an object")
+            self._validate_keys(
+                replacement,
+                {"old_text", "new_text", "expected_occurrences"},
+                label=f"replacement {index}",
+            )
+            old_text = self._required_string(replacement, "old_text")
+            new_text = replacement.get("new_text")
+            expected = replacement.get("expected_occurrences")
+            if not isinstance(new_text, str):
+                raise FileToolError(f"Replacement {index} new_text must be a string")
+            if not isinstance(expected, int) or isinstance(expected, bool) or expected < 1:
+                raise FileToolError(
+                    f"Replacement {index} expected_occurrences must be a positive integer"
+                )
+            if old_text == new_text:
+                raise FileToolError(f"Replacement {index} does not change the file")
+
+            occurrences = updated.count(old_text)
+            if occurrences != expected:
+                raise FileToolError(
+                    f"Replacement {index} expected {expected} occurrence(s), found {occurrences}"
+                )
+            updated = updated.replace(old_text, new_text)
+            applied += occurrences
+
+        updated_bytes = updated.encode("utf-8")
+        if len(updated_bytes) > _MAX_FILE_BYTES:
+            raise FileToolError(f"Edited file exceeds {_MAX_FILE_BYTES} bytes")
+
+        self._write_existing_regular_file(target, updated)
+        return {
+            "path": target.relative_to(self.project_root).as_posix(),
+            "replacements_applied": applied,
+            "before_sha256": self._sha256(original.encode("utf-8")),
+            "after_sha256": self._sha256(updated_bytes),
+        }
+
+    def write_tmp_file(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        self._validate_keys(arguments, {"path", "content", "overwrite"}, label="arguments")
+        relative_path = self._required_string(arguments, "path")
+        content = arguments.get("content")
+        overwrite = arguments.get("overwrite", False)
+        if not isinstance(content, str):
+            raise FileToolError("content must be a string")
+        if not isinstance(overwrite, bool):
+            raise FileToolError("overwrite must be a boolean")
+
+        content_bytes = content.encode("utf-8")
+        if len(content_bytes) > _MAX_FILE_BYTES:
+            raise FileToolError(f"Temporary file exceeds {_MAX_FILE_BYTES} bytes")
+
+        target = self._tmp_file(relative_path)
+        self._ensure_no_symlink_components(target.parent, allow_missing=True)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_no_symlink_components(target.parent, allow_missing=False)
+
+        if target.exists() and not overwrite:
+            raise FileToolError(f"Temporary file already exists: {relative_path}")
+        if target.is_symlink():
+            raise FileToolError("Symbolic links are not allowed")
+        if target.exists() and not target.is_file():
+            raise FileToolError("Temporary path is not a regular file")
+
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        if not overwrite:
+            flags |= os.O_EXCL
+        flags |= getattr(os, "O_NOFOLLOW", 0)
+        try:
+            fd = os.open(target, flags, 0o600)
+        except FileExistsError as exc:
+            raise FileToolError(f"Temporary file already exists: {relative_path}") from exc
+        with os.fdopen(fd, "wb") as file:
+            file.write(content_bytes)
+
+        return {
+            "path": target.relative_to(self.project_root).as_posix(),
+            "bytes": len(content_bytes),
+            "sha256": self._sha256(content_bytes),
+        }
+
+    def _editable_file(self, path: str) -> Path:
+        relative = self._repository_relative_path(path)
+        target = self.project_root / relative
+        if target.is_symlink():
+            raise FileToolError("Symbolic links are not allowed")
+        if not target.exists():
+            raise FileToolError("The edit target must already exist")
+        resolved = target.resolve(strict=False)
+        if not any(resolved.is_relative_to(root) for root in self.edit_roots):
+            raise FileToolError(
+                "Existing files may only be edited under workdir/, modules/, "
+                "or data_service/templates/"
+            )
+        self._ensure_no_symlink_components(target, allow_missing=False)
+        if not target.is_file():
+            raise FileToolError("The edit target must be a regular file, not a symbolic link")
+        return target
+
+    def _tmp_file(self, path: str) -> Path:
+        relative = self._relative_path(path, label="tmp path")
+        target = self.tmp_root / relative
+        if not target.resolve(strict=False).is_relative_to(self.tmp_root):
+            raise FileToolError("Temporary path escapes tmp/")
+        return target
+
+    def _repository_relative_path(self, path: str) -> Path:
+        return self._relative_path(path, label="repository path")
+
+    @staticmethod
+    def _relative_path(path: str, *, label: str) -> Path:
+        if "\x00" in path:
+            raise FileToolError(f"{label} may not contain null bytes")
+        value = Path(path)
+        if not path.strip() or value.is_absolute():
+            raise FileToolError(f"{label} must be a non-empty relative path")
+        if any(part in {"", ".", ".."} for part in value.parts):
+            raise FileToolError(f"{label} may not contain '.', '..', or empty components")
+        return value
+
+    def _ensure_no_symlink_components(self, path: Path, *, allow_missing: bool) -> None:
+        try:
+            relative = path.relative_to(self.project_root)
+        except ValueError as exc:
+            raise FileToolError("Path escapes the repository") from exc
+
+        current = self.project_root
+        for part in relative.parts:
+            current /= part
+            if current.is_symlink():
+                raise FileToolError("Symbolic links are not allowed in file tool paths")
+            if not current.exists():
+                if allow_missing:
+                    continue
+                raise FileToolError(f"Path component does not exist: {part}")
+
+    @staticmethod
+    def _required_string(arguments: dict[str, Any], key: str) -> str:
+        value = arguments.get(key)
+        if not isinstance(value, str) or not value:
+            raise FileToolError(f"{key} must be a non-empty string")
+        return value
+
+    @staticmethod
+    def _validate_keys(arguments: dict[str, Any], allowed: set[str], *, label: str) -> None:
+        unexpected = sorted(set(arguments) - allowed)
+        if unexpected:
+            raise FileToolError(f"Unexpected {label} field(s): {', '.join(unexpected)}")
+
+    @staticmethod
+    def _read_regular_file(path: Path) -> str:
+        flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(path, flags)
+        try:
+            file_stat = os.fstat(fd)
+            if not stat.S_ISREG(file_stat.st_mode):
+                raise FileToolError("The edit target must be a regular file")
+            if file_stat.st_size > _MAX_FILE_BYTES:
+                raise FileToolError(f"The edit target exceeds {_MAX_FILE_BYTES} bytes")
+            with os.fdopen(fd, "r", encoding="utf-8", newline="") as file:
+                fd = -1
+                return file.read()
+        finally:
+            if fd >= 0:
+                os.close(fd)
+
+    @staticmethod
+    def _write_existing_regular_file(path: Path, content: str) -> None:
+        flags = os.O_WRONLY | os.O_TRUNC | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(path, flags)
+        try:
+            if not stat.S_ISREG(os.fstat(fd).st_mode):
+                raise FileToolError("The edit target must remain a regular file")
+            with os.fdopen(fd, "w", encoding="utf-8", newline="") as file:
+                fd = -1
+                file.write(content)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+
+    @staticmethod
+    def _sha256(content: bytes) -> str:
+        return hashlib.sha256(content).hexdigest()
+
+    @staticmethod
+    def _tool_response(success: bool, payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "success": success,
+            "contentItems": [
+                {
+                    "type": "inputText",
+                    "text": json.dumps(payload, ensure_ascii=False),
+                }
+            ],
+        }

--- a/ai/scripts/manual_alert_tool.py
+++ b/ai/scripts/manual_alert_tool.py
@@ -1,0 +1,669 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import math
+import threading
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from pathlib import Path
+from typing import Any
+
+from data_service.config import sanitize_manual_alert_templates
+
+_CONTEXT_TOOL_NAME = "get_manual_alert_context"
+_SET_TOOL_NAME = "set_manual_alert_trigger"
+_DELETE_TOOL_NAME = "delete_manual_alert_triggers"
+_MAX_MANUAL_ALERT_TRIGGERS = 50
+_MAX_MANUAL_ALERT_TEMPLATES = 50
+_TEMPLATE_MESSAGE_PREVIEW_CHARS = 500
+
+
+class ManualAlertToolError(ValueError):
+    """A manual-alert tool request rejected before changing session state."""
+
+
+class ManualAlertRegistryBridge:
+    """Run registry access on the data-service event loop from the SDK reader thread."""
+
+    def __init__(self, registry: Any, *, timeout_seconds: float = 15.0) -> None:
+        self._registry = registry
+        self._timeout_seconds = timeout_seconds
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._loop_thread_id: int | None = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+        self._loop_thread_id = threading.get_ident()
+
+    def unbind_loop(self) -> None:
+        self._loop = None
+        self._loop_thread_id = None
+
+    def execute(self, operation: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            raise ManualAlertToolError("Manual Alert service is not running")
+        if threading.get_ident() == self._loop_thread_id:
+            raise ManualAlertToolError("Manual Alert tool cannot block the data-service event loop")
+
+        future = asyncio.run_coroutine_threadsafe(
+            self._execute_on_loop(operation, arguments),
+            loop,
+        )
+        try:
+            return future.result(timeout=self._timeout_seconds)
+        except FutureTimeoutError:
+            future.cancel()
+            raise ManualAlertToolError("Manual Alert operation timed out") from None
+
+    async def _execute_on_loop(
+        self,
+        operation: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        if operation == "context":
+            return self._context()
+        if operation == "set_trigger":
+            return await self._set_trigger(arguments)
+        if operation == "delete_triggers":
+            return await self._delete_triggers(arguments)
+        raise ManualAlertToolError(f"Unknown Manual Alert operation: {operation}")
+
+    def _context(self) -> dict[str, Any]:
+        sessions: list[dict[str, Any]] = []
+        for session in self._registry.sessions.values():
+            spec = session.spec
+            script_title = str(session.chart_info.get("script_title") or "").strip()
+            if not script_title and spec.script_name:
+                script_title = Path(spec.script_name).stem
+            base_asset = str(spec.symbol).split("/", 1)[0]
+
+            templates = [
+                {
+                    "index": index,
+                    "title": str(template.get("title") or ""),
+                    "message_preview": str(template.get("message") or "")[
+                        :_TEMPLATE_MESSAGE_PREVIEW_CHARS
+                    ],
+                }
+                for index, template in enumerate(spec.manual_alert_templates)
+            ]
+            active_triggers = [
+                {
+                    "id": str(trigger.get("id") or ""),
+                    "price": trigger.get("price"),
+                    "template_title": str((trigger.get("template") or {}).get("title") or ""),
+                }
+                for trigger in spec.manual_alert_triggers
+                if trigger.get("enabled")
+            ]
+            sessions.append({
+                "session_id": spec.id,
+                "provider": spec.provider,
+                "exchange": spec.exchange,
+                "symbol": spec.symbol,
+                "base_asset": base_asset,
+                "market_type": spec.market_type,
+                "timeframe": spec.timeframe,
+                "script_name": spec.script_name,
+                "script_title": script_title,
+                "tv_symbol": str(session.logo_info.get("tv_symbol") or ""),
+                "last_price": session.feed.last_price(),
+                "templates": templates,
+                "active_triggers": active_triggers,
+            })
+
+        return {
+            "session_count": len(sessions),
+            "sessions": sessions,
+        }
+
+    async def _set_trigger(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        session_id = arguments["session_id"].strip()
+        session = self._registry.get(session_id)
+        if session is None:
+            raise ManualAlertToolError(
+                "session_id is not an active session; refresh Manual Alert context"
+            )
+
+        price = float(arguments["price"])
+        templates = [dict(template) for template in session.spec.manual_alert_templates]
+        template_index = arguments.get("template_index")
+        custom_title = arguments.get("custom_template_title")
+        custom_message = arguments.get("custom_template_message")
+
+        has_custom_template = custom_title is not None or custom_message is not None
+        if template_index is not None and has_custom_template:
+            raise ManualAlertToolError(
+                "use either template_index or custom template fields, not both"
+            )
+
+        template_added = False
+        if template_index is not None:
+            if template_index >= len(templates):
+                raise ManualAlertToolError(
+                    "template_index is out of date; refresh Manual Alert context"
+                )
+            template = templates[template_index]
+            template_source = "configured"
+        elif has_custom_template:
+            sanitized = sanitize_manual_alert_templates([{
+                "title": custom_title,
+                "message": custom_message,
+            }])
+            if len(sanitized) != 1:
+                raise ManualAlertToolError(
+                    "custom_template_title and custom_template_message must both be valid"
+                )
+            template = sanitized[0]
+            exact_template_index = next(
+                (
+                    index for index, configured in enumerate(templates)
+                    if configured == template
+                ),
+                None,
+            )
+            if exact_template_index is not None:
+                template_index = exact_template_index
+                template = templates[template_index]
+                template_source = "configured"
+            else:
+                title_conflict = next(
+                    (
+                        configured for configured in templates
+                        if configured.get("title") == template["title"]
+                    ),
+                    None,
+                )
+                if title_conflict is not None:
+                    raise ManualAlertToolError(
+                        "a template with this title already exists with a different message"
+                    )
+                if len(templates) >= _MAX_MANUAL_ALERT_TEMPLATES:
+                    raise ManualAlertToolError(
+                        f"session already has the maximum {_MAX_MANUAL_ALERT_TEMPLATES} Manual Alert templates"
+                    )
+                template_index = len(templates)
+                templates.append(template)
+                template_added = True
+                template_source = "added"
+        else:
+            raise ManualAlertToolError(
+                "template_index or both custom template fields are required"
+            )
+
+        current = [dict(trigger) for trigger in session.spec.manual_alert_triggers]
+        replace_existing = bool(arguments.get("replace_existing_triggers", False))
+        duplicate = next(
+            (
+                trigger for trigger in current
+                if trigger.get("enabled")
+                and float(trigger.get("price")) == price
+                and trigger.get("template") == template
+            ),
+            None,
+        )
+        if duplicate is not None:
+            final_triggers = [duplicate] if replace_existing else current
+            replaced_trigger_count = len(current) - len(final_triggers)
+            if template_added:
+                await self._registry.update_manual_alert_configuration(
+                    session_id,
+                    templates=templates,
+                    triggers=final_triggers,
+                )
+            elif replaced_trigger_count:
+                await self._registry.update_manual_alert_triggers(
+                    session_id,
+                    final_triggers,
+                )
+            return self._set_result(
+                session=session,
+                trigger=duplicate,
+                created=False,
+                template_source=template_source,
+                template_index=template_index,
+                template_added=template_added,
+                replaced_trigger_count=replaced_trigger_count,
+                active_trigger_count=len(final_triggers),
+            )
+
+        if not replace_existing and len(current) >= _MAX_MANUAL_ALERT_TRIGGERS:
+            raise ManualAlertToolError(
+                f"session already has the maximum {_MAX_MANUAL_ALERT_TRIGGERS} Manual Alert triggers"
+            )
+
+        new_trigger = {
+            "enabled": True,
+            "price": price,
+            "template": template,
+        }
+        requested_triggers = [new_trigger] if replace_existing else [*current, new_trigger]
+        if template_added:
+            updated_configuration = await self._registry.update_manual_alert_configuration(
+                session_id,
+                templates=templates,
+                triggers=requested_triggers,
+            )
+            updated = updated_configuration["triggers"]
+        else:
+            updated = await self._registry.update_manual_alert_triggers(
+                session_id,
+                requested_triggers,
+            )
+        expected_count = 1 if replace_existing else len(current) + 1
+        if len(updated) != expected_count:
+            raise RuntimeError("Manual Alert trigger was not persisted")
+        return self._set_result(
+            session=session,
+            trigger=updated[-1],
+            created=True,
+            template_source=template_source,
+            template_index=template_index,
+            template_added=template_added,
+            replaced_trigger_count=len(current) if replace_existing else 0,
+            active_trigger_count=len(updated),
+        )
+
+    async def _delete_triggers(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        session_id = arguments.get("session_id")
+        trigger_ids = arguments.get("trigger_ids") or []
+        delete_all = bool(arguments.get("delete_all", False))
+
+        if session_id is not None and self._registry.get(session_id) is None:
+            raise ManualAlertToolError(
+                "session_id is not an active session; refresh Manual Alert context"
+            )
+
+        if delete_all:
+            if session_id is None:
+                selections = {
+                    active_session_id: None
+                    for active_session_id in self._registry.sessions
+                }
+                scope = "all_sessions"
+            else:
+                selections = {session_id: None}
+                scope = "session"
+        else:
+            selections = {session_id: set(trigger_ids)}
+            scope = "selected"
+
+        deleted_records = await self._registry.delete_manual_alert_triggers(selections)
+        deleted_triggers: list[dict[str, Any]] = []
+        deleted_ids: set[str] = set()
+        for record in deleted_records:
+            trigger = record.get("trigger") or {}
+            trigger_id = str(trigger.get("id") or "")
+            deleted_ids.add(trigger_id)
+            template = trigger.get("template") or {}
+            deleted_triggers.append({
+                "session_id": record.get("session_id"),
+                "exchange": record.get("exchange"),
+                "symbol": record.get("symbol"),
+                "timeframe": record.get("timeframe"),
+                "trigger_id": trigger_id,
+                "price": trigger.get("price"),
+                "template_title": str(template.get("title") or ""),
+            })
+
+        remaining = [
+            {
+                "session_id": selected_session_id,
+                "active_trigger_count": len(
+                    self._registry.sessions[selected_session_id].spec.manual_alert_triggers
+                ),
+            }
+            for selected_session_id in selections
+        ]
+        return {
+            "deleted": bool(deleted_triggers),
+            "scope": scope,
+            "deleted_count": len(deleted_triggers),
+            "affected_session_count": len({
+                trigger["session_id"] for trigger in deleted_triggers
+            }),
+            "deleted_triggers": deleted_triggers,
+            "not_found_trigger_ids": [
+                trigger_id for trigger_id in trigger_ids
+                if trigger_id not in deleted_ids
+            ],
+            "templates_preserved": True,
+            "remaining": remaining,
+        }
+
+    @staticmethod
+    def _set_result(
+        *,
+        session: Any,
+        trigger: dict[str, Any],
+        created: bool,
+        template_source: str,
+        template_index: int,
+        template_added: bool,
+        replaced_trigger_count: int,
+        active_trigger_count: int,
+    ) -> dict[str, Any]:
+        template = trigger.get("template") or {}
+        return {
+            "set": True,
+            "created": created,
+            "session_id": session.spec.id,
+            "exchange": session.spec.exchange,
+            "symbol": session.spec.symbol,
+            "timeframe": session.spec.timeframe,
+            "trigger_id": str(trigger.get("id") or ""),
+            "price": trigger.get("price"),
+            "template_title": str(template.get("title") or ""),
+            "template_source": template_source,
+            "template_index": template_index,
+            "template_added": template_added,
+            "replaced_trigger_count": replaced_trigger_count,
+            "active_trigger_count": active_trigger_count,
+        }
+
+
+class ManualAlertTools:
+    """Expose context lookup and persistent Manual Alert trigger changes."""
+
+    def __init__(self, registry: Any) -> None:
+        self.bridge = ManualAlertRegistryBridge(registry)
+
+    @property
+    def names(self) -> set[str]:
+        return {_CONTEXT_TOOL_NAME, _SET_TOOL_NAME, _DELETE_TOOL_NAME}
+
+    @property
+    def specs(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "type": "function",
+                "name": _CONTEXT_TOOL_NAME,
+                "description": (
+                    "List active PyneReal sessions, their exact session IDs, current prices, "
+                    "configured Manual Alert templates, and active price triggers. Call this "
+                    "before setting or deleting a Manual Alert. Do not guess a session, template, "
+                    "or trigger when the user's request can match more than one result."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": _SET_TOOL_NAME,
+                "description": (
+                    "Persist one Manual Alert price trigger in an active PyneReal session. Use "
+                    "only after the user has clearly identified the session, trigger price, and "
+                    "alert template. For a session with templates, pass the exact template_index "
+                    "from get_manual_alert_context when the requested template exists. If the "
+                    "requested template is missing, first ask the user for both its title and "
+                    "message format, then pass the custom fields; the tool adds that template and "
+                    "sets the trigger together. Never invent missing values."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Exact active session_id returned by get_manual_alert_context.",
+                        },
+                        "price": {
+                            "type": "number",
+                            "exclusiveMinimum": 0,
+                            "description": "Exact positive trigger price explicitly requested by the user.",
+                        },
+                        "template_index": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "description": "Configured template index. Required only when templates exist.",
+                        },
+                        "custom_template_title": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 100,
+                            "description": "User-supplied title for a requested template that is not configured.",
+                        },
+                        "custom_template_message": {
+                            "type": "string",
+                            "minLength": 1,
+                            "maxLength": 5000,
+                            "description": "User-supplied message format for a template that is not configured.",
+                        },
+                        "replace_existing_triggers": {
+                            "type": "boolean",
+                            "description": (
+                                "Set true only when the user explicitly asks to remove every active "
+                                "trigger in this session and replace them with this new trigger. "
+                                "Configured templates are always preserved."
+                            ),
+                        },
+                    },
+                    "required": ["session_id", "price"],
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": _DELETE_TOOL_NAME,
+                "description": (
+                    "Delete selected or all active Manual Alert price triggers while always "
+                    "preserving configured templates. First call get_manual_alert_context and "
+                    "resolve natural-language targets to internal IDs; never ask the user to "
+                    "provide IDs. For selected deletion, pass one session_id and one or more "
+                    "trigger_ids. Set delete_all=true with a session_id only when the user asks "
+                    "to delete all triggers in that session. Omit session_id with delete_all=true "
+                    "only when the user explicitly asks to delete all Manual Alerts across every "
+                    "session. Ask for clarification when the deletion scope is ambiguous."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": {
+                            "type": "string",
+                            "minLength": 1,
+                            "description": "Exact session ID for selected or session-wide deletion.",
+                        },
+                        "trigger_ids": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": 50,
+                            "uniqueItems": True,
+                            "items": {
+                                "type": "string",
+                                "minLength": 1,
+                                "maxLength": 64,
+                            },
+                            "description": "Exact active trigger IDs for selected deletion.",
+                        },
+                        "delete_all": {
+                            "type": "boolean",
+                            "description": "Explicit all-triggers scope; never infer this from an ambiguous request.",
+                        },
+                    },
+                    "additionalProperties": False,
+                },
+            },
+        ]
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.bridge.bind_loop(loop)
+
+    def unbind_loop(self) -> None:
+        self.bridge.unbind_loop()
+
+    def handle_server_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if method != "item/tool/call" or not isinstance(params, dict):
+            return {}
+        tool = params.get("tool")
+        if tool not in self.names:
+            return {}
+
+        try:
+            arguments = params.get("arguments")
+            if not isinstance(arguments, dict):
+                raise ManualAlertToolError("Tool arguments must be an object")
+            if tool == _CONTEXT_TOOL_NAME:
+                self._validate_context_arguments(arguments)
+                result = self.bridge.execute("context", arguments)
+            elif tool == _SET_TOOL_NAME:
+                validated = self._validate_set_arguments(arguments)
+                result = self.bridge.execute("set_trigger", validated)
+            else:
+                validated = self._validate_delete_arguments(arguments)
+                result = self.bridge.execute("delete_triggers", validated)
+        except ManualAlertToolError as exc:
+            return self._tool_response(False, {"error": str(exc)})
+        except Exception as exc:
+            print(f"[ai] Manual Alert tool failed: {type(exc).__name__}")
+            return self._tool_response(
+                False,
+                {"error": f"Manual Alert operation failed ({type(exc).__name__})"},
+            )
+
+        if tool == _SET_TOOL_NAME:
+            print(
+                f"[ai] Manual Alert set session={result['session_id']} "
+                f"price={result['price']} template={result['template_title']!r} "
+                f"created={result['created']}"
+            )
+        elif tool == _DELETE_TOOL_NAME:
+            print(
+                f"[ai] Manual Alert delete scope={result['scope']} "
+                f"deleted={result['deleted_count']}"
+            )
+        return self._tool_response(True, result)
+
+    @staticmethod
+    def _validate_context_arguments(arguments: dict[str, Any]) -> None:
+        if arguments:
+            raise ManualAlertToolError("get_manual_alert_context does not accept arguments")
+
+    @staticmethod
+    def _validate_set_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
+        allowed = {
+            "session_id",
+            "price",
+            "template_index",
+            "custom_template_title",
+            "custom_template_message",
+            "replace_existing_triggers",
+        }
+        unexpected = sorted(set(arguments) - allowed)
+        if unexpected:
+            raise ManualAlertToolError(
+                f"Unexpected argument field(s): {', '.join(unexpected)}"
+            )
+
+        session_id = arguments.get("session_id")
+        if not isinstance(session_id, str) or not session_id.strip():
+            raise ManualAlertToolError("session_id must be a non-empty string")
+
+        price = arguments.get("price")
+        if isinstance(price, bool) or not isinstance(price, (int, float)):
+            raise ManualAlertToolError("price must be a number")
+        price = float(price)
+        if not math.isfinite(price) or price <= 0:
+            raise ManualAlertToolError("price must be a finite positive number")
+
+        template_index = arguments.get("template_index")
+        if template_index is not None:
+            if isinstance(template_index, bool) or not isinstance(template_index, int):
+                raise ManualAlertToolError("template_index must be a non-negative integer")
+            if template_index < 0:
+                raise ManualAlertToolError("template_index must be a non-negative integer")
+
+        custom_title = arguments.get("custom_template_title")
+        if custom_title is not None and not isinstance(custom_title, str):
+            raise ManualAlertToolError("custom_template_title must be a string")
+        custom_message = arguments.get("custom_template_message")
+        if custom_message is not None and not isinstance(custom_message, str):
+            raise ManualAlertToolError("custom_template_message must be a string")
+        if isinstance(custom_title, str) and len(custom_title.strip()) > 100:
+            raise ManualAlertToolError("custom_template_title exceeds 100 characters")
+        if isinstance(custom_message, str) and len(custom_message.strip()) > 5000:
+            raise ManualAlertToolError("custom_template_message exceeds 5000 characters")
+        replace_existing = arguments.get("replace_existing_triggers", False)
+        if not isinstance(replace_existing, bool):
+            raise ManualAlertToolError("replace_existing_triggers must be boolean")
+
+        validated = dict(arguments)
+        validated["session_id"] = session_id.strip()
+        validated["price"] = price
+        validated["replace_existing_triggers"] = replace_existing
+        return validated
+
+    @staticmethod
+    def _validate_delete_arguments(arguments: dict[str, Any]) -> dict[str, Any]:
+        unexpected = sorted(set(arguments) - {"session_id", "trigger_ids", "delete_all"})
+        if unexpected:
+            raise ManualAlertToolError(
+                f"Unexpected argument field(s): {', '.join(unexpected)}"
+            )
+
+        session_id = arguments.get("session_id")
+        if session_id is not None:
+            if not isinstance(session_id, str) or not session_id.strip():
+                raise ManualAlertToolError("session_id must be a non-empty string")
+            session_id = session_id.strip()
+
+        delete_all = arguments.get("delete_all", False)
+        if not isinstance(delete_all, bool):
+            raise ManualAlertToolError("delete_all must be boolean")
+
+        trigger_ids = arguments.get("trigger_ids")
+        if delete_all:
+            if trigger_ids is not None:
+                raise ManualAlertToolError(
+                    "trigger_ids cannot be combined with delete_all=true"
+                )
+            return {
+                "session_id": session_id,
+                "delete_all": True,
+            }
+
+        if session_id is None:
+            raise ManualAlertToolError(
+                "session_id is required for selected trigger deletion"
+            )
+        if not isinstance(trigger_ids, list) or not trigger_ids:
+            raise ManualAlertToolError(
+                "trigger_ids must be a non-empty array for selected deletion"
+            )
+        if len(trigger_ids) > 50:
+            raise ManualAlertToolError("trigger_ids can contain at most 50 items")
+
+        normalized_ids: list[str] = []
+        for trigger_id in trigger_ids:
+            if not isinstance(trigger_id, str) or not trigger_id.strip():
+                raise ManualAlertToolError("each trigger_id must be a non-empty string")
+            trigger_id = trigger_id.strip()
+            if len(trigger_id) > 64:
+                raise ManualAlertToolError("trigger_id exceeds 64 characters")
+            if trigger_id not in normalized_ids:
+                normalized_ids.append(trigger_id)
+
+        return {
+            "session_id": session_id,
+            "trigger_ids": normalized_ids,
+            "delete_all": False,
+        }
+
+    @staticmethod
+    def _tool_response(success: bool, payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "success": success,
+            "contentItems": [
+                {
+                    "type": "inputText",
+                    "text": json.dumps(payload, ensure_ascii=False),
+                }
+            ],
+        }

--- a/ai/scripts/position.py
+++ b/ai/scripts/position.py
@@ -1,0 +1,708 @@
+#!/usr/bin/env python3
+"""Collect normalized, read-only exchange positions through CCXT."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import ssl
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+import certifi
+import ccxt
+from websockets.sync.client import connect
+
+from asset import (
+    DEFAULT_CONFIG,
+    build_exchange,
+    eprint,
+    number_or_none,
+    read_provider_config,
+    redact_error,
+    select_accounts,
+    secret_values,
+    utc_now,
+)
+
+
+SCHEMA_VERSION = "1.4"
+DEFAULT_ACCOUNT_TYPE = "swap"
+
+BINANCE_ALL_POSITION_SCOPES = (
+    (
+        "usd_m",
+        {"type": "swap", "subType": "linear", "useV2": True},
+    ),
+    (
+        "coin_m",
+        {"type": "delivery", "subType": "inverse"},
+    ),
+)
+BITGET_ALL_POSITION_SCOPES = (
+    "USDT-FUTURES",
+    "USDC-FUTURES",
+    "COIN-FUTURES",
+)
+
+
+def normalized_side(position: dict[str, Any], contracts: int | float | None) -> str | None:
+    side = position.get("side")
+    if isinstance(side, str) and side.lower() in {"long", "short"}:
+        return side.lower()
+    if contracts is not None and contracts < 0:
+        return "short"
+    return None
+
+
+def normalize_position(position: dict[str, Any]) -> dict[str, Any]:
+    contracts = number_or_none(position.get("contracts"))
+    contract_size = number_or_none(position.get("contractSize"))
+    quantity = contracts
+    if contracts is not None and contract_size is not None:
+        quantity = contracts * contract_size
+    return {
+        "symbol": str(position.get("symbol") or ""),
+        "side": normalized_side(position, contracts),
+        "quantity": quantity,
+        "contracts": contracts,
+        "contract_size": contract_size,
+        "notional": number_or_none(position.get("notional")),
+        "leverage": number_or_none(position.get("leverage")),
+        "entry_price": number_or_none(position.get("entryPrice")),
+        "mark_price": number_or_none(position.get("markPrice")),
+        "liquidation_price": number_or_none(position.get("liquidationPrice")),
+        "collateral": number_or_none(position.get("collateral")),
+        "initial_margin": number_or_none(position.get("initialMargin")),
+        "maintenance_margin": number_or_none(position.get("maintenanceMargin")),
+        "margin_ratio": number_or_none(position.get("marginRatio")),
+        "margin_mode": position.get("marginMode"),
+        "hedged": position.get("hedged") if isinstance(position.get("hedged"), bool) else None,
+        "unrealized_pnl": number_or_none(position.get("unrealizedPnl")),
+        "realized_pnl": number_or_none(position.get("realizedPnl")),
+        "percentage": number_or_none(position.get("percentage")),
+        "stop_loss_price": number_or_none(position.get("stopLossPrice")),
+        "take_profit_price": number_or_none(position.get("takeProfitPrice")),
+        "timestamp": position.get("timestamp"),
+        "datetime": position.get("datetime"),
+        "last_update_timestamp": position.get("lastUpdateTimestamp"),
+    }
+
+
+def normalize_hyperliquid_position(position: dict[str, Any]) -> dict[str, Any]:
+    normalized = normalize_position(position)
+    info = position.get("info")
+    info = info if isinstance(info, dict) else {}
+    entry = info.get("position")
+    entry = entry if isinstance(entry, dict) else {}
+    return_on_equity = number_or_none(entry.get("returnOnEquity"))
+    if return_on_equity is not None:
+        normalized["percentage"] = round(return_on_equity * 100, 12)
+        return normalized
+
+    unrealized_pnl = number_or_none(normalized.get("unrealized_pnl"))
+    initial_margin = number_or_none(normalized.get("initial_margin"))
+    normalized["percentage"] = (
+        round(unrealized_pnl / initial_margin * 100, 12)
+        if unrealized_pnl is not None and initial_margin not in {None, 0}
+        else None
+    )
+    return normalized
+
+
+def is_open_position(position: dict[str, Any]) -> bool:
+    for key in ("contracts", "quantity", "notional"):
+        value = number_or_none(position.get(key))
+        if value is not None and value != 0:
+            return True
+    return False
+
+
+def fetch_positions_with_retry(
+    exchange: ccxt.Exchange,
+    symbols: list[str] | None,
+    params: dict[str, Any],
+    attempts: int,
+    secrets: list[str],
+) -> list[dict[str, Any]]:
+    for attempt in range(1, attempts + 1):
+        try:
+            positions = exchange.fetch_positions(symbols, params)
+            if not isinstance(positions, list):
+                raise TypeError("CCXT fetch_positions() returned a non-list result")
+            return [item for item in positions if isinstance(item, dict)]
+        except (
+            ccxt.ArgumentsRequired,
+            ccxt.AuthenticationError,
+            ccxt.BadRequest,
+            ccxt.NotSupported,
+            ccxt.PermissionDenied,
+        ):
+            raise
+        except ccxt.BaseError as exc:
+            if attempt >= attempts:
+                raise
+            delay = min(2 ** (attempt - 1), 4)
+            eprint(
+                f"[position] {exchange.id} fetch failed ({attempt}/{attempts}): "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}; retrying in {delay}s"
+            )
+            time.sleep(delay)
+    raise RuntimeError("position retry loop ended unexpectedly")
+
+
+def binance_position_scopes(
+    account_type: str,
+    all_derivative_scopes: bool,
+) -> list[tuple[str, dict[str, Any]]]:
+    if all_derivative_scopes or account_type == "all":
+        return [(name, dict(params)) for name, params in BINANCE_ALL_POSITION_SCOPES]
+    if account_type in {"coin", "coin-m", "coin_m", "delivery", "inverse"}:
+        return [("coin_m", {"type": "delivery", "subType": "inverse"})]
+    return [
+        (
+            "usd_m",
+            {"type": account_type, "subType": "linear", "useV2": True},
+        )
+    ]
+
+
+def bitget_position_scopes(
+    account_type: str,
+    all_derivative_scopes: bool,
+) -> list[str]:
+    if all_derivative_scopes or account_type == "all":
+        return list(BITGET_ALL_POSITION_SCOPES)
+    product_types = {
+        "coin": "COIN-FUTURES",
+        "coin-futures": "COIN-FUTURES",
+        "coin_m": "COIN-FUTURES",
+        "delivery": "COIN-FUTURES",
+        "inverse": "COIN-FUTURES",
+        "linear": "USDT-FUTURES",
+        "swap": "USDT-FUTURES",
+        "future": "USDT-FUTURES",
+        "usdc": "USDC-FUTURES",
+        "usdc-futures": "USDC-FUTURES",
+        "usdt": "USDT-FUTURES",
+        "usdt-futures": "USDT-FUTURES",
+    }
+    product_type = product_types.get(account_type)
+    if product_type is None:
+        raise ValueError(f"unsupported Bitget position account type: {account_type}")
+    return [product_type]
+
+
+def fetch_bitget_positions_with_retry(
+    exchange: ccxt.Exchange,
+    product_type: str,
+    symbols: list[str] | None,
+    attempts: int,
+    secrets: list[str],
+) -> list[dict[str, Any]]:
+    for attempt in range(1, attempts + 1):
+        try:
+            exchange.load_markets()
+            response = exchange.privateMixGetV2MixPositionAllPosition(
+                {"productType": product_type}
+            )
+            raw_positions = response.get("data") if isinstance(response, dict) else None
+            if not isinstance(raw_positions, list):
+                raise TypeError("Bitget all-position endpoint returned invalid data")
+            positions = [
+                exchange.parse_position(item)
+                for item in raw_positions
+                if isinstance(item, dict)
+            ]
+            if symbols:
+                requested = set(symbols)
+                positions = [
+                    position
+                    for position in positions
+                    if position.get("symbol") in requested
+                ]
+            return positions
+        except (
+            ccxt.ArgumentsRequired,
+            ccxt.AuthenticationError,
+            ccxt.BadRequest,
+            ccxt.NotSupported,
+            ccxt.PermissionDenied,
+        ):
+            raise
+        except ccxt.BaseError as exc:
+            if attempt >= attempts:
+                raise
+            delay = min(2 ** (attempt - 1), 4)
+            eprint(
+                f"[position] bitget {product_type} fetch failed "
+                f"({attempt}/{attempts}): {type(exc).__name__}: "
+                f"{redact_error(exc, secrets)}; retrying in {delay}s"
+            )
+            time.sleep(delay)
+    raise RuntimeError("Bitget position retry loop ended unexpectedly")
+
+
+def hyperliquid_ws_url(exchange: ccxt.Exchange) -> str:
+    api = exchange.urls.get("api", {})
+    public_url = api.get("public") if isinstance(api, dict) else None
+    if not isinstance(public_url, str):
+        raise ValueError("Hyperliquid public API URL is not configured")
+    public_url = public_url.replace("{hostname}", str(exchange.hostname))
+    if public_url.startswith("https://"):
+        return f"wss://{public_url.removeprefix('https://').rstrip('/')}/ws"
+    if public_url.startswith("http://"):
+        return f"ws://{public_url.removeprefix('http://').rstrip('/')}/ws"
+    raise ValueError(f"unsupported Hyperliquid public API URL: {public_url}")
+
+
+def parse_hyperliquid_dex_states(value: Any) -> list[tuple[str, dict[str, Any]]]:
+    if isinstance(value, dict):
+        items = value.items()
+    elif isinstance(value, list):
+        items = (
+            item
+            for item in value
+            if isinstance(item, list) and len(item) == 2
+        )
+    else:
+        raise TypeError("Hyperliquid clearinghouseStates has an invalid type")
+
+    states: list[tuple[str, dict[str, Any]]] = []
+    for raw_dex, state in items:
+        if not isinstance(state, dict):
+            continue
+        dex = str(raw_dex or "").strip().lower() or "default"
+        states.append((dex, state))
+    if not states:
+        raise ValueError("Hyperliquid returned no DEX clearinghouse states")
+    return states
+
+
+def fetch_hyperliquid_all_dex_states(
+    exchange: ccxt.Exchange,
+    attempts: int,
+    secrets: list[str],
+) -> list[tuple[str, dict[str, Any]]]:
+    wallet_address, _ = exchange.handle_public_address("fetchPositions", {})
+    wallet_address = str(wallet_address or "").strip()
+    if not wallet_address:
+        raise ccxt.ArgumentsRequired("Hyperliquid walletAddress is required")
+    request = {
+        "method": "subscribe",
+        "subscription": {
+            "type": "allDexsClearinghouseState",
+            "user": wallet_address,
+        },
+    }
+    ssl_context = ssl.create_default_context(cafile=certifi.where())
+    for attempt in range(1, attempts + 1):
+        try:
+            with connect(
+                hyperliquid_ws_url(exchange),
+                ssl=ssl_context,
+                open_timeout=10,
+                close_timeout=5,
+            ) as websocket:
+                websocket.send(json.dumps(request))
+                deadline = time.monotonic() + min(exchange.timeout / 1000, 30)
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise TimeoutError("Hyperliquid all-DEX position snapshot timed out")
+                    message = json.loads(websocket.recv(timeout=remaining))
+                    if not isinstance(message, dict):
+                        continue
+                    if message.get("channel") != "allDexsClearinghouseState":
+                        continue
+                    data = message.get("data")
+                    if not isinstance(data, dict):
+                        raise TypeError("Hyperliquid all-DEX snapshot has invalid data")
+                    return parse_hyperliquid_dex_states(data.get("clearinghouseStates"))
+        except Exception as exc:
+            if attempt >= attempts:
+                raise
+            delay = min(2 ** (attempt - 1), 4)
+            eprint(
+                f"[position] hyperliquid all-DEX snapshot failed ({attempt}/{attempts}): "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}; "
+                f"retrying in {delay}s"
+            )
+            time.sleep(delay)
+    raise RuntimeError("Hyperliquid all-DEX snapshot retry loop ended unexpectedly")
+
+
+def configure_hyperliquid_dex_markets(
+    exchange: ccxt.Exchange,
+    dexes: list[str],
+) -> None:
+    fetch_markets = exchange.options.get("fetchMarkets")
+    fetch_markets = dict(fetch_markets) if isinstance(fetch_markets, dict) else {}
+    fetch_markets["types"] = ["swap"] + (["hip3"] if dexes else [])
+    hip3 = fetch_markets.get("hip3")
+    hip3 = dict(hip3) if isinstance(hip3, dict) else {}
+    hip3["dexes"] = dexes
+    fetch_markets["hip3"] = hip3
+    exchange.options["fetchMarkets"] = fetch_markets
+
+
+def load_hyperliquid_position_markets(
+    exchange: ccxt.Exchange,
+    dexes: list[str],
+    attempts: int,
+    secrets: list[str],
+) -> None:
+    configure_hyperliquid_dex_markets(exchange, dexes)
+    for attempt in range(1, attempts + 1):
+        try:
+            exchange.load_markets()
+            return
+        except ccxt.BaseError as exc:
+            if attempt >= attempts:
+                raise
+            delay = min(2 ** (attempt - 1), 4)
+            eprint(
+                f"[position] hyperliquid market metadata failed ({attempt}/{attempts}): "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}; "
+                f"retrying in {delay}s"
+            )
+            time.sleep(delay)
+    raise RuntimeError("Hyperliquid market metadata retry loop ended unexpectedly")
+
+
+def fetch_hyperliquid_positions(
+    exchange: ccxt.Exchange,
+    args: argparse.Namespace,
+    secrets: list[str],
+) -> tuple[list[dict[str, Any]], list[str], str]:
+    if not args.dex and not args.symbols:
+        states = fetch_hyperliquid_all_dex_states(exchange, args.attempts, secrets)
+        active_dexes = [
+            dex
+            for dex, state in states
+            if dex != "default" and state.get("assetPositions")
+        ]
+        if any(state.get("assetPositions") for _, state in states):
+            load_hyperliquid_position_markets(
+                exchange,
+                active_dexes,
+                args.attempts,
+                secrets,
+            )
+        positions: list[dict[str, Any]] = []
+        for dex, state in states:
+            raw_positions = state.get("assetPositions", [])
+            if not isinstance(raw_positions, list):
+                raise TypeError(f"Hyperliquid {dex} assetPositions has an invalid type")
+            for raw_position in raw_positions:
+                if not isinstance(raw_position, dict):
+                    continue
+                normalized = normalize_hyperliquid_position(
+                    exchange.parse_position(raw_position)
+                )
+                normalized["dex"] = dex
+                positions.append(normalized)
+        return (
+            positions,
+            [dex for dex, _ in states],
+            "hyperliquid.all_dexs_clearinghouse_state",
+        )
+
+    dexes: list[str | None] = [args.dex] if args.dex else [None]
+
+    positions: list[dict[str, Any]] = []
+    queried_dexes: list[str] = []
+    for dex in dexes:
+        params = {"dex": dex} if dex else {}
+        fetched = fetch_positions_with_retry(
+            exchange,
+            args.symbols or None,
+            params,
+            args.attempts,
+            secrets,
+        )
+        dex_name = dex or "default"
+        queried_dexes.append(dex_name)
+        for position in fetched:
+            normalized = normalize_hyperliquid_position(position)
+            normalized["dex"] = dex_name
+            positions.append(normalized)
+    return positions, queried_dexes, "ccxt.fetch_positions"
+
+
+def collect_one(
+    account_name: str,
+    exchange_id: str,
+    account_type: str,
+    config: dict[str, Any],
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    secrets = secret_values(config)
+    exchange: ccxt.Exchange | None = None
+    eprint(
+        f"[position] collecting account={account_name} exchange={exchange_id} "
+        f"account_type={account_type}"
+    )
+    try:
+        exchange = build_exchange(exchange_id, config, args.timeout_ms, account_type)
+        if not exchange.has.get("fetchPositions"):
+            raise ccxt.NotSupported(f"{exchange_id} does not support fetchPositions")
+        if exchange_id == "hyperliquid":
+            normalized, queried_dexes, source = fetch_hyperliquid_positions(
+                exchange,
+                args,
+                secrets,
+            )
+            queried_scopes = ["all_dexs"] if not args.dex and not args.symbols else []
+        elif exchange_id == "binance":
+            normalized = []
+            queried_dexes = []
+            queried_scopes = []
+            scopes = binance_position_scopes(
+                account_type,
+                args.all_derivative_scopes,
+            )
+            for scope, params in scopes:
+                positions = fetch_positions_with_retry(
+                    exchange,
+                    args.symbols or None,
+                    params,
+                    args.attempts,
+                    secrets,
+                )
+                queried_scopes.append(scope)
+                for position in positions:
+                    item = normalize_position(position)
+                    item["market_scope"] = scope
+                    normalized.append(item)
+            source = "ccxt.fetch_positions"
+        elif exchange_id == "bitget":
+            normalized = []
+            queried_dexes = []
+            queried_scopes = []
+            product_types = bitget_position_scopes(
+                account_type,
+                args.all_derivative_scopes,
+            )
+            for product_type in product_types:
+                positions = fetch_bitget_positions_with_retry(
+                    exchange,
+                    product_type,
+                    args.symbols or None,
+                    args.attempts,
+                    secrets,
+                )
+                queried_scopes.append(product_type)
+                for position in positions:
+                    item = normalize_position(position)
+                    item["market_scope"] = product_type
+                    normalized.append(item)
+            source = "bitget.all_position"
+        else:
+            params: dict[str, Any] = {"type": account_type}
+            positions = fetch_positions_with_retry(
+                exchange,
+                args.symbols or None,
+                params,
+                args.attempts,
+                secrets,
+            )
+            normalized = [normalize_position(position) for position in positions]
+            queried_dexes = []
+            queried_scopes = [account_type]
+            source = "ccxt.fetch_positions"
+        if not args.include_closed:
+            normalized = [position for position in normalized if is_open_position(position)]
+        normalized.sort(
+            key=lambda item: (
+                str(item.get("dex")),
+                str(item.get("symbol")),
+                str(item.get("side")),
+            )
+        )
+        return {
+            "account": account_name,
+            "exchange": exchange_id,
+            "account_type": account_type,
+            "dex": (
+                args.dex or ("all" if not args.symbols else None)
+                if exchange_id == "hyperliquid"
+                else None
+            ),
+            "queried_dexes": queried_dexes if exchange_id == "hyperliquid" else None,
+            "queried_scopes": queried_scopes,
+            "source": source,
+            "positions": normalized,
+            "position_count": len(normalized),
+            "status": "ok",
+        }
+    except Exception as exc:
+        message = redact_error(exc, secrets)
+        eprint(
+            f"[position] {account_name}/{exchange_id}/{account_type} failed: "
+            f"{type(exc).__name__}: {message}"
+        )
+        return {
+            "account": account_name,
+            "exchange": exchange_id,
+            "account_type": account_type,
+            "dex": args.dex if exchange_id == "hyperliquid" else None,
+            "queried_scopes": [],
+            "source": (
+                "hyperliquid.all_dexs_clearinghouse_state"
+                if exchange_id == "hyperliquid" and not args.dex and not args.symbols
+                else "ccxt.fetch_positions"
+            ),
+            "positions": [],
+            "position_count": 0,
+            "status": "error",
+            "error": {"type": type(exc).__name__, "message": message},
+        }
+    finally:
+        if exchange is not None:
+            try:
+                exchange.close()
+            except Exception:
+                pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Read normalized exchange positions from providers.toml via CCXT."
+    )
+    parser.add_argument(
+        "--account",
+        "--profile",
+        action="append",
+        dest="accounts",
+        help="Configured ccxt account name. Repeat for multiple accounts.",
+    )
+    parser.add_argument(
+        "--exchange",
+        action="append",
+        dest="exchanges",
+        help="CCXT exchange id. Selects every configured account for that exchange.",
+    )
+    parser.add_argument(
+        "--account-type",
+        action="append",
+        dest="account_types",
+        help=(
+            "Limit the derivative scope, for example swap, usdc, or delivery. "
+            "By default all supported scopes are queried."
+        ),
+    )
+    parser.add_argument(
+        "--symbol",
+        action="append",
+        dest="symbols",
+        help="CCXT unified symbol. Repeat to filter multiple symbols.",
+    )
+    parser.add_argument(
+        "--dex",
+        help="Hyperliquid HIP-3 perp DEX name, for example xyz.",
+    )
+    parser.add_argument(
+        "--include-closed",
+        action="store_true",
+        help="Include zero-size position records returned by the exchange.",
+    )
+    parser.add_argument("--config", type=Path, default=DEFAULT_CONFIG)
+    parser.add_argument("--timeout-ms", type=int, default=30_000)
+    parser.add_argument("--attempts", type=int, default=3)
+    args = parser.parse_args()
+    if args.timeout_ms <= 0:
+        parser.error("--timeout-ms must be greater than zero")
+    if args.attempts <= 0:
+        parser.error("--attempts must be greater than zero")
+    args.all_derivative_scopes = not bool(args.account_types)
+    args.account_types = list(
+        dict.fromkeys(
+            value.strip().lower()
+            for value in (args.account_types or [DEFAULT_ACCOUNT_TYPE])
+            if value.strip()
+        )
+    )
+    args.symbols = list(
+        dict.fromkeys(value.strip() for value in (args.symbols or []) if value.strip())
+    )
+    args.dex = args.dex.strip().lower() if isinstance(args.dex, str) and args.dex.strip() else None
+    return args
+
+
+def print_fatal_result(error_type: str, message: str) -> None:
+    output = {
+        "schema_version": SCHEMA_VERSION,
+        "collected_at": utc_now(),
+        "source": "exchange.positions",
+        "read_only": True,
+        "results": [],
+        "summary": {
+            "requested": 0,
+            "succeeded": 0,
+            "failed": 1,
+            "open_positions": 0,
+        },
+        "error": {"type": error_type, "message": message},
+    }
+    print(json.dumps(output, ensure_ascii=False, indent=2, allow_nan=False))
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        data = read_provider_config(args.config.resolve())
+    except Exception as exc:
+        message = str(exc).replace("\n", " ")[:500]
+        eprint(f"[position] config error: {type(exc).__name__}: {message}")
+        print_fatal_result(type(exc).__name__, message)
+        return 2
+
+    try:
+        accounts = select_accounts(data, args.accounts, args.exchanges)
+    except Exception as exc:
+        message = str(exc).replace("\n", " ")[:500]
+        eprint(f"[position] account config error: {type(exc).__name__}: {message}")
+        print_fatal_result(type(exc).__name__, message)
+        return 2
+    if not accounts:
+        eprint(
+            "[position] no account selected; pass --account/--exchange or configure "
+            "[ccxt.<exchange>] or [ccxt_accounts.<name>]"
+        )
+        print_fatal_result("ConfigurationError", "no exchange account selected or configured")
+        return 2
+
+    results = [
+        collect_one(
+            account.name,
+            account.exchange_id,
+            account_type,
+            account.config,
+            args,
+        )
+        for account in accounts
+        for account_type in args.account_types
+    ]
+    failed = sum(result["status"] != "ok" for result in results)
+    output = {
+        "schema_version": SCHEMA_VERSION,
+        "collected_at": utc_now(),
+        "source": "exchange.positions",
+        "read_only": True,
+        "results": results,
+        "summary": {
+            "requested": len(results),
+            "succeeded": len(results) - failed,
+            "failed": failed,
+            "open_positions": sum(result["position_count"] for result in results),
+        },
+    }
+    print(json.dumps(output, ensure_ascii=False, indent=2, allow_nan=False))
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/ai/scripts/telegram_tool.py
+++ b/ai/scripts/telegram_tool.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+_TOOL_NAME = "send_telegram_message"
+_MAX_MESSAGE_CHARS = 12_000
+_TELEGRAM_CHUNK_CHARS = 3_900
+
+
+class TelegramToolError(ValueError):
+    """A Telegram delivery rejected before any network request was made."""
+
+
+def _load_default_token() -> str:
+    from data_service.config import default_telegram_token
+
+    return default_telegram_token()
+
+
+def _load_default_chat_id() -> str:
+    from data_service.config import default_telegram_chat_id
+
+    return default_telegram_chat_id()
+
+
+def _send_default_message(token: str, chat_id: str, text: str) -> dict[str, Any]:
+    from data_service.manual_alerts import post_telegram_message
+
+    return post_telegram_message(token, chat_id, text)
+
+
+class TelegramMessageTool:
+    """Send AI results to the server-configured Telegram destination."""
+
+    def __init__(
+        self,
+        *,
+        token_loader: Callable[[], str] = _load_default_token,
+        chat_id_loader: Callable[[], str] = _load_default_chat_id,
+        sender: Callable[[str, str, str], dict[str, Any]] = _send_default_message,
+    ) -> None:
+        self._token_loader = token_loader
+        self._chat_id_loader = chat_id_loader
+        self._sender = sender
+
+    @property
+    def name(self) -> str:
+        return _TOOL_NAME
+
+    @property
+    def spec(self) -> dict[str, Any]:
+        return {
+            "type": "function",
+            "name": _TOOL_NAME,
+            "description": (
+                "Send a completed result to the Telegram chat configured by the server's "
+                "BOT_TOKEN and CHAT_ID. Use only when the user explicitly asks to send the "
+                "result to Telegram. Pass concise plain text; do not include credentials."
+            ),
+            "inputSchema": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "minLength": 1,
+                        "maxLength": _MAX_MESSAGE_CHARS,
+                        "description": "Complete plain-text message to deliver.",
+                    },
+                },
+                "required": ["message"],
+                "additionalProperties": False,
+            },
+        }
+
+    def handle_server_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if method != "item/tool/call" or not isinstance(params, dict):
+            return {}
+        if params.get("tool") != _TOOL_NAME:
+            return {}
+
+        try:
+            arguments = params.get("arguments")
+            if not isinstance(arguments, dict):
+                raise TelegramToolError("Tool arguments must be an object")
+            result = self.send(arguments)
+        except TelegramToolError as exc:
+            return self._tool_response(False, {"error": str(exc)})
+        except Exception as exc:
+            print(f"[ai] Telegram send failed: {type(exc).__name__}")
+            return self._tool_response(
+                False,
+                {"error": f"Telegram send failed ({type(exc).__name__})"},
+            )
+
+        print(
+            f"[ai] Telegram sent messages={result['messages_sent']} "
+            f"characters={result['characters']}"
+        )
+        return self._tool_response(True, result)
+
+    def send(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        unexpected = sorted(set(arguments) - {"message"})
+        if unexpected:
+            raise TelegramToolError(f"Unexpected argument field(s): {', '.join(unexpected)}")
+
+        message = arguments.get("message")
+        if not isinstance(message, str) or not message.strip():
+            raise TelegramToolError("message must be a non-empty string")
+        message = message.strip()
+        if len(message) > _MAX_MESSAGE_CHARS:
+            raise TelegramToolError(
+                f"message exceeds the {_MAX_MESSAGE_CHARS}-character delivery limit"
+            )
+
+        token = self._token_loader().strip()
+        chat_id = self._chat_id_loader().strip()
+        if not token or not chat_id:
+            raise TelegramToolError("BOT_TOKEN and CHAT_ID are not configured")
+
+        chunks = self._split_message(message)
+        sent = 0
+        try:
+            for chunk in chunks:
+                self._sender(token, chat_id, chunk)
+                sent += 1
+        except Exception as exc:
+            print(
+                f"[ai] Telegram partial failure sent={sent}/{len(chunks)} "
+                f"error={type(exc).__name__}"
+            )
+            raise RuntimeError(
+                f"Telegram delivery stopped after {sent}/{len(chunks)} message(s)"
+            ) from exc
+
+        return {
+            "sent": True,
+            "messages_sent": sent,
+            "characters": len(message),
+        }
+
+    @staticmethod
+    def _split_message(message: str) -> list[str]:
+        chunks: list[str] = []
+        remaining = message
+        while len(remaining) > _TELEGRAM_CHUNK_CHARS:
+            split_at = remaining.rfind("\n", 0, _TELEGRAM_CHUNK_CHARS + 1)
+            if split_at <= 0:
+                split_at = _TELEGRAM_CHUNK_CHARS
+            else:
+                split_at += 1
+            chunks.append(remaining[:split_at])
+            remaining = remaining[split_at:]
+        if remaining:
+            chunks.append(remaining)
+        return chunks
+
+    @staticmethod
+    def _tool_response(success: bool, payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "success": success,
+            "contentItems": [
+                {
+                    "type": "inputText",
+                    "text": json.dumps(payload, ensure_ascii=False),
+                }
+            ],
+        }

--- a/ai/workflows/delete_manual_alert.md
+++ b/ai/workflows/delete_manual_alert.md
@@ -1,0 +1,22 @@
+# Delete Manual Alert Triggers
+
+Use this workflow only when the user explicitly asks to delete active Manual
+Alert price triggers. Deleting triggers never deletes configured templates.
+
+1. Call `get_manual_alert_context`.
+2. Resolve symbols, asset or company names, exchanges, timeframes, strategy
+   names, alert titles, and prices to active sessions and triggers. Use IDs only
+   internally; never ask the user to provide them.
+3. For one or more selected triggers in one session, pass that `session_id` and
+   the exact `trigger_ids` to `delete_manual_alert_triggers`.
+4. If the user explicitly asks to delete every trigger in one session, pass its
+   `session_id` with `delete_all=true`.
+5. If the user explicitly asks to delete every Manual Alert without limiting the
+   request to a session, call the tool with only `delete_all=true`.
+6. If the target or scope is ambiguous and the user did not say all, ask for a
+   human-readable distinction before deleting anything.
+7. Report the deleted count and affected symbols only from the tool result.
+
+If one instruction asks to clear a session and immediately set a new trigger in
+that same session, use the setting workflow with
+`replace_existing_triggers=true` instead of this workflow.

--- a/ai/workflows/evaluate_position.md
+++ b/ai/workflows/evaluate_position.md
@@ -1,0 +1,37 @@
+# Evaluate Position
+
+## Goal
+
+Evaluate the current state and risk of a running strategy position using fresh,
+read-only evidence.
+
+## Inputs
+
+- PyneReal session identifier
+- Strategy name and script path
+- Exchange account or provider identifier
+- Symbol and timeframe
+
+## Procedure
+
+1. Collect the current session and strategy state.
+2. Run `python ai/scripts/position.py --account <account>` with the relevant
+   symbol, account type, or Hyperliquid DEX. Use `--exchange <exchange>` only
+   when every configured account for that exchange must be evaluated. Then
+   collect balances, open orders, and recent executions from their dedicated
+   read-only scripts.
+3. Collect the latest confirmed market bars and relevant strategy outputs.
+4. Verify that timestamps, symbols, position sides, and quantities agree across
+   the collected sources.
+5. Evaluate exposure, entry stage, liquidation and margin risk, invalidation
+   conditions, and plausible response choices.
+
+## Response
+
+Report the observation time, factual position summary, strategy state, primary
+risks, missing evidence, and a concise evaluation. Separate facts from judgment.
+During collection, report only the account, exchange, or market currently being
+queried and material partial failures. Do not narrate instruction reading,
+repository exploration, workflow selection, script option checks, or plans for
+the final response. Start the final response with the observation time and
+position result rather than a generic preamble.

--- a/ai/workflows/inspect_account.md
+++ b/ai/workflows/inspect_account.md
@@ -45,3 +45,8 @@ as the account currently being queried or a partial failure. Do not mention
 instruction files, repository inspection, workflow selection, script option
 review, or plans to organize the result. Start the final response with the
 observation time and account scope, then present the balances directly.
+
+When the user explicitly asks to send the result to Telegram, first complete
+the account lookup, convert the result to concise plain text, and call
+`send_telegram_message`. Do not claim delivery unless the tool succeeds. Without
+an explicit Telegram instruction, return the result only in browser chat.

--- a/ai/workflows/inspect_account.md
+++ b/ai/workflows/inspect_account.md
@@ -1,0 +1,47 @@
+# Inspect Account
+
+## Goal
+
+Produce a read-only snapshot of an exchange account for a requested market or
+symbol.
+
+## Procedure
+
+1. Resolve the account scope without printing credentials. If no account or
+   exchange is specified, select every account configured in
+   `workdir/config/providers.toml`. If only an exchange is specified, select
+   every configured account for that exchange. Select one account only when its
+   configured account name is explicitly given.
+2. For exchange asset balances, use the matching command:
+   - No account or exchange specified: `python ai/scripts/asset.py`
+   - Exchange specified: `python ai/scripts/asset.py --exchange <exchange>`
+   - Account specified: `python ai/scripts/asset.py --account <account>`
+   The default command collects spot, futures, margin, funding, and earn assets.
+   Add `--account-type` only when the request intentionally limits the scope.
+3. For derivative positions, use the matching command:
+   - No account or exchange specified: `python ai/scripts/position.py`
+   - Exchange specified: `python ai/scripts/position.py --exchange <exchange>`
+   - Account specified: `python ai/scripts/position.py --account <account>`
+   With no `--account-type`, Binance includes USD-M (USDT-M and USDC-M) and
+   COIN-M, while Bitget includes USDT-, USDC-, and Coin-M futures. Treat this
+   complete product scope as the default for a general position request.
+   Add `--symbol`, `--account-type`, or Hyperliquid `--dex` when explicitly
+   requested or otherwise required by the named market. Do not add `--dex` to a
+   general Hyperliquid position request; omitting it includes the default Perp
+   DEX and all HIP-3 DEXs from one `allDexsClearinghouseState` WebSocket
+   snapshot.
+4. Collect any additionally requested open orders and recent executions with
+   their dedicated read-only scripts.
+5. Normalize exchange-specific values into the relevant schema under
+   `ai/schemas/`.
+6. Verify the exchange timestamp and record the collection time.
+7. Report unavailable endpoints or partial results instead of fabricating data.
+
+## Response
+
+Return a concise account summary followed by risks or inconsistencies found in
+the collected evidence. During collection, report only concrete progress such
+as the account currently being queried or a partial failure. Do not mention
+instruction files, repository inspection, workflow selection, script option
+review, or plans to organize the result. Start the final response with the
+observation time and account scope, then present the balances directly.

--- a/ai/workflows/set_manual_alert.md
+++ b/ai/workflows/set_manual_alert.md
@@ -1,0 +1,29 @@
+# Set Manual Alert Trigger
+
+Use this workflow only when the user explicitly asks to set a Manual Alert
+price trigger.
+
+1. Call `get_manual_alert_context`.
+2. Match the user's symbol, company or asset name, exchange, timeframe, or
+   strategy description to one exact active session. Use its `session_id`
+   internally; never ask the user to provide that ID.
+3. Require one exact positive trigger price.
+4. If the requested template exists, use its returned `index`.
+5. If the requested template does not exist, ask the user for both its title
+   and message format. Preserve the supplied format exactly and pass both custom
+   fields so the tool adds the template and trigger in one operation. Do not
+   tell the user to add it through the dashboard.
+6. If more than one session matches, ask a concise question using a meaningful
+   distinction such as exchange, timeframe, or strategy name. If another value
+   is missing or ambiguous, ask for it and stop without calling the setting
+   tool.
+7. Call `set_manual_alert_trigger` with the resolved values.
+8. Report the session, symbol, price, and template title returned by the tool.
+
+If the same instruction explicitly asks to remove every existing trigger in the
+selected session before setting the new one, pass
+`replace_existing_triggers=true`. This replaces the trigger list in one save and
+preserves all configured templates. Do not call the deletion tool first.
+
+Do not send the alert immediately. Do not edit `sessions.json` directly. The
+data service persists the trigger and handles price-touch firing and removal.

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -591,6 +591,41 @@ def build_control_router(registry: SessionRegistry, codex_service: CodexService)
     async def get_ai_chat() -> JSONResponse:
         return JSONResponse(_present_ai_chat_state(await codex_service.chat_state()))
 
+    @r.get("/api/ai/models")
+    async def get_ai_models() -> JSONResponse:
+        try:
+            models = await codex_service.model_options()
+            prefs = await codex_service.chat_preferences()
+        except Exception as e:
+            return JSONResponse({"error": str(e)}, status_code=503)
+        return JSONResponse({
+            "models": models,
+            "selected_model": prefs["model"],
+            "selected_effort": prefs["effort"],
+        })
+
+    @r.put("/api/ai/chat/preferences")
+    async def set_ai_chat_preferences(payload: dict = Body(default_factory=dict)) -> JSONResponse:
+        model = payload.get("model")
+        if model is not None and not isinstance(model, str):
+            return JSONResponse({"error": "model must be a string"}, status_code=400)
+        effort = payload.get("effort")
+        if effort is not None and not isinstance(effort, str):
+            return JSONResponse({"error": "effort must be a string"}, status_code=400)
+        try:
+            prefs = await codex_service.set_chat_preferences(model, effort)
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
+        except Exception as e:
+            return JSONResponse({"error": str(e)}, status_code=503)
+        # other connected browsers switch to the same selection
+        await registry.hub_ws.broadcast_json({
+            "type": "ai_prefs_updated",
+            "model": prefs["model"],
+            "effort": prefs["effort"],
+        })
+        return JSONResponse(prefs)
+
     @r.put("/api/ai/chat/state")
     async def import_ai_chat_state(payload: dict = Body(default_factory=dict)) -> JSONResponse:
         conversation_id = payload.get("conversation_id")
@@ -617,6 +652,28 @@ def build_control_router(registry: SessionRegistry, codex_service: CodexService)
         conversation_id = payload.get("conversation_id")
         if conversation_id is not None and not isinstance(conversation_id, str):
             return JSONResponse({"error": "conversation_id must be a string"}, status_code=400)
+        model = payload.get("model")
+        if model is not None and not isinstance(model, str):
+            return JSONResponse({"error": "model must be a string"}, status_code=400)
+        effort = payload.get("effort")
+        if effort is not None and not isinstance(effort, str):
+            return JSONResponse({"error": "effort must be a string"}, status_code=400)
+        try:
+            model = await codex_service.validate_model(model)
+            effort = await codex_service.validate_effort(effort, model)
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
+        if model is None or effort is None:
+            # fall back to the shared dashboard selection (or its defaults)
+            try:
+                prefs = await codex_service.chat_preferences()
+            except Exception:
+                prefs = None
+            if prefs:
+                if model is None:
+                    model = prefs["model"]
+                if effort is None and model == prefs["model"]:
+                    effort = prefs["effort"]
         history = _sanitize_ai_chat_history(payload.get("history"))
         async def notify_chat_updated() -> None:
             await registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})
@@ -626,6 +683,8 @@ def build_control_router(registry: SessionRegistry, codex_service: CodexService)
             client_conversation_id=(conversation_id or "").strip() or None,
             client_history=history,
             on_state_changed=notify_chat_updated,
+            model=model,
+            effort=effort,
         )
 
         async def stream() -> AsyncIterator[str]:

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -689,7 +689,10 @@ def build_control_router(registry: SessionRegistry, codex_service: CodexService)
 
     @r.get("/api/sessions")
     def list_sessions() -> JSONResponse:
-        return JSONResponse({"sessions": registry.snapshots()})
+        return JSONResponse({
+            "sessions": registry.snapshots(),
+            "ai_enabled": codex_service.enabled,
+        })
 
     @r.put("/api/sessions/order")
     async def reorder_sessions(payload: dict = Body(default_factory=dict)) -> JSONResponse:

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -19,6 +19,7 @@ from pynecore.core.csv_file import CSVReader
 
 import ccxt.pro as ccxtpro
 
+from ai.provider.codex_service import CodexService
 from registry import (
     SessionExistsError,
     SessionLimitError,
@@ -33,7 +34,6 @@ from config import (
     sanitize_manual_alert_templates,
     sanitize_manual_alert_triggers,
 )
-from codex_service import CodexService
 from manual_alerts import send_manual_alert_payload
 from ohlcv_io import make_ccxt_pro_client
 
@@ -618,16 +618,22 @@ def build_control_router(registry: SessionRegistry, codex_service: CodexService)
         if conversation_id is not None and not isinstance(conversation_id, str):
             return JSONResponse({"error": "conversation_id must be a string"}, status_code=400)
         history = _sanitize_ai_chat_history(payload.get("history"))
+        async def notify_chat_updated() -> None:
+            await registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})
+
+        run = codex_service.start_shared_chat(
+            message,
+            client_conversation_id=(conversation_id or "").strip() or None,
+            client_history=history,
+            on_state_changed=notify_chat_updated,
+        )
+
         async def stream() -> AsyncIterator[str]:
             streamed_answer = ""
             pending_delta = ""
             last_delta_emit = 0.0
             try:
-                async for event in codex_service.stream_shared_chat(
-                    message,
-                    client_conversation_id=(conversation_id or "").strip() or None,
-                    client_history=history,
-                ):
+                async for event in run.events():
                     if event.event == "delta":
                         delta = str(event.payload.get("text") or "")
                         streamed_answer += delta
@@ -648,14 +654,16 @@ def build_control_router(registry: SessionRegistry, codex_service: CodexService)
                             {"text": pending_delta, "html": _render_ai_markdown(streamed_answer)},
                         )
                         pending_delta = ""
-                    if event.event in ("conversation", "done"):
-                        await registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})
                     event_payload = event.payload
                     if event.event == "done":
                         answer = str(event.payload.get("answer") or "")
                         event_payload = {**event.payload, "html": _render_ai_markdown(answer)}
                     yield _sse_event(event.event, event_payload)
             except asyncio.CancelledError:
+                print(
+                    f"[ai] stream={run.id} client disconnected; "
+                    "background turn continues"
+                )
                 raise
             except Exception as e:
                 await registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 import asyncio
 import ast
 import json
+import time
 from datetime import datetime, UTC
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 from fastapi import APIRouter, Body, Request
 from fastapi.responses import JSONResponse, StreamingResponse
+from markdown_it import MarkdownIt
 
 from pynecore.cli.app import app_state
 from pynecore.core.exchange_policy import tradingview_hides_zero_volume
@@ -31,12 +33,21 @@ from config import (
     sanitize_manual_alert_templates,
     sanitize_manual_alert_triggers,
 )
+from codex_service import CodexService
 from manual_alerts import send_manual_alert_payload
 from ohlcv_io import make_ccxt_pro_client
 
 # Cache of exchange -> ccxt markets so symbol validation hits the network at most
 # once per exchange for the hub's lifetime.
 _markets_cache: dict[tuple[str, str], dict] = {}
+_AI_CHAT_MAX_MESSAGE_CHARS = 4000
+_AI_CHAT_MAX_HISTORY_MESSAGES = 12
+_AI_MARKDOWN_STREAM_INTERVAL_SECONDS = 0.05
+_AI_MARKDOWN = MarkdownIt(
+    "commonmark",
+    {"html": False, "linkify": False, "typographer": False},
+).enable("table")
+_AI_STRONG_WORD_BOUNDARY_TOKEN = "AI_MD_STRONG_WORD_BOUNDARY_7F1C"
 
 
 def _tail_log_text(log_path: Path, lines: int) -> tuple[str, int]:
@@ -49,6 +60,70 @@ def _tail_log_text(log_path: Path, lines: int) -> tuple[str, int]:
 def _sse_event(event: str, payload: dict[str, Any]) -> str:
     data = json.dumps(payload, ensure_ascii=False)
     return f"event: {event}\ndata: {data}\n\n"
+
+
+def _normalize_ai_strong_word_boundaries(content: str) -> str:
+    normalized: list[str] = []
+    strong_open = False
+    index = 0
+    while index < len(content):
+        if content.startswith("**", index):
+            normalized.append("**")
+            index += 2
+            if strong_open:
+                if index < len(content) and (content[index].isalnum() or content[index] == "_"):
+                    normalized.append(f" {_AI_STRONG_WORD_BOUNDARY_TOKEN}")
+                strong_open = False
+            else:
+                strong_open = True
+            continue
+        char = content[index]
+        normalized.append(char)
+        index += 1
+        if char == "\n":
+            strong_open = False
+    return "".join(normalized)
+
+
+def _render_ai_markdown(content: str) -> str:
+    normalized = _normalize_ai_strong_word_boundaries(content)
+    return _AI_MARKDOWN.render(normalized).replace(
+        f" {_AI_STRONG_WORD_BOUNDARY_TOKEN}",
+        "",
+    )
+
+
+def _present_ai_chat_state(state: dict[str, Any]) -> dict[str, Any]:
+    presented = dict(state)
+    messages: list[dict[str, Any]] = []
+    for raw in state.get("messages", []):
+        if not isinstance(raw, dict):
+            continue
+        message = dict(raw)
+        content = message.get("content")
+        if message.get("role") == "assistant" and not message.get("error") and isinstance(content, str):
+            message["html"] = _render_ai_markdown(content)
+        messages.append(message)
+    presented["messages"] = messages
+    return presented
+
+
+def _sanitize_ai_chat_history(raw: Any) -> list[dict[str, str]]:
+    if not isinstance(raw, list):
+        return []
+    items: list[dict[str, str]] = []
+    for entry in raw:
+        if not isinstance(entry, dict):
+            continue
+        role = entry.get("role")
+        content = entry.get("content")
+        if role not in ("user", "assistant") or not isinstance(content, str):
+            continue
+        content = content.strip()
+        if not content:
+            continue
+        items.append({"role": role, "content": content[:_AI_CHAT_MAX_MESSAGE_CHARS]})
+    return items[-_AI_CHAT_MAX_HISTORY_MESSAGES:]
 
 
 def _market_type_from_market(market: dict) -> str:
@@ -72,12 +147,18 @@ def _market_scope_from_symbol(exchange: str, symbol: str) -> str:
     return "inverse"
 
 
-async def _load_exchange_markets(exchange: str, symbol: str) -> dict:
+async def _load_exchange_markets(
+    exchange: str,
+    symbol: str,
+    *,
+    force_refresh: bool = False,
+) -> tuple[dict, bool]:
     scope = _market_scope_from_symbol(exchange, symbol)
     cache_key = (exchange, scope)
-    cached = _markets_cache.get(cache_key)
-    if cached is not None:
-        return cached
+    if not force_refresh:
+        cached = _markets_cache.get(cache_key)
+        if cached is not None:
+            return cached, True
     ex = make_ccxt_pro_client(
         ccxtpro,
         exchange,
@@ -93,7 +174,16 @@ async def _load_exchange_markets(exchange: str, symbol: str) -> dict:
         except Exception:
             pass
     _markets_cache[cache_key] = markets
-    return markets
+    return markets, False
+
+
+async def _find_exchange_market(exchange: str, symbol: str) -> dict | None:
+    markets, from_cache = await _load_exchange_markets(exchange, symbol)
+    market = markets.get(symbol)
+    if market is None and from_cache:
+        markets, _ = await _load_exchange_markets(exchange, symbol, force_refresh=True)
+        market = markets.get(symbol)
+    return market
 
 
 # Cache of script path -> (mtime, is_strategy) so we only AST-parse on change.
@@ -494,8 +584,100 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
 # ----------------------------------------------------------------------
 # Control-plane router:  /api/sessions ...
 # ----------------------------------------------------------------------
-def build_control_router(registry: SessionRegistry) -> APIRouter:
+def build_control_router(registry: SessionRegistry, codex_service: CodexService) -> APIRouter:
     r = APIRouter()
+
+    @r.get("/api/ai/chat")
+    async def get_ai_chat() -> JSONResponse:
+        return JSONResponse(_present_ai_chat_state(await codex_service.chat_state()))
+
+    @r.put("/api/ai/chat/state")
+    async def import_ai_chat_state(payload: dict = Body(default_factory=dict)) -> JSONResponse:
+        conversation_id = payload.get("conversation_id")
+        if conversation_id is not None and not isinstance(conversation_id, str):
+            return JSONResponse({"error": "conversation_id must be a string"}, status_code=400)
+        state = await codex_service.import_chat_state(
+            payload.get("messages"),
+            (conversation_id or "").strip() or None,
+        )
+        await registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})
+        return JSONResponse(_present_ai_chat_state(state))
+
+    @r.post("/api/ai/chat")
+    async def ai_chat(payload: dict = Body(default_factory=dict)):
+        message = payload.get("message")
+        if not isinstance(message, str) or not message.strip():
+            return JSONResponse({"error": "message must be a non-empty string"}, status_code=400)
+        message = message.strip()
+        if len(message) > _AI_CHAT_MAX_MESSAGE_CHARS:
+            return JSONResponse(
+                {"error": f"message is too long (max {_AI_CHAT_MAX_MESSAGE_CHARS} chars)"},
+                status_code=400,
+            )
+        conversation_id = payload.get("conversation_id")
+        if conversation_id is not None and not isinstance(conversation_id, str):
+            return JSONResponse({"error": "conversation_id must be a string"}, status_code=400)
+        history = _sanitize_ai_chat_history(payload.get("history"))
+        async def stream() -> AsyncIterator[str]:
+            streamed_answer = ""
+            pending_delta = ""
+            last_delta_emit = 0.0
+            try:
+                async for event in codex_service.stream_shared_chat(
+                    message,
+                    client_conversation_id=(conversation_id or "").strip() or None,
+                    client_history=history,
+                ):
+                    if event.event == "delta":
+                        delta = str(event.payload.get("text") or "")
+                        streamed_answer += delta
+                        pending_delta += delta
+                        now = time.monotonic()
+                        if last_delta_emit and now - last_delta_emit < _AI_MARKDOWN_STREAM_INTERVAL_SECONDS:
+                            continue
+                        yield _sse_event(
+                            "delta",
+                            {"text": pending_delta, "html": _render_ai_markdown(streamed_answer)},
+                        )
+                        pending_delta = ""
+                        last_delta_emit = now
+                        continue
+                    if event.event == "done" and pending_delta:
+                        yield _sse_event(
+                            "delta",
+                            {"text": pending_delta, "html": _render_ai_markdown(streamed_answer)},
+                        )
+                        pending_delta = ""
+                    if event.event in ("conversation", "done"):
+                        await registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})
+                    event_payload = event.payload
+                    if event.event == "done":
+                        answer = str(event.payload.get("answer") or "")
+                        event_payload = {**event.payload, "html": _render_ai_markdown(answer)}
+                    yield _sse_event(event.event, event_payload)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                await registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})
+                yield _sse_event("stream_error", {"error": str(e)})
+
+        return StreamingResponse(
+            stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache, no-transform",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @r.post("/api/ai/chat/reset")
+    async def reset_ai_chat(payload: dict = Body(default_factory=dict)) -> JSONResponse:
+        conversation_id = payload.get("conversation_id")
+        await codex_service.clear_shared_chat(
+            conversation_id.strip() if isinstance(conversation_id, str) else None
+        )
+        await registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})
+        return JSONResponse({"ok": True})
 
     @r.get("/api/sessions")
     def list_sessions() -> JSONResponse:
@@ -685,11 +867,10 @@ def build_validation_router() -> APIRouter:
         if exchange not in ccxtpro.exchanges:
             return JSONResponse({"exists": False, "error": f"unknown exchange: {exchange}"})
         try:
-            markets = await _load_exchange_markets(exchange, symbol)
+            market = await _find_exchange_market(exchange, symbol)
         except Exception as e:
             # Network/market-load failure: don't claim the symbol is invalid.
             return JSONResponse({"exists": None, "error": f"could not load markets: {e}"})
-        market = markets.get(symbol)
         if not market:
             return JSONResponse({"exists": False})
         return JSONResponse({"exists": True, "market_type": _market_type_from_market(market)})

--- a/data_service/codex_service.py
+++ b/data_service/codex_service.py
@@ -1,0 +1,550 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import time
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from openai_codex import ApprovalMode, AsyncCodex, AsyncThread, CodexConfig, Sandbox
+from openai_codex.errors import TransportClosedError
+from openai_codex.generated.v2_all import (
+    AgentMessageDeltaNotification,
+    AgentMessageThreadItem,
+    CommandExecutionThreadItem,
+    DynamicToolCallThreadItem,
+    ItemCompletedNotification,
+    ItemStartedNotification,
+    McpToolCallThreadItem,
+    MessagePhase,
+    ReasoningEffort,
+    TurnCompletedNotification,
+    TurnStatus,
+    WebSearchThreadItem,
+)
+
+DEFAULT_DEVELOPER_INSTRUCTIONS = (
+    "너는 PyneReal 대시보드의 AI 어시스턴트야. "
+    "조회만 수행하고 주문, 취소, 레버리지 변경 등 계정 상태를 변경하는 작업과 파일 수정은 하지 마. "
+    "계정이나 거래소를 지정하지 않은 자산 또는 포지션 조회 요청은 providers.toml에 등록된 "
+    "모든 계정을 대상으로 전용 스크립트를 실행해. "
+    "DB 접속정보와 API key, secret 등 비밀값은 응답에 포함하지 마. "
+    "자산 또는 포지션 조회의 중간 진행 설명에는 실제 조회 대상, 조회 진행, 부분 실패처럼 "
+    "사용자에게 의미 있는 상태만 포함해. 지침 파일 확인, 저장소 탐색, 워크플로 선택, 실행 옵션 "
+    "검토 같은 내부 준비 과정이나 결과를 나중에 정리하겠다는 설명은 출력하지 마. "
+    "최종 답변도 작업 절차를 나열하지 말고 조회 결과부터 바로 제시해."
+)
+_MAX_PERSISTED_MESSAGES = 200
+_MAX_CONTEXT_MESSAGES = 12
+_MAX_PERSISTED_CONTENT_CHARS = 40_000
+
+
+@dataclass(frozen=True)
+class CodexStreamEvent:
+    event: str
+    payload: dict[str, Any]
+
+
+class CodexService:
+    """Own one long-running Codex app-server and its dashboard chat threads."""
+
+    def __init__(
+        self,
+        project_root: Path,
+        developer_instructions: str = DEFAULT_DEVELOPER_INSTRUCTIONS,
+        timeout_seconds: float = 180,
+        chat_state_path: Path | None = None,
+    ) -> None:
+        self.project_root = project_root.resolve()
+        self.developer_instructions = developer_instructions
+        self.timeout_seconds = timeout_seconds
+        self.chat_state_path = (
+            chat_state_path or self.project_root / "workdir" / "config" / "ai_chat.json"
+        ).resolve()
+        self._codex: AsyncCodex | None = None
+        self._lifecycle_lock = asyncio.Lock()
+        self._conversations_lock = asyncio.Lock()
+        self._shared_chat_lock = asyncio.Lock()
+        self._chat_state_lock = asyncio.Lock()
+        self._conversations: dict[str, AsyncThread] = {}
+        self._turn_locks: dict[str, asyncio.Lock] = {}
+        self._warm_thread_task: asyncio.Task[AsyncThread | None] | None = None
+        self._chat_messages: list[dict[str, Any]] = []
+        self._chat_conversation_id: str | None = None
+        self._load_chat_state()
+
+    async def start(self) -> None:
+        async with self._lifecycle_lock:
+            if self._codex is not None:
+                return
+
+            started_at = time.perf_counter()
+            codex_bin = shutil.which("codex")
+            codex = AsyncCodex(CodexConfig(
+                codex_bin=codex_bin,
+                cwd=str(self.project_root),
+                config_overrides=(
+                    "sandbox_workspace_write.network_access=true",
+                    'web_search="live"',
+                ),
+            ))
+            try:
+                await codex.__aenter__()
+                account = await codex.account()
+                if account.account is None:
+                    raise RuntimeError("Codex is not authenticated; run `codex login` first")
+            except Exception:
+                await codex.close()
+                raise
+
+            self._codex = codex
+            self._warm_thread_task = asyncio.create_task(self._prepare_warm_thread(codex))
+            elapsed_ms = (time.perf_counter() - started_at) * 1000
+            print(
+                "[ai] Codex app-server started with the current local login "
+                f"in {elapsed_ms:.0f}ms"
+            )
+
+    async def close(self) -> None:
+        async with self._lifecycle_lock:
+            codex = self._codex
+            self._codex = None
+            warm_thread_task = self._warm_thread_task
+            self._warm_thread_task = None
+            self._conversations.clear()
+            self._turn_locks.clear()
+            if warm_thread_task is not None:
+                warm_thread_task.cancel()
+                await asyncio.gather(warm_thread_task, return_exceptions=True)
+            if codex is not None:
+                await codex.close()
+                print("[ai] Codex app-server stopped")
+
+    async def stream_chat(
+        self,
+        message: str,
+        *,
+        conversation_id: str | None = None,
+        initial_context: str | None = None,
+        history_messages: int = 0,
+    ) -> AsyncIterator[CodexStreamEvent]:
+        request_started_at = time.perf_counter()
+        trace_id = uuid.uuid4().hex[:8]
+        thread, conversation_id, is_new, thread_source = await self._conversation(conversation_id)
+        prompt = initial_context if is_new and initial_context else message
+        conversation_ms = (time.perf_counter() - request_started_at) * 1000
+        print(
+            f"[ai] chat={trace_id} conversation={'new' if is_new else 'reused'} "
+            f"thread={thread_source} prepare={conversation_ms:.0f}ms "
+            f"history={history_messages if is_new else 0} "
+            f"prompt_chars={len(prompt)}"
+        )
+        yield CodexStreamEvent("conversation", {"conversation_id": conversation_id})
+        async with self._turn_locks[conversation_id]:
+            async for event in self._stream_turn(
+                thread,
+                prompt,
+                trace_id=trace_id,
+                request_started_at=request_started_at,
+            ):
+                yield event
+
+    async def stream_shared_chat(
+        self,
+        message: str,
+        *,
+        client_history: list[dict[str, Any]] | None = None,
+        client_conversation_id: str | None = None,
+    ) -> AsyncIterator[CodexStreamEvent]:
+        async with self._shared_chat_lock:
+            history, conversation_id = await self._begin_shared_chat(
+                message,
+                client_history=client_history,
+                client_conversation_id=client_conversation_id,
+            )
+            try:
+                async for event in self.stream_chat(
+                    message,
+                    conversation_id=conversation_id,
+                    initial_context=self._build_initial_context(message, history),
+                    history_messages=len(history),
+                ):
+                    if event.event == "conversation":
+                        await self._set_chat_conversation_id(
+                            str(event.payload.get("conversation_id") or "") or None
+                        )
+                    elif event.event == "done":
+                        answer = str(event.payload.get("answer") or "").strip()
+                        if answer:
+                            await self._append_chat_message("assistant", answer)
+                    yield event
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                await self._append_chat_message(
+                    "assistant",
+                    f"AI call failed: {e}",
+                    error=True,
+                )
+                raise
+
+    async def chat_state(self) -> dict[str, Any]:
+        async with self._chat_state_lock:
+            return self._chat_state_payload()
+
+    async def import_chat_state(
+        self,
+        messages: Any,
+        conversation_id: str | None,
+    ) -> dict[str, Any]:
+        async with self._chat_state_lock:
+            if not self._chat_messages:
+                imported = self._sanitize_chat_messages(messages)
+                if imported:
+                    self._chat_messages = imported
+                    self._chat_conversation_id = conversation_id or None
+                    self._save_chat_state()
+            return self._chat_state_payload()
+
+    async def clear_shared_chat(self, conversation_id: str | None = None) -> None:
+        async with self._shared_chat_lock:
+            async with self._chat_state_lock:
+                stored_conversation_id = self._chat_conversation_id
+                self._chat_messages = []
+                self._chat_conversation_id = None
+                self._save_chat_state()
+            for value in {conversation_id, stored_conversation_id}:
+                if value:
+                    await self.reset(value)
+
+    async def reset(self, conversation_id: str) -> None:
+        async with self._conversations_lock:
+            self._conversations.pop(conversation_id, None)
+            self._turn_locks.pop(conversation_id, None)
+
+    async def _begin_shared_chat(
+        self,
+        message: str,
+        *,
+        client_history: list[dict[str, Any]] | None,
+        client_conversation_id: str | None,
+    ) -> tuple[list[dict[str, str]], str | None]:
+        async with self._chat_state_lock:
+            if not self._chat_messages and client_history:
+                self._chat_messages = self._sanitize_chat_messages(client_history)
+                self._chat_conversation_id = client_conversation_id or None
+            history = [
+                {"role": item["role"], "content": item["content"]}
+                for item in self._chat_messages
+                if not item.get("error")
+            ][-_MAX_CONTEXT_MESSAGES:]
+            conversation_id = self._chat_conversation_id or client_conversation_id
+            self._chat_messages.append({"role": "user", "content": message})
+            self._chat_messages = self._chat_messages[-_MAX_PERSISTED_MESSAGES:]
+            self._save_chat_state()
+            return history, conversation_id
+
+    async def _set_chat_conversation_id(self, conversation_id: str | None) -> None:
+        async with self._chat_state_lock:
+            if conversation_id == self._chat_conversation_id:
+                return
+            self._chat_conversation_id = conversation_id
+            self._save_chat_state()
+
+    async def _append_chat_message(self, role: str, content: str, *, error: bool = False) -> None:
+        entry: dict[str, Any] = {
+            "role": role,
+            "content": content[:_MAX_PERSISTED_CONTENT_CHARS],
+        }
+        if error:
+            entry["error"] = True
+        async with self._chat_state_lock:
+            self._chat_messages.append(entry)
+            self._chat_messages = self._chat_messages[-_MAX_PERSISTED_MESSAGES:]
+            self._save_chat_state()
+
+    def _load_chat_state(self) -> None:
+        if not self.chat_state_path.exists():
+            return
+        try:
+            payload = json.loads(self.chat_state_path.read_text(encoding="utf-8"))
+            self._chat_messages = self._sanitize_chat_messages(payload.get("messages"))
+            conversation_id = payload.get("conversation_id")
+            self._chat_conversation_id = (
+                conversation_id if isinstance(conversation_id, str) and conversation_id else None
+            )
+        except Exception as e:
+            print(f"[ai] chat state load failed: {e}")
+
+    def _save_chat_state(self) -> None:
+        self.chat_state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.chat_state_path.with_name(self.chat_state_path.name + ".tmp")
+        tmp.write_text(
+            json.dumps(self._chat_state_payload(), ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+        tmp.replace(self.chat_state_path)
+
+    def _chat_state_payload(self) -> dict[str, Any]:
+        return {
+            "conversation_id": self._chat_conversation_id,
+            "messages": [dict(item) for item in self._chat_messages],
+        }
+
+    @staticmethod
+    def _sanitize_chat_messages(raw: Any) -> list[dict[str, Any]]:
+        if not isinstance(raw, list):
+            return []
+        messages: list[dict[str, Any]] = []
+        for item in raw:
+            if not isinstance(item, dict):
+                continue
+            role = item.get("role")
+            content = item.get("content")
+            if role not in ("user", "assistant") or not isinstance(content, str):
+                continue
+            content = content.strip()
+            if not content:
+                continue
+            message: dict[str, Any] = {
+                "role": role,
+                "content": content[:_MAX_PERSISTED_CONTENT_CHARS],
+            }
+            if bool(item.get("error")):
+                message["error"] = True
+            messages.append(message)
+        return messages[-_MAX_PERSISTED_MESSAGES:]
+
+    @staticmethod
+    def _build_initial_context(message: str, history: list[dict[str, str]]) -> str:
+        lines: list[str] = []
+        if history:
+            lines.append("서버에 저장된 이전 대화:")
+            for item in history:
+                role = "사용자" if item["role"] == "user" else "AI"
+                lines.append(f"[{role}] {item['content']}")
+            lines.append("")
+        lines.append(f"[현재 사용자 질문] {message}")
+        return "\n".join(lines)
+
+    async def _get_codex(self) -> AsyncCodex:
+        if self._codex is None:
+            await self.start()
+        if self._codex is None:
+            raise RuntimeError("Codex app-server is unavailable")
+        return self._codex
+
+    async def _conversation(
+        self,
+        conversation_id: str | None,
+    ) -> tuple[AsyncThread, str, bool, str]:
+        async with self._conversations_lock:
+            if conversation_id:
+                thread = self._conversations.get(conversation_id)
+                if thread is not None:
+                    return thread, conversation_id, False, "reused"
+
+            codex = await self._get_codex()
+            warm_thread_task = self._warm_thread_task
+            thread = None
+            if warm_thread_task is not None:
+                thread = await asyncio.shield(warm_thread_task)
+                if self._warm_thread_task is warm_thread_task:
+                    self._warm_thread_task = None
+            thread_source = "prewarmed"
+            if thread is None:
+                thread = await self._start_thread(codex)
+                thread_source = "created"
+            new_id = uuid.uuid4().hex
+            self._conversations[new_id] = thread
+            self._turn_locks[new_id] = asyncio.Lock()
+            return thread, new_id, True, thread_source
+
+    async def _prepare_warm_thread(self, codex: AsyncCodex) -> AsyncThread | None:
+        started_at = time.perf_counter()
+        try:
+            thread = await self._start_thread(codex)
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            elapsed_ms = (time.perf_counter() - started_at) * 1000
+            print(f"[ai] warm thread failed after {elapsed_ms:.0f}ms: {e}")
+            return None
+        elapsed_ms = (time.perf_counter() - started_at) * 1000
+        print(f"[ai] warm thread ready in {elapsed_ms:.0f}ms")
+        return thread
+
+    async def _start_thread(self, codex: AsyncCodex) -> AsyncThread:
+        return await codex.thread_start(
+            approval_mode=ApprovalMode.deny_all,
+            cwd=str(self.project_root),
+            developer_instructions=self.developer_instructions,
+            ephemeral=True,
+            sandbox=Sandbox.workspace_write,
+        )
+
+    @staticmethod
+    def _agent_message(item: Any) -> AgentMessageThreadItem | None:
+        value = item.root if hasattr(item, "root") else item
+        return value if isinstance(value, AgentMessageThreadItem) else None
+
+    @staticmethod
+    def _short_work_value(value: Any, limit: int = 100) -> str:
+        text = " ".join(str(value or "").split())
+        if len(text) <= limit:
+            return text
+        return text[:limit - 3].rstrip() + "..."
+
+    @classmethod
+    def _work_status(cls, item: Any, *, completed: bool) -> str | None:
+        value = item.root if hasattr(item, "root") else item
+        if isinstance(value, WebSearchThreadItem):
+            query = cls._short_work_value(value.query)
+            if completed:
+                return f'Searched the web for "{query}"' if query else "Searched the web"
+            return f'Searching the web for "{query}"...' if query else "Searching the web..."
+        if isinstance(value, CommandExecutionThreadItem):
+            script_name = next(
+                (
+                    Path(token.strip("'\"")).name
+                    for token in value.command.split()
+                    if token.strip("'\"").endswith(".py")
+                ),
+                "local data lookup",
+            )
+            return f"Finished {script_name}" if completed else f"Running {script_name}..."
+        if isinstance(value, McpToolCallThreadItem):
+            tool = cls._short_work_value(value.tool, limit=60) or "MCP tool"
+            return f"Completed {tool}" if completed else f"Calling {tool}..."
+        if isinstance(value, DynamicToolCallThreadItem):
+            tool = cls._short_work_value(value.tool, limit=60) or "tool"
+            return f"Completed {tool}" if completed else f"Running {tool}..."
+        return None
+
+    async def _stream_turn(
+        self,
+        thread: AsyncThread,
+        prompt: str,
+        *,
+        trace_id: str,
+        request_started_at: float,
+    ) -> AsyncIterator[CodexStreamEvent]:
+        turn = None
+        first_event_ms: float | None = None
+        first_delta_ms: float | None = None
+        try:
+            turn_start_requested_at = time.perf_counter()
+            turn = await thread.turn(
+                prompt,
+                approval_mode=ApprovalMode.deny_all,
+                effort=ReasoningEffort.xhigh,
+            )
+            turn_start_ms = (time.perf_counter() - turn_start_requested_at) * 1000
+            request_to_turn_ms = (time.perf_counter() - request_started_at) * 1000
+            print(
+                f"[ai] chat={trace_id} turn_started rpc={turn_start_ms:.0f}ms "
+                f"request_elapsed={request_to_turn_ms:.0f}ms"
+            )
+            phases: dict[str, MessagePhase | None] = {}
+            commentary_texts: dict[str, str] = {}
+            streamed_text = ""
+            final_text = ""
+            stream = turn.stream()
+            try:
+                async with asyncio.timeout(self.timeout_seconds):
+                    async for event in stream:
+                        if first_event_ms is None:
+                            first_event_ms = (time.perf_counter() - request_started_at) * 1000
+                            print(
+                                f"[ai] chat={trace_id} first_event={first_event_ms:.0f}ms "
+                                f"type={event.method}"
+                            )
+                        payload = event.payload
+                        if isinstance(payload, ItemStartedNotification):
+                            message = self._agent_message(payload.item)
+                            if message is not None:
+                                phases[message.id] = message.phase
+                                if message.phase == MessagePhase.commentary:
+                                    commentary_texts[message.id] = message.text
+                            else:
+                                work_status = self._work_status(payload.item, completed=False)
+                                if work_status:
+                                    yield CodexStreamEvent("work_status", {"text": work_status})
+                            continue
+                        if isinstance(payload, AgentMessageDeltaNotification):
+                            phase = phases.get(payload.item_id)
+                            if phase == MessagePhase.commentary:
+                                commentary = commentary_texts.get(payload.item_id, "") + payload.delta
+                                commentary_texts[payload.item_id] = commentary
+                                if commentary.strip():
+                                    yield CodexStreamEvent("status", {"text": commentary})
+                                continue
+                            if first_delta_ms is None:
+                                first_delta_ms = (
+                                    time.perf_counter() - request_started_at
+                                ) * 1000
+                                print(
+                                    f"[ai] chat={trace_id} first_delta={first_delta_ms:.0f}ms"
+                                )
+                            streamed_text += payload.delta
+                            yield CodexStreamEvent("delta", {"text": payload.delta})
+                            continue
+                        if isinstance(payload, ItemCompletedNotification):
+                            message = self._agent_message(payload.item)
+                            if message is not None:
+                                if message.phase == MessagePhase.commentary:
+                                    previous_commentary = commentary_texts.get(message.id, "")
+                                    commentary_texts[message.id] = message.text
+                                    if message.text.strip() and message.text != previous_commentary:
+                                        yield CodexStreamEvent("status", {"text": message.text})
+                                else:
+                                    final_text = message.text
+                            else:
+                                work_status = self._work_status(payload.item, completed=True)
+                                if work_status:
+                                    yield CodexStreamEvent("work_status", {"text": work_status})
+                            continue
+                        if isinstance(payload, TurnCompletedNotification):
+                            if payload.turn.status == TurnStatus.failed:
+                                error = payload.turn.error
+                                raise RuntimeError(
+                                    error.message if error and error.message else "Codex turn failed"
+                                )
+                            if payload.turn.status == TurnStatus.interrupted:
+                                raise RuntimeError("Codex turn was interrupted")
+            except asyncio.TimeoutError:
+                elapsed_ms = (time.perf_counter() - request_started_at) * 1000
+                print(f"[ai] chat={trace_id} timeout total={elapsed_ms:.0f}ms")
+                try:
+                    await turn.interrupt()
+                except Exception:
+                    pass
+                raise RuntimeError("Codex response timed out") from None
+            except asyncio.CancelledError:
+                elapsed_ms = (time.perf_counter() - request_started_at) * 1000
+                print(f"[ai] chat={trace_id} cancelled total={elapsed_ms:.0f}ms")
+                try:
+                    await turn.interrupt()
+                except Exception:
+                    pass
+                raise
+            finally:
+                await stream.aclose()
+        except TransportClosedError:
+            await self.close()
+            raise RuntimeError("Codex app-server stopped unexpectedly; retry the request") from None
+
+        answer = (final_text or streamed_text).strip()
+        if not answer:
+            raise RuntimeError("Codex returned an empty response")
+        total_ms = (time.perf_counter() - request_started_at) * 1000
+        first_delta_label = f"{first_delta_ms:.0f}ms" if first_delta_ms is not None else "none"
+        print(
+            f"[ai] chat={trace_id} completed total={total_ms:.0f}ms "
+            f"first_delta={first_delta_label} answer_chars={len(answer)}"
+        )
+        yield CodexStreamEvent("done", {"answer": answer})

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from config import ensure_provider_config, load_hub_config, load_initial_sessions
+from codex_service import CodexService
 from registry import SessionRegistry
 from api import build_session_api_router, build_control_router, build_validation_router
 from ui import build_ui_router
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 _BANNER = r"""
     ____                   ____             __
@@ -20,10 +24,10 @@ _BANNER = r"""
 """
 
 
-def build_app(registry: SessionRegistry) -> FastAPI:
+def build_app(registry: SessionRegistry, codex_service: CodexService) -> FastAPI:
     app = FastAPI()
     app.include_router(build_ui_router())
-    app.include_router(build_control_router(registry))
+    app.include_router(build_control_router(registry, codex_service))
     app.include_router(build_validation_router())
     app.include_router(build_session_api_router(registry))
 
@@ -109,7 +113,12 @@ async def main() -> None:
     cfg = load_hub_config()
     specs = load_initial_sessions()
     registry = SessionRegistry(port=cfg.port)
-    app = build_app(registry)
+    codex_service = CodexService(project_root=_PROJECT_ROOT)
+    try:
+        await codex_service.start()
+    except Exception as e:
+        print(f"[ai] Codex app-server startup failed: {e}")
+    app = build_app(registry, codex_service)
 
     await registry.start_all(specs)
     heartbeat = asyncio.create_task(_hub_status_heartbeat(registry))
@@ -122,7 +131,10 @@ async def main() -> None:
         await server.serve()
     finally:
         heartbeat.cancel()
-        await registry.shutdown()
+        try:
+            await registry.shutdown()
+        finally:
+            await codex_service.close()
 
 
 if __name__ == "__main__":

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -124,6 +124,7 @@ async def main() -> None:
         project_root=_PROJECT_ROOT,
         session_registry=registry,
     )
+    registry.set_ai_instruction_handler(codex_service.handle_strategy_instruction)
     try:
         await codex_service.start()
     except Exception as e:

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -38,7 +38,11 @@ def build_app(registry: SessionRegistry, codex_service: CodexService) -> FastAPI
     async def hub_ws(ws: WebSocket):
         await registry.hub_ws.connect(ws)
         registry.retry_missing_symbol_logos()
-        await registry.hub_ws.send(ws, {"type": "sessions", "sessions": registry.snapshots()})
+        await registry.hub_ws.send(ws, {
+            "type": "sessions",
+            "sessions": registry.snapshots(),
+            "ai_enabled": codex_service.enabled,
+        })
         try:
             while True:
                 # Dashboard clients only receive pushes; ignore inbound keepalive.

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -1,18 +1,21 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
 
 import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
+from ai.provider.codex_service import CodexService
 from config import ensure_provider_config, load_hub_config, load_initial_sessions
-from codex_service import CodexService
 from registry import SessionRegistry
 from api import build_session_api_router, build_control_router, build_validation_router
 from ui import build_ui_router
-
-_PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
 _BANNER = r"""
     ____                   ____             __
@@ -113,7 +116,10 @@ async def main() -> None:
     cfg = load_hub_config()
     specs = load_initial_sessions()
     registry = SessionRegistry(port=cfg.port)
-    codex_service = CodexService(project_root=_PROJECT_ROOT)
+    codex_service = CodexService(
+        project_root=_PROJECT_ROOT,
+        session_registry=registry,
+    )
     try:
         await codex_service.start()
     except Exception as e:

--- a/data_service/manual_alerts.py
+++ b/data_service/manual_alerts.py
@@ -7,7 +7,20 @@ from typing import Any
 
 import requests
 
-from config import SessionSpec, default_telegram_chat_id, default_telegram_token, default_webhook_url
+try:
+    from .config import (
+        SessionSpec,
+        default_telegram_chat_id,
+        default_telegram_token,
+        default_webhook_url,
+    )
+except ImportError:
+    from config import (
+        SessionSpec,
+        default_telegram_chat_id,
+        default_telegram_token,
+        default_webhook_url,
+    )
 from pynecore.core.exchange_policy import normalize_exchange_name
 
 

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import shutil
 import traceback
-from typing import Dict, List, Optional
+from typing import Awaitable, Callable, Dict, List, Optional
 
 from config import MAX_SESSIONS, FeedSpec, SessionSpec, save_sessions
 from collector_loop import fix_missing_bars_loop, watch_trades_loop
@@ -44,6 +44,9 @@ class SessionRegistry:
         self.supervisor = RunnerSupervisor(port=port, on_change=self.notify_hub)
         self.logo_resolver = TradingViewLogoResolver()
         self.logo_tasks: Dict[str, asyncio.Task] = {}
+        self.ai_instruction_handler: Optional[
+            Callable[[Session, dict], Awaitable[None]]
+        ] = None
 
     # ------------------------------------------------------------------
     # Queries
@@ -79,6 +82,14 @@ class SessionRegistry:
             if task is not None and not task.done():
                 continue
             self._schedule_logo_resolution(session)
+
+    def set_ai_instruction_handler(
+        self,
+        handler: Callable[[Session, dict], Awaitable[None]],
+    ) -> None:
+        self.ai_instruction_handler = handler
+        for session in self.sessions.values():
+            session.on_ai_instruction = handler
 
     def _schedule_logo_resolution(self, session: Session) -> None:
         task = self.logo_tasks.pop(session.spec.id, None)
@@ -162,6 +173,7 @@ class SessionRegistry:
         session = Session(spec, feed)
         session.on_status_change = self.notify_hub
         session.on_spec_change = self._persist_and_notify
+        session.on_ai_instruction = self.ai_instruction_handler
         feed.subscribers[spec.id] = session
         self.sessions[spec.id] = session
         self._schedule_logo_resolution(session)

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -245,6 +245,92 @@ class SessionRegistry:
         await self.notify_hub()
         return [dict(t) for t in session.spec.manual_alert_triggers]
 
+    async def update_manual_alert_configuration(
+        self,
+        session_id: str,
+        *,
+        templates: list[dict],
+        triggers: object,
+    ) -> dict[str, list[dict]]:
+        """Persist templates and triggers together for one AI-driven alert setup."""
+        session = self.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFoundError(session_id)
+
+        previous_spec = session.spec
+        session.spec = (
+            session.spec
+            .with_manual_alert_templates(templates)
+            .with_manual_alert_triggers(triggers)
+        )
+        try:
+            self._persist()
+        except Exception:
+            session.spec = previous_spec
+            raise
+
+        session.reset_manual_alert_trigger_gate()
+        await session.push_manual_alert_trigger()
+        await self.notify_hub()
+        return {
+            "templates": [dict(t) for t in session.spec.manual_alert_templates],
+            "triggers": [dict(t) for t in session.spec.manual_alert_triggers],
+        }
+
+    async def delete_manual_alert_triggers(
+        self,
+        selections: dict[str, set[str] | None],
+    ) -> list[dict]:
+        """Delete selected or all triggers from multiple sessions in one save."""
+        unknown = [session_id for session_id in selections if session_id not in self.sessions]
+        if unknown:
+            raise SessionNotFoundError(unknown[0])
+
+        changes: list[tuple[Session, object, list[dict]]] = []
+        deleted: list[dict] = []
+        for session_id, trigger_ids in selections.items():
+            session = self.sessions[session_id]
+            current = [dict(trigger) for trigger in session.spec.manual_alert_triggers]
+            if trigger_ids is None:
+                removed = current
+                remaining: list[dict] = []
+            else:
+                removed = [
+                    trigger for trigger in current
+                    if str(trigger.get("id") or "") in trigger_ids
+                ]
+                remaining = [
+                    trigger for trigger in current
+                    if str(trigger.get("id") or "") not in trigger_ids
+                ]
+            if not removed:
+                continue
+            changes.append((session, session.spec, removed))
+            session.spec = session.spec.with_manual_alert_triggers(remaining)
+
+        if not changes:
+            return []
+
+        try:
+            self._persist()
+        except Exception:
+            for session, previous_spec, _ in changes:
+                session.spec = previous_spec
+            raise
+
+        for session, _, removed in changes:
+            session.reset_manual_alert_trigger_gate()
+            await session.push_manual_alert_trigger()
+            deleted.extend({
+                "session_id": session.spec.id,
+                "exchange": session.spec.exchange,
+                "symbol": session.spec.symbol,
+                "timeframe": session.spec.timeframe,
+                "trigger": dict(trigger),
+            } for trigger in removed)
+        await self.notify_hub()
+        return deleted
+
     # ------------------------------------------------------------------
     # Runner control
     # ------------------------------------------------------------------

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional
@@ -15,6 +16,10 @@ from ohlcv_paths import make_ohlcv_paths, runtime_output_dir
 from state import DataState
 from tv_logos import static_logo_info
 from ws_manager import WSManager
+
+
+_MAX_AI_INSTRUCTION_CHARS = 4_000
+_MAX_PROCESSED_AI_INSTRUCTION_EVENTS = 500
 
 
 # ======================================================================
@@ -170,6 +175,9 @@ class Session:
         # registry wires this to push /ws/hub status when runner connect/disconnect.
         self.on_status_change: Optional[Callable[[], Awaitable[None]]] = None
         self.on_spec_change: Optional[Callable[[], Awaitable[None]]] = None
+        self.on_ai_instruction: Optional[Callable[["Session", dict], Awaitable[None]]] = None
+        self._processed_ai_instruction_ids: set[str] = set()
+        self._processed_ai_instruction_order: deque[str] = deque()
         self._manual_alert_trigger_sending_ids: set[str] = set()
         self._manual_alert_trigger_last_bar_time: dict[str, int] = {}
 
@@ -287,6 +295,37 @@ class Session:
                         reader.close()
                 except Exception as e:
                     print(f"[{self.spec.id}] Failed to send confirmed bar: {e}")
+
+        elif msg_type == "ai_instruction":
+            if self.client_roles.get(ws) != "runner":
+                return
+            event_id = str(event.get("event_id") or "").strip()
+            instruction = str(event.get("instruction") or "").strip()
+            if not event_id or len(event_id) > 128:
+                log_with_time(f"[{self.spec.id}] ignored AI instruction with invalid event ID")
+                return
+            if not instruction or len(instruction) > _MAX_AI_INSTRUCTION_CHARS:
+                log_with_time(f"[{self.spec.id}] ignored invalid AI instruction")
+                return
+            if event_id in self._processed_ai_instruction_ids:
+                return
+
+            self._processed_ai_instruction_ids.add(event_id)
+            self._processed_ai_instruction_order.append(event_id)
+            while len(self._processed_ai_instruction_order) > _MAX_PROCESSED_AI_INSTRUCTION_EVENTS:
+                expired_id = self._processed_ai_instruction_order.popleft()
+                self._processed_ai_instruction_ids.discard(expired_id)
+
+            if self.on_ai_instruction is None:
+                log_with_time(f"[{self.spec.id}] AI instruction skipped: no handler")
+                return
+            normalized_event = dict(event)
+            normalized_event["event_id"] = event_id
+            normalized_event["instruction"] = instruction
+            try:
+                await self.on_ai_instruction(self, normalized_event)
+            except Exception as e:
+                log_with_time(f"[{self.spec.id}] AI instruction dispatch failed: {e}")
 
         elif msg_type in ("trade_entry", "trade_close"):
             if event not in self.trades_history:

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -648,7 +648,7 @@ tr:last-child td { border-bottom: none; }
   right: 20px;
   bottom: 84px;
   z-index: 59;
-  width: min(380px, calc(100vw - 40px));
+  width: min(520px, calc(100vw - 40px));
   height: min(520px, calc(100vh - 130px));
   display: flex;
   flex-direction: column;
@@ -670,8 +670,22 @@ tr:last-child td { border-bottom: none; }
   display: inline-flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text);
   font-size: 13px;
   font-weight: 600;
+  font-family: inherit;
+  letter-spacing: 0;
+  cursor: default;
+}
+/* desktop title is a plain label; the chevron appears only on mobile, where
+   tapping the title opens the model / reasoning menu */
+.ai-chat-title-chevron {
+  display: none;
+  color: var(--muted);
 }
 .ai-chat-title .pepe {
   width: 18px;
@@ -854,12 +868,20 @@ tr:last-child td { border-bottom: none; }
   40% { opacity: 1; }
 }
 .ai-chat-form {
-  display: flex;
-  align-items: flex-end;
-  gap: 8px;
   padding: 10px;
   border-top: 1px solid var(--border);
 }
+.ai-chat-composer {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  min-width: 0;
+  padding: 7px 7px 7px 11px;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: var(--bg);
+}
+.ai-chat-composer:focus-within { border-color: var(--accent); }
 .ai-chat-input {
   flex: 1;
   min-width: 0;
@@ -869,26 +891,133 @@ tr:last-child td { border-bottom: none; }
   overflow-y: auto;
   scrollbar-width: none;
   resize: none;
-  background: var(--bg);
-  border: 1px solid var(--border);
+  background: transparent;
+  border: 0;
   color: var(--text);
-  border-radius: 8px;
-  padding: 8px 10px;
+  padding: 5px 1px;
   font: inherit;
   font-size: 13px;
   line-height: 1.4;
 }
 .ai-chat-input::-webkit-scrollbar { display: none; }
-.ai-chat-input:focus { outline: none; border-color: var(--accent); }
+.ai-chat-input:focus { outline: none; }
+.ai-chat-composer-actions {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  gap: 6px;
+}
+.ai-model-selector {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  max-width: 190px;
+  height: 32px;
+  padding: 0 8px;
+  overflow: hidden;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 12px;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+.ai-model-selector:hover,
+.ai-model-selector[aria-expanded="true"] { background: #21262d; color: var(--text); }
+.ai-model-selector:disabled { cursor: default; opacity: 0.55; }
+.ai-model-selector > :first-child {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.ai-model-chevron { flex: none; display: block; }
 #ai-chat-send {
   flex: 0 0 auto;
-  align-self: flex-end;
-  height: 36px;
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  background: var(--text);
+  color: var(--bg);
+  font: inherit;
+  font-size: 21px;
+  line-height: 1;
+  cursor: pointer;
 }
-#ai-chat-send:disabled { cursor: wait; opacity: 0.65; }
+#ai-chat-send span { transform: translateY(-1px); }
+#ai-chat-send:disabled { cursor: wait; opacity: 0.4; }
+.ai-model-menu {
+  position: absolute;
+  z-index: 3;
+  width: min(290px, calc(100% - 24px));
+  max-height: min(340px, calc(100% - 110px));
+  padding: 6px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: #161b22;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.45);
+  scrollbar-color: #3a4350 #0b0e13;
+  scrollbar-width: thin;
+}
+.ai-model-menu::-webkit-scrollbar { width: 9px; }
+.ai-model-menu::-webkit-scrollbar-track { background: #0b0e13; border-radius: 999px; }
+.ai-model-menu::-webkit-scrollbar-thumb {
+  background: #3a4350;
+  border: 2px solid #0b0e13;
+  border-radius: 999px;
+}
+.ai-model-menu-heading {
+  padding: 5px 10px 4px;
+  color: var(--muted);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0;
+}
+.ai-model-menu-heading:not(:first-child) {
+  margin-top: 6px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+.ai-model-option {
+  position: relative;
+  display: block;
+  width: 100%;
+  padding: 8px 30px 8px 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--text);
+  text-align: left;
+  font: inherit;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+.ai-model-option:hover,
+.ai-model-option[aria-selected="true"] { background: #21262d; }
+.ai-model-option[aria-selected="true"]::after {
+  content: "\2713";
+  position: absolute;
+  top: 9px;
+  right: 10px;
+  color: #58a6ff;
+}
+.ai-model-option-label { display: block; font-size: 13px; font-weight: 600; }
+.ai-model-option-description {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+}
 
 /* ---- mobile: stack form, turn the wide table into cards ---- */
 @media (max-width: 720px) {
@@ -1041,6 +1170,9 @@ tr:last-child td { border-bottom: none; }
   /* the header doubles as the drag-to-close handle; without touch-action:none
      the browser turns the downward drag into page scroll / pull-to-refresh */
   .ai-chat-header { padding-top: 16px; touch-action: none; }
+  .ai-chat-title { cursor: pointer; }
+  .ai-chat-title-chevron { display: inline; }
+  .ai-model-selector { display: none; }
   .ai-msg-markdown { overflow-x: visible; }
   .ai-msg-markdown table {
     display: table;

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -586,9 +586,323 @@ tr:last-child td { border-bottom: none; }
   gap: 8px;
 }
 
+/* ---- AI chat: floating 🐸 button + chat panel ---- */
+.ai-chat-fab {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 60;
+  width: 52px;
+  height: 52px;
+  padding: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  /* bare face, no backing shape: shadow the drawing itself */
+  filter: drop-shadow(0 4px 8px rgba(0, 0, 0, 0.45));
+  transition: transform 120ms ease;
+  user-select: none;
+  -webkit-user-select: none;
+  /* pointer-drag needs the browser to hand us every touch move */
+  touch-action: none;
+}
+.ai-chat-fab .pepe {
+  width: 100%;
+  height: 100%;
+  display: block;
+  /* keep the button itself as the sole pointer target for tap/drag */
+  pointer-events: none;
+}
+/* pepe face: JS toggles .pepe-blink at random intervals and steers the
+   pupils via a transform attribute from the pointer-tracking handler */
+.pepe .pepe-eye {
+  transform-box: fill-box;
+  transform-origin: 50% 55%;
+  transition: transform 100ms ease-out;
+}
+.pepe.pepe-blink .pepe-eye {
+  transform: scaleY(0.15);
+  transition-duration: 70ms;
+}
+/* hover-capable pointers only: on touch the sticky :hover would keep the
+   face enlarged after a tap or drag */
+@media (hover: hover) and (pointer: fine) {
+  .ai-chat-fab:hover { transform: scale(1.1); }
+}
+.ai-chat-fab.dragging {
+  cursor: grabbing;
+  opacity: 0.85;
+  transform: scale(1.15);
+}
+/* mobile release: glide to the nearest side edge (left/top must NOT be in the
+   base transition, or every drag move would lag behind the finger) */
+.ai-chat-fab.snapping {
+  transition: transform 120ms ease, left 200ms ease-out, top 200ms ease-out;
+}
+
+.ai-chat-panel {
+  position: fixed;
+  right: 20px;
+  bottom: 84px;
+  z-index: 59;
+  width: min(380px, calc(100vw - 40px));
+  height: min(520px, calc(100vh - 130px));
+  display: flex;
+  flex-direction: column;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+  overscroll-behavior: contain;
+}
+.ai-chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+}
+.ai-chat-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+}
+.ai-chat-title .pepe {
+  width: 18px;
+  height: 18px;
+  flex: none;
+}
+.ai-chat-messages {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  -webkit-overflow-scrolling: touch;
+  overscroll-behavior: contain;
+  touch-action: pan-y;
+  scrollbar-color: #3a4350 #0b0e13;
+  scrollbar-width: thin;
+}
+.ai-chat-messages::-webkit-scrollbar {
+  width: 10px;
+}
+.ai-chat-messages::-webkit-scrollbar-track {
+  background: #0b0e13;
+  border-radius: 999px;
+}
+.ai-chat-messages::-webkit-scrollbar-thumb {
+  background: #3a4350;
+  border: 2px solid #0b0e13;
+  border-radius: 999px;
+}
+.ai-chat-messages::-webkit-scrollbar-thumb:hover {
+  background: #4a5565;
+}
+.ai-chat-messages::-webkit-scrollbar-corner {
+  background: #0b0e13;
+}
+.ai-chat-empty { color: var(--muted); font-size: 13px; text-align: center; margin: auto; }
+.ai-msg {
+  flex: 0 0 auto;
+  max-width: 85%;
+  padding: 8px 11px;
+  border-radius: 12px;
+  font-size: 13px;
+  line-height: 1.45;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+.ai-msg-user {
+  align-self: flex-end;
+  background: var(--accent);
+  color: #fff;
+  border-bottom-right-radius: 4px;
+}
+.ai-msg-assistant {
+  align-self: flex-start;
+  background: #21262d;
+  border: 1px solid var(--border);
+  border-bottom-left-radius: 4px;
+}
+.ai-msg-work {
+  position: relative;
+  align-self: flex-start;
+  max-width: 78%;
+  margin-top: -5px;
+  padding: 5px 9px 5px 20px;
+  border: 1px solid #30363d;
+  border-radius: 9px;
+  border-top-left-radius: 3px;
+  background: #161b22;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+.ai-msg-work::before {
+  content: "";
+  position: absolute;
+  left: 9px;
+  top: 50%;
+  width: 5px;
+  height: 5px;
+  margin-top: -2.5px;
+  border-radius: 50%;
+  background: #58a6ff;
+  animation: ai-work-pulse 1.2s ease-in-out infinite;
+}
+@keyframes ai-work-pulse {
+  0%, 100% { opacity: 0.35; }
+  50% { opacity: 1; }
+}
+.ai-msg-markdown {
+  min-width: 0;
+  white-space: normal;
+  overflow: visible;
+}
+.ai-msg-markdown > :first-child { margin-top: 0; }
+.ai-msg-markdown > :last-child { margin-bottom: 0; }
+.ai-msg-markdown p { margin: 0 0 8px; }
+.ai-msg-markdown h1,
+.ai-msg-markdown h2,
+.ai-msg-markdown h3 {
+  margin: 10px 0 6px;
+  line-height: 1.3;
+}
+.ai-msg-markdown h1 { font-size: 15px; }
+.ai-msg-markdown h2 { font-size: 14px; }
+.ai-msg-markdown h3 { font-size: 13px; }
+.ai-msg-markdown hr {
+  margin: 10px 0;
+  border: 0;
+  border-top: 1px solid #3a4350;
+}
+.ai-msg-markdown ul,
+.ai-msg-markdown ol {
+  margin: 6px 0 8px;
+  padding-left: 20px;
+}
+.ai-msg-markdown li + li { margin-top: 3px; }
+.ai-msg-markdown a { color: #58a6ff; }
+.ai-msg-markdown code {
+  padding: 1px 4px;
+  border-radius: 3px;
+  background: #0d1117;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.92em;
+}
+.ai-msg-markdown pre {
+  margin: 8px 0;
+  padding: 9px;
+  overflow-x: auto;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  background: #0d1117;
+  white-space: pre;
+}
+.ai-msg-markdown pre code {
+  padding: 0;
+  background: transparent;
+}
+.ai-msg-markdown blockquote {
+  margin: 8px 0;
+  padding-left: 10px;
+  border-left: 3px solid #3a4350;
+  color: var(--muted);
+}
+.ai-msg-markdown table {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  margin: 8px 0;
+  border-collapse: collapse;
+  table-layout: fixed;
+  font-size: 12px;
+}
+.ai-msg-markdown th,
+.ai-msg-markdown td {
+  padding: 5px 7px;
+  border: 1px solid #3a4350;
+  text-align: left;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+.ai-msg-markdown th {
+  background: #161b22;
+  font-weight: 600;
+}
+.ai-msg-error {
+  background: transparent;
+  border: 1px solid var(--danger);
+  color: var(--danger);
+}
+.ai-msg-pending { color: var(--muted); }
+.ai-msg-pending .ai-dot { display: inline-block; animation: ai-dot-blink 1.2s infinite; }
+.ai-msg-pending .ai-dot:nth-child(2) { animation-delay: 0.2s; }
+.ai-msg-pending .ai-dot:nth-child(3) { animation-delay: 0.4s; }
+@keyframes ai-dot-blink {
+  0%, 80%, 100% { opacity: 0.25; }
+  40% { opacity: 1; }
+}
+/* temporary: live viewport numbers for debugging the iOS keyboard layout */
+.ai-chat-debug {
+  display: none;
+  padding: 2px 10px;
+  font-size: 10px;
+  color: var(--muted);
+  white-space: nowrap;
+  overflow-x: auto;
+}
+.ai-chat-form {
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 10px;
+  border-top: 1px solid var(--border);
+}
+.ai-chat-input {
+  flex: 1;
+  min-width: 0;
+  /* grows with the content (see autosizeAiInput); clamp so the message
+     list can't be squeezed out of the panel */
+  max-height: 200px;
+  overflow-y: auto;
+  scrollbar-width: none;
+  resize: none;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  color: var(--text);
+  border-radius: 8px;
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 13px;
+  line-height: 1.4;
+}
+.ai-chat-input::-webkit-scrollbar { display: none; }
+.ai-chat-input:focus { outline: none; border-color: var(--accent); }
+#ai-chat-send {
+  flex: 0 0 auto;
+  align-self: flex-end;
+  height: 36px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+#ai-chat-send:disabled { cursor: wait; opacity: 0.65; }
+
 /* ---- mobile: stack form, turn the wide table into cards ---- */
 @media (max-width: 720px) {
   .topbar {
+    gap: 8px;
     padding: 12px 14px;
     padding-right: 58px;
   }
@@ -626,7 +940,9 @@ tr:last-child td { border-bottom: none; }
     -webkit-overflow-scrolling: touch;
     overscroll-behavior-x: contain;
     padding-bottom: 6px;
+    scrollbar-width: none;
   }
+  #sessions > tbody::-webkit-scrollbar { display: none; }
   tr {
     display: block;
     flex: 0 0 90%;            /* ~one card per view, next card peeks */
@@ -684,4 +1000,93 @@ tr:last-child td { border-bottom: none; }
   /* bigger touch targets on mobile */
   .btn { padding: 8px 12px; }
   input[type="checkbox"] { width: 18px; height: 18px; }
+
+  @media (hover: hover) and (pointer: fine) {
+    #sessions > tbody { cursor: grab; }
+    #sessions > tbody.session-carousel-dragging {
+      cursor: grabbing;
+      scroll-snap-type: none;
+      user-select: none;
+      -webkit-user-select: none;
+    }
+  }
+
+  /* initial spot: middle-right of the screen (around the "Last bar" row of a
+     session card); a drag replaces this with inline left/top */
+  .ai-chat-fab {
+    right: 12px;
+    bottom: auto;
+    top: calc(50% - 26px);
+  }
+
+  /* AI chat: near-fullscreen bottom sheet with a grabber bar; layered above
+     the FAB so a dragged button can't end up covering the conversation.
+     JS lifts `bottom` by the keyboard height (visualViewport) so the input
+     stays visible while typing. */
+  .ai-chat-panel {
+    left: 0;
+    right: 0;
+    bottom: 0;
+    top: 7vh;
+    top: max(44px, 7dvh);
+    width: auto;
+    height: auto;
+    z-index: 61;
+    border: 0;
+    border-radius: 18px 18px 0 0;
+    box-shadow: 0 -8px 32px rgba(0, 0, 0, 0.5);
+  }
+  .ai-chat-panel::before {
+    content: "";
+    position: absolute;
+    top: 7px;
+    left: 50%;
+    width: 40px;
+    height: 4px;
+    margin-left: -20px;
+    border-radius: 999px;
+    background: var(--border);
+  }
+  /* the header doubles as the drag-to-close handle; without touch-action:none
+     the browser turns the downward drag into page scroll / pull-to-refresh */
+  .ai-chat-header { padding-top: 16px; touch-action: none; }
+  .ai-chat-debug { display: block; }
+  .ai-msg-markdown { overflow-x: visible; }
+  .ai-msg-markdown table {
+    display: table;
+    width: 100%;
+    min-width: 0;
+    max-width: 100%;
+    table-layout: fixed;
+  }
+  .ai-msg-markdown thead { display: table-header-group; }
+  .ai-msg-markdown tbody {
+    display: table-row-group;
+    overflow: visible;
+    padding: 0;
+    scroll-snap-type: none;
+  }
+  .ai-msg-markdown tr {
+    display: table-row;
+    width: auto;
+    padding: 0;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+  .ai-msg-markdown th,
+  .ai-msg-markdown td {
+    display: table-cell;
+    width: auto;
+    padding: 5px 7px;
+    border: 1px solid #3a4350;
+    text-align: left;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+  .ai-msg-markdown td::before { content: none; }
+  .ai-msg-markdown tr:last-child td,
+  .ai-msg-markdown tr td:last-child { border: 1px solid #3a4350; }
+  /* keep Send above the iPhone home indicator */
+  .ai-chat-form { padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px)); }
 }

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -853,15 +853,6 @@ tr:last-child td { border-bottom: none; }
   0%, 80%, 100% { opacity: 0.25; }
   40% { opacity: 1; }
 }
-/* temporary: live viewport numbers for debugging the iOS keyboard layout */
-.ai-chat-debug {
-  display: none;
-  padding: 2px 10px;
-  font-size: 10px;
-  color: var(--muted);
-  white-space: nowrap;
-  overflow-x: auto;
-}
 .ai-chat-form {
   display: flex;
   align-items: flex-end;
@@ -1050,7 +1041,6 @@ tr:last-child td { border-bottom: none; }
   /* the header doubles as the drag-to-close handle; without touch-action:none
      the browser turns the downward drag into page scroll / pull-to-refresh */
   .ai-chat-header { padding-top: 16px; touch-action: none; }
-  .ai-chat-debug { display: block; }
   .ai-msg-markdown { overflow-x: visible; }
   .ai-msg-markdown table {
     display: table;

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -138,7 +138,7 @@
     </div>
   </div>
 
-  <button id="ai-chat-fab" class="ai-chat-fab" type="button" aria-label="Open AI chat" aria-expanded="false">
+  <button id="ai-chat-fab" class="ai-chat-fab hidden" type="button" aria-label="Open AI chat" aria-expanded="false">
     <svg class="pepe" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
       <path d="M32 10C18 10 9 19 9 31c0 7 3 13 8 17 4 3.2 9.3 5 15 5s11-1.8 15-5c5-4 8-10 8-17 0-12-9-21-23-21z" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.8" stroke-linejoin="round"/>
       <path d="M13 22c1-5 5.5-8 10-8s8 3 8.5 7.5" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.6"/>
@@ -196,6 +196,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=16"></script>
+  <script src="/static/dashboard.js?v=17"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=11" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=13" />
 </head>
 <body>
   <header class="topbar">
@@ -162,7 +162,7 @@
 
   <div id="ai-chat-panel" class="ai-chat-panel hidden" role="dialog" aria-label="AI chat" aria-hidden="true">
     <div class="ai-chat-header">
-      <span class="ai-chat-title">
+      <button id="ai-chat-title" class="ai-chat-title" type="button" aria-haspopup="listbox" aria-expanded="false">
         <svg class="pepe" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
           <path d="M32 10C18 10 9 19 9 31c0 7 3 13 8 17 4 3.2 9.3 5 15 5s11-1.8 15-5c5-4 8-10 8-17 0-12-9-21-23-21z" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.8" stroke-linejoin="round"/>
           <path d="M13 22c1-5 5.5-8 10-8s8 3 8.5 7.5" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.6"/>
@@ -182,20 +182,33 @@
           <path d="M14 38c2-2.5 6-4 11-3.5l16 1.5c5 .5 8.5 2 9.5 4.5-.5 3-4 5-9 4.7l-18-1c-5-.3-9-2.7-9.5-6.2z" fill="#B0623F" stroke="#2f5c28" stroke-width="1.6" stroke-linejoin="round"/>
           <path d="M16.5 39.5c4.5 1.8 10 2.6 16.5 2.9 6 .3 11.5-.2 15.5-1.6" stroke="#2f5c28" stroke-width="1.5" stroke-linecap="round"/>
         </svg>
-        AI Chat
-      </span>
+        <span>PyneReal Ai</span><span class="ai-chat-title-chevron" aria-hidden="true">&gt;</span>
+      </button>
       <div class="modal-actions">
         <button id="ai-chat-clear" class="btn btn-danger" title="Clear chat">&#x1f5d1;&#xfe0f;</button>
         <button id="ai-chat-close" class="btn" title="Close">&times;</button>
       </div>
     </div>
+    <div id="ai-model-menu" class="ai-model-menu hidden" role="listbox" aria-label="AI model and reasoning effort"></div>
     <div id="ai-chat-messages" class="ai-chat-messages"></div>
     <form id="ai-chat-form" class="ai-chat-form">
-      <textarea id="ai-chat-input" class="ai-chat-input" rows="1" placeholder="Ask AI anything&#8230;" enterkeyhint="send"></textarea>
-      <button type="submit" id="ai-chat-send" class="btn btn-primary">Send</button>
+      <div class="ai-chat-composer">
+        <textarea id="ai-chat-input" class="ai-chat-input" rows="1" placeholder="Ask AI anything&#8230;" enterkeyhint="send"></textarea>
+        <div class="ai-chat-composer-actions">
+          <button id="ai-model-selector" class="ai-model-selector" type="button" aria-haspopup="listbox" aria-expanded="false" disabled>
+            <span id="ai-model-label">Default model</span>
+            <!-- inline SVG instead of the &#8964; glyph: the text arrowhead sits below
+                 the baseline and looked sunken next to the label -->
+            <svg class="ai-model-chevron" viewBox="0 0 12 12" width="12" height="12" aria-hidden="true" focusable="false">
+              <path d="M2.5 4.25 6 7.75l3.5-3.5" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+            </svg>
+          </button>
+          <button type="submit" id="ai-chat-send" class="ai-chat-send" aria-label="Send" title="Send"><span aria-hidden="true">&#8593;</span></button>
+        </div>
+      </div>
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=18"></script>
+  <script src="/static/dashboard.js?v=21"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=10" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=11" />
 </head>
 <body>
   <header class="topbar">
@@ -190,13 +190,12 @@
       </div>
     </div>
     <div id="ai-chat-messages" class="ai-chat-messages"></div>
-    <div id="ai-chat-debug" class="ai-chat-debug mono"></div>
     <form id="ai-chat-form" class="ai-chat-form">
       <textarea id="ai-chat-input" class="ai-chat-input" rows="1" placeholder="Ask AI anything&#8230;" enterkeyhint="send"></textarea>
       <button type="submit" id="ai-chat-send" class="btn btn-primary">Send</button>
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=14"></script>
+  <script src="/static/dashboard.js?v=16"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -196,6 +196,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=17"></script>
+  <script src="/static/dashboard.js?v=18"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=10" />
 </head>
 <body>
   <header class="topbar">
@@ -138,6 +138,65 @@
     </div>
   </div>
 
-  <script src="/static/dashboard.js"></script>
+  <button id="ai-chat-fab" class="ai-chat-fab" type="button" aria-label="Open AI chat" aria-expanded="false">
+    <svg class="pepe" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+      <path d="M32 10C18 10 9 19 9 31c0 7 3 13 8 17 4 3.2 9.3 5 15 5s11-1.8 15-5c5-4 8-10 8-17 0-12-9-21-23-21z" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.8" stroke-linejoin="round"/>
+      <path d="M13 22c1-5 5.5-8 10-8s8 3 8.5 7.5" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.6"/>
+      <path d="M32.5 21.5C33 17 36.5 14 41 14s9 3 10 8" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.6"/>
+      <g class="pepe-eye">
+        <ellipse cx="23" cy="23.5" rx="8" ry="5.5" fill="#fff" stroke="#2f5c28" stroke-width="1.5"/>
+        <circle class="pepe-pupil" cx="24" cy="26" r="1.8" fill="#1c1c1c"/>
+        <path d="M15 22.2c2-3.5 5-4.8 8-4.8s6 1.3 8 4.8c-1 1.5-4 2.6-8 2.6s-7-1.1-8-2.6z" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.4"/>
+      </g>
+      <g class="pepe-eye">
+        <ellipse cx="41" cy="23.5" rx="8" ry="5.5" fill="#fff" stroke="#2f5c28" stroke-width="1.5"/>
+        <circle class="pepe-pupil" cx="40" cy="26" r="1.8" fill="#1c1c1c"/>
+        <path d="M33 22.2c2-3.5 5-4.8 8-4.8s6 1.3 8 4.8c-1 1.5-4 2.6-8 2.6s-7-1.1-8-2.6z" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.4"/>
+      </g>
+      <circle cx="30" cy="33" r=".9" fill="#2f5c28"/>
+      <circle cx="34" cy="33" r=".9" fill="#2f5c28"/>
+      <path d="M14 38c2-2.5 6-4 11-3.5l16 1.5c5 .5 8.5 2 9.5 4.5-.5 3-4 5-9 4.7l-18-1c-5-.3-9-2.7-9.5-6.2z" fill="#B0623F" stroke="#2f5c28" stroke-width="1.6" stroke-linejoin="round"/>
+      <path d="M16.5 39.5c4.5 1.8 10 2.6 16.5 2.9 6 .3 11.5-.2 15.5-1.6" stroke="#2f5c28" stroke-width="1.5" stroke-linecap="round"/>
+    </svg>
+  </button>
+
+  <div id="ai-chat-panel" class="ai-chat-panel hidden" role="dialog" aria-label="AI chat" aria-hidden="true">
+    <div class="ai-chat-header">
+      <span class="ai-chat-title">
+        <svg class="pepe" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
+          <path d="M32 10C18 10 9 19 9 31c0 7 3 13 8 17 4 3.2 9.3 5 15 5s11-1.8 15-5c5-4 8-10 8-17 0-12-9-21-23-21z" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.8" stroke-linejoin="round"/>
+          <path d="M13 22c1-5 5.5-8 10-8s8 3 8.5 7.5" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.6"/>
+          <path d="M32.5 21.5C33 17 36.5 14 41 14s9 3 10 8" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.6"/>
+          <g class="pepe-eye">
+            <ellipse cx="23" cy="23.5" rx="8" ry="5.5" fill="#fff" stroke="#2f5c28" stroke-width="1.5"/>
+            <circle class="pepe-pupil" cx="24" cy="26" r="1.8" fill="#1c1c1c"/>
+            <path d="M15 22.2c2-3.5 5-4.8 8-4.8s6 1.3 8 4.8c-1 1.5-4 2.6-8 2.6s-7-1.1-8-2.6z" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.4"/>
+          </g>
+          <g class="pepe-eye">
+            <ellipse cx="41" cy="23.5" rx="8" ry="5.5" fill="#fff" stroke="#2f5c28" stroke-width="1.5"/>
+            <circle class="pepe-pupil" cx="40" cy="26" r="1.8" fill="#1c1c1c"/>
+            <path d="M33 22.2c2-3.5 5-4.8 8-4.8s6 1.3 8 4.8c-1 1.5-4 2.6-8 2.6s-7-1.1-8-2.6z" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.4"/>
+          </g>
+          <circle cx="30" cy="33" r=".9" fill="#2f5c28"/>
+          <circle cx="34" cy="33" r=".9" fill="#2f5c28"/>
+          <path d="M14 38c2-2.5 6-4 11-3.5l16 1.5c5 .5 8.5 2 9.5 4.5-.5 3-4 5-9 4.7l-18-1c-5-.3-9-2.7-9.5-6.2z" fill="#B0623F" stroke="#2f5c28" stroke-width="1.6" stroke-linejoin="round"/>
+          <path d="M16.5 39.5c4.5 1.8 10 2.6 16.5 2.9 6 .3 11.5-.2 15.5-1.6" stroke="#2f5c28" stroke-width="1.5" stroke-linecap="round"/>
+        </svg>
+        AI Chat
+      </span>
+      <div class="modal-actions">
+        <button id="ai-chat-clear" class="btn btn-danger" title="Clear chat">&#x1f5d1;&#xfe0f;</button>
+        <button id="ai-chat-close" class="btn" title="Close">&times;</button>
+      </div>
+    </div>
+    <div id="ai-chat-messages" class="ai-chat-messages"></div>
+    <div id="ai-chat-debug" class="ai-chat-debug mono"></div>
+    <form id="ai-chat-form" class="ai-chat-form">
+      <textarea id="ai-chat-input" class="ai-chat-input" rows="1" placeholder="Ask AI anything&#8230;" enterkeyhint="send"></textarea>
+      <button type="submit" id="ai-chat-send" class="btn btn-primary">Send</button>
+    </form>
+  </div>
+
+  <script src="/static/dashboard.js?v=14"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -15,6 +15,7 @@
   const desktopCardCarouselQuery = window.matchMedia(
     "(max-width: 720px) and (hover: hover) and (pointer: fine)",
   );
+  const mobileAiQuery = window.matchMedia("(max-width: 720px)");
 
   const el = (id) => document.getElementById(id);
 
@@ -729,6 +730,14 @@
   const AI_CHAT_CONVERSATION_KEY = "aiChatConversationId";
   const AI_CHAT_FAB_POS_KEY = "aiChatFabPos";
   const AI_CHAT_MAX_HISTORY = 12;
+  const AI_EFFORT_LABELS = {
+    none: "None",
+    minimal: "Minimal",
+    low: "Low",
+    medium: "Medium",
+    high: "High",
+    xhigh: "Extra High",
+  };
   let aiEnabled = false;
   let aiMessages = [];
   let aiConversationId = "";
@@ -738,12 +747,229 @@
   let aiRenderFrame = null;
   let aiChatLockedScroll = false;
   let aiStateSyncPromise = null;
+  let aiModelsPromise = null;
+  let aiModels = [];
+  let aiSelectedModel = "";
+  let aiSelectedEffort = "";
+  let aiModelMenuAnchor = null;
+  let reclampAiFab = null; // set by initAiChat; re-clamps the saved FAB spot
 
   function applyAiAvailability(enabled) {
     if (typeof enabled !== "boolean") return;
     aiEnabled = enabled;
     el("ai-chat-fab").classList.toggle("hidden", !aiEnabled);
+    // the FAB was display:none until now, so any earlier clamp math ran with
+    // zero dimensions — redo it against the real size
+    if (aiEnabled && reclampAiFab) reclampAiFab();
+    if (aiEnabled) loadAiModels();
     if (!aiEnabled && isAiChatOpen()) closeAiChat();
+  }
+
+  function aiEffortLabel(value) {
+    return AI_EFFORT_LABELS[value] || value.charAt(0).toUpperCase() + value.slice(1);
+  }
+
+  function aiSupportedEfforts() {
+    const selected = aiModels.find((item) => item.value === aiSelectedModel);
+    return selected && Array.isArray(selected.efforts) ? selected.efforts : [];
+  }
+
+  // keep the effort valid for the selected model; an empty supported list means
+  // the server does not know the model's efforts, so keep the current pick
+  function clampAiEffort() {
+    const efforts = aiSupportedEfforts();
+    if (!efforts.length || efforts.includes(aiSelectedEffort)) return;
+    aiSelectedEffort = efforts.includes("medium") ? "medium" : efforts[efforts.length - 1];
+  }
+
+  // the selection lives on the server so every browser shares it; the
+  // ai_prefs_updated broadcast brings other clients in line
+  function pushAiPrefs() {
+    api("/api/ai/chat/preferences", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: aiSelectedModel || null,
+        effort: aiSelectedEffort || null,
+      }),
+    }).catch(() => {});
+  }
+
+  function applyAiPrefs(model, effort) {
+    let changed = false;
+    if (
+      typeof model === "string" && model && model !== aiSelectedModel
+      && aiModels.some((item) => item.value === model)
+    ) {
+      aiSelectedModel = model;
+      changed = true;
+    }
+    if (typeof effort === "string" && effort && effort !== aiSelectedEffort) {
+      aiSelectedEffort = effort;
+      changed = true;
+    }
+    if (!changed) return;
+    clampAiEffort();
+    renderAiModelMenu();
+    updateAiModelControls();
+    if (aiModelMenuAnchor) positionAiModelMenu(aiModelMenuAnchor);
+  }
+
+  function updateAiModelControls() {
+    const selected = aiModels.find((item) => item.value === aiSelectedModel);
+    let label = selected ? selected.label : "Default model";
+    if (selected && aiSelectedEffort) label += ` · ${aiEffortLabel(aiSelectedEffort)}`;
+    el("ai-model-label").textContent = label;
+    el("ai-model-selector").disabled = aiModels.length === 0;
+    for (const option of el("ai-model-menu").querySelectorAll(".ai-model-option")) {
+      const selectedValue = option.dataset.kind === "effort" ? aiSelectedEffort : aiSelectedModel;
+      option.setAttribute("aria-selected", String(option.dataset.value === selectedValue));
+    }
+  }
+
+  function selectAiModel(value) {
+    if (!aiModels.some((item) => item.value === value)) return;
+    aiSelectedModel = value;
+    clampAiEffort();
+    pushAiPrefs();
+    // the reasoning section follows the model, so rebuild and keep the menu
+    // open for the follow-up effort pick
+    renderAiModelMenu();
+    updateAiModelControls();
+    if (aiModelMenuAnchor) positionAiModelMenu(aiModelMenuAnchor);
+  }
+
+  function selectAiEffort(value) {
+    if (!aiSupportedEfforts().includes(value)) return;
+    aiSelectedEffort = value;
+    pushAiPrefs();
+    updateAiModelControls();
+    closeAiModelMenu();
+  }
+
+  function renderAiModelMenu() {
+    const menu = el("ai-model-menu");
+    menu.textContent = "";
+    const addHeading = (text) => {
+      const heading = document.createElement("div");
+      heading.className = "ai-model-menu-heading";
+      heading.textContent = text;
+      menu.appendChild(heading);
+    };
+    const addOption = (kind, value, labelText, descriptionText, selected, onSelect) => {
+      const option = document.createElement("button");
+      option.className = "ai-model-option";
+      option.type = "button";
+      option.dataset.value = value;
+      option.dataset.kind = kind;
+      option.setAttribute("role", "option");
+      option.setAttribute("aria-selected", String(selected));
+
+      const label = document.createElement("span");
+      label.className = "ai-model-option-label";
+      label.textContent = labelText;
+      option.appendChild(label);
+      if (descriptionText) {
+        const description = document.createElement("span");
+        description.className = "ai-model-option-description";
+        description.textContent = descriptionText;
+        option.appendChild(description);
+      }
+      option.addEventListener("click", onSelect);
+      menu.appendChild(option);
+    };
+    addHeading("Model");
+    for (const item of aiModels) {
+      addOption(
+        "model",
+        item.value,
+        item.label,
+        item.description,
+        item.value === aiSelectedModel,
+        () => selectAiModel(item.value),
+      );
+    }
+    const efforts = aiSupportedEfforts();
+    if (efforts.length) {
+      addHeading("Reasoning");
+      for (const value of efforts) {
+        addOption(
+          "effort",
+          value,
+          aiEffortLabel(value),
+          "",
+          value === aiSelectedEffort,
+          () => selectAiEffort(value),
+        );
+      }
+    }
+  }
+
+  async function loadAiModels() {
+    if (aiModelsPromise) return aiModelsPromise;
+    aiModelsPromise = (async () => {
+      const response = await api("/api/ai/models");
+      aiModels = Array.isArray(response.models)
+        ? response.models.filter((item) =>
+          item && typeof item.value === "string" && typeof item.label === "string")
+        : [];
+      // the server owns the shared selection; is_default/first are only a
+      // safety net if it did not resolve one
+      const serverModel = typeof response.selected_model === "string"
+        ? response.selected_model : "";
+      const selected = aiModels.find((item) => item.value === serverModel)
+        || aiModels.find((item) => item.is_default)
+        || aiModels[0];
+      aiSelectedModel = selected ? selected.value : "";
+      aiSelectedEffort = typeof response.selected_effort === "string"
+        ? response.selected_effort : "";
+      clampAiEffort();
+      renderAiModelMenu();
+      updateAiModelControls();
+    })().catch(() => {
+      el("ai-model-label").textContent = "Models unavailable";
+      el("ai-model-selector").disabled = true;
+    });
+    return aiModelsPromise;
+  }
+
+  function positionAiModelMenu(anchor) {
+    const panel = el("ai-chat-panel");
+    const menu = el("ai-model-menu");
+    const panelRect = panel.getBoundingClientRect();
+    const anchorRect = anchor.getBoundingClientRect();
+    const margin = 8;
+    let left = mobileAiQuery.matches
+      ? 12
+      : anchorRect.right - panelRect.left - menu.offsetWidth;
+    let top = mobileAiQuery.matches
+      ? anchorRect.bottom - panelRect.top + 7
+      : anchorRect.top - panelRect.top - menu.offsetHeight - 7;
+    left = Math.min(Math.max(left, margin), panel.clientWidth - menu.offsetWidth - margin);
+    top = Math.min(Math.max(top, margin), panel.clientHeight - menu.offsetHeight - margin);
+    menu.style.left = `${left}px`;
+    menu.style.top = `${top}px`;
+  }
+
+  function openAiModelMenu(anchor) {
+    if (!aiModels.length) return;
+    const menu = el("ai-model-menu");
+    if (!menu.classList.contains("hidden") && aiModelMenuAnchor === anchor) {
+      closeAiModelMenu();
+      return;
+    }
+    aiModelMenuAnchor = anchor;
+    menu.classList.remove("hidden");
+    el("ai-model-selector").setAttribute("aria-expanded", String(anchor === el("ai-model-selector")));
+    el("ai-chat-title").setAttribute("aria-expanded", String(anchor === el("ai-chat-title")));
+    positionAiModelMenu(anchor);
+  }
+
+  function closeAiModelMenu() {
+    aiModelMenuAnchor = null;
+    el("ai-model-menu").classList.add("hidden");
+    el("ai-model-selector").setAttribute("aria-expanded", "false");
+    el("ai-chat-title").setAttribute("aria-expanded", "false");
   }
 
   function loadPersistentAiValue(key) {
@@ -799,6 +1025,8 @@
       ? state.conversation_id
       : "";
     aiRemotePending = Boolean(state && state.pending);
+    // catch up on a model/effort change whose broadcast this client missed
+    if (state) applyAiPrefs(state.model, state.effort);
     saveAiMessages();
     saveAiConversationId();
     el("ai-chat-send").disabled = aiPending || aiRemotePending;
@@ -989,6 +1217,7 @@
 
   function closeAiChat() {
     if (!isAiChatOpen()) return;
+    closeAiModelMenu();
     const panel = el("ai-chat-panel");
     panel.classList.add("hidden");
     panel.setAttribute("aria-hidden", "true");
@@ -1038,7 +1267,13 @@
       await streamSse("/api/ai/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ message, history, conversation_id: aiConversationId || null }),
+        body: JSON.stringify({
+          message,
+          history,
+          conversation_id: aiConversationId || null,
+          model: aiSelectedModel || null,
+          effort: aiSelectedEffort || null,
+        }),
       }, (eventName, data) => {
         if (eventName === "conversation") {
           aiConversationId = data.conversation_id || aiConversationId;
@@ -1134,9 +1369,14 @@
     let drag = null;
     let suppressClick = false;
 
+    // the FAB is display:none until the AI availability check lands, and a
+    // hidden element measures 0 — clamping with that width let a saved spot
+    // land almost entirely off-screen (only FAB_MARGIN px stayed visible)
+    const fabSize = () => fab.offsetWidth || 52;
+
     function applyFabPos(left, top) {
-      const maxLeft = window.innerWidth - fab.offsetWidth - FAB_MARGIN;
-      const maxTop = window.innerHeight - fab.offsetHeight - FAB_MARGIN;
+      const maxLeft = window.innerWidth - fabSize() - FAB_MARGIN;
+      const maxTop = window.innerHeight - fabSize() - FAB_MARGIN;
       fab.style.left = `${Math.min(Math.max(left, FAB_MARGIN), Math.max(maxLeft, FAB_MARGIN))}px`;
       fab.style.top = `${Math.min(Math.max(top, FAB_MARGIN), Math.max(maxTop, FAB_MARGIN))}px`;
       fab.style.right = "auto";
@@ -1163,8 +1403,8 @@
 
     // mobile: the face always rests against the nearest side edge
     function snappedFabLeft(left) {
-      const maxLeft = Math.max(window.innerWidth - fab.offsetWidth - FAB_MARGIN, FAB_MARGIN);
-      return left + fab.offsetWidth / 2 < window.innerWidth / 2 ? FAB_MARGIN : maxLeft;
+      const maxLeft = Math.max(window.innerWidth - fabSize() - FAB_MARGIN, FAB_MARGIN);
+      return left + fabSize() / 2 < window.innerWidth / 2 ? FAB_MARGIN : maxLeft;
     }
 
     let snapTimer = null;
@@ -1190,6 +1430,7 @@
       } catch {}
       resetFabPos(); // no saved spot: fall back to the per-breakpoint CSS default
     }
+    reclampAiFab = restoreFabPos;
 
     fab.addEventListener("pointerdown", (e) => {
       if (!e.isPrimary) return;
@@ -1252,6 +1493,7 @@
     // breakpoint's CSS default), then re-dock or reset the panel
     if (desktopReorderQuery.addEventListener) {
       desktopReorderQuery.addEventListener("change", () => {
+        closeAiModelMenu();
         restoreFabPos();
         positionAiChatPanel();
       });
@@ -1297,6 +1539,21 @@
     }
     sheetHeader.addEventListener("pointerup", endSheetDrag);
     sheetHeader.addEventListener("pointercancel", endSheetDrag);
+
+    el("ai-model-selector").addEventListener("click", () => {
+      if (!mobileAiQuery.matches) openAiModelMenu(el("ai-model-selector"));
+    });
+    el("ai-chat-title").addEventListener("click", () => {
+      if (mobileAiQuery.matches) openAiModelMenu(el("ai-chat-title"));
+    });
+    document.addEventListener("pointerdown", (e) => {
+      if (el("ai-model-menu").classList.contains("hidden")) return;
+      if (e.target.closest("#ai-model-menu, #ai-model-selector, #ai-chat-title")) return;
+      closeAiModelMenu();
+    });
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape") closeAiModelMenu();
+    });
 
     el("ai-chat-close").addEventListener("click", closeAiChat);
     el("ai-chat-clear").addEventListener("click", () => {
@@ -2137,6 +2394,8 @@
           applySessions(msg.sessions || []);
         } else if (msg.type === "ai_chat_updated" && !aiPending) {
           syncAiChatState({ allowImport: false });
+        } else if (msg.type === "ai_prefs_updated") {
+          applyAiPrefs(msg.model, msg.effort);
         }
       } catch {}
     };

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -732,6 +732,7 @@
   let aiMessages = [];
   let aiConversationId = "";
   let aiPending = false;
+  let aiRemotePending = false;
   let aiStreamingResponse = false;
   let aiRenderFrame = null;
   let aiChatLockedScroll = false;
@@ -789,8 +790,10 @@
     aiConversationId = state && typeof state.conversation_id === "string"
       ? state.conversation_id
       : "";
+    aiRemotePending = Boolean(state && state.pending);
     saveAiMessages();
     saveAiConversationId();
+    el("ai-chat-send").disabled = aiPending || aiRemotePending;
     renderAiMessages();
   }
 
@@ -828,7 +831,7 @@
   function renderAiMessages() {
     const box = el("ai-chat-messages");
     box.textContent = "";
-    if (!aiMessages.length && !aiPending) {
+    if (!aiMessages.length && !aiPending && !aiRemotePending) {
       const empty = document.createElement("div");
       empty.className = "ai-chat-empty";
       empty.textContent = "Ask anything about your sessions.";
@@ -857,7 +860,7 @@
         box.appendChild(work);
       }
     }
-    if (aiPending && !aiStreamingResponse) {
+    if ((aiPending || aiRemotePending) && !aiStreamingResponse) {
       const div = document.createElement("div");
       div.className = "ai-msg ai-msg-assistant ai-msg-pending";
       div.innerHTML = '<span class="ai-dot">&#9679;</span><span class="ai-dot">&#9679;</span><span class="ai-dot">&#9679;</span>';
@@ -954,23 +957,6 @@
       panel.style.bottom = "";
       panel.style.paddingBottom = "";
     }
-    updateAiChatDebug(keyboard);
-  }
-
-  // temporary: live viewport numbers so the iOS keyboard layout can be
-  // debugged on-device — remove once the sheet behaves
-  function updateAiChatDebug(keyboard) {
-    const dbg = el("ai-chat-debug");
-    if (!dbg) return;
-    const vv = window.visualViewport;
-    const panel = el("ai-chat-panel");
-    dbg.textContent =
-      `ih:${window.innerHeight}` +
-      ` vvh:${vv ? Math.round(vv.height) : "-"}` +
-      ` ot:${vv ? Math.round(vv.offsetTop) : "-"}` +
-      ` sy:${Math.round(window.scrollY || 0)}` +
-      ` kb:${Math.round(keyboard)}` +
-      ` top:${panel.style.top || "-"} h:${panel.style.height || "-"}`;
   }
 
   function openAiChat() {
@@ -1019,9 +1005,9 @@
   }
 
   async function sendAiChatMessage() {
-    if (aiPending) return;
+    if (aiPending || aiRemotePending) return;
     await syncAiChatState();
-    if (aiPending) return;
+    if (aiPending || aiRemotePending) return;
     const input = el("ai-chat-input");
     const message = input.value.trim();
     if (!message) return;
@@ -1126,9 +1112,10 @@
     } finally {
       aiPending = false;
       aiStreamingResponse = false;
-      el("ai-chat-send").disabled = false;
+      el("ai-chat-send").disabled = aiRemotePending;
       saveAiMessages();
       renderAiMessages();
+      await syncAiChatState({ allowImport: false });
     }
   }
 

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -12,6 +12,9 @@
   const desktopReorderQuery = window.matchMedia(
     "(min-width: 721px) and (hover: hover) and (pointer: fine)",
   );
+  const desktopCardCarouselQuery = window.matchMedia(
+    "(max-width: 720px) and (hover: hover) and (pointer: fine)",
+  );
 
   const el = (id) => document.getElementById(id);
 
@@ -491,6 +494,56 @@
     return data;
   }
 
+  async function streamSse(path, opts, onEvent) {
+    const resp = await fetch(path, opts);
+    if (!resp.ok) {
+      const data = await resp.json().catch(() => ({}));
+      throw new Error(data.error || `HTTP ${resp.status}`);
+    }
+    if (!resp.body) throw new Error("Streaming response is unavailable");
+
+    const reader = resp.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    function dispatch(block) {
+      let eventName = "message";
+      const dataLines = [];
+      for (const line of block.split("\n")) {
+        if (!line || line.startsWith(":")) continue;
+        const colon = line.indexOf(":");
+        const field = colon < 0 ? line : line.slice(0, colon);
+        let value = colon < 0 ? "" : line.slice(colon + 1);
+        if (value.startsWith(" ")) value = value.slice(1);
+        if (field === "event") eventName = value;
+        else if (field === "data") dataLines.push(value);
+      }
+      if (!dataLines.length) return;
+      const raw = dataLines.join("\n");
+      let data;
+      try { data = JSON.parse(raw); }
+      catch { data = { text: raw }; }
+      onEvent(eventName, data);
+    }
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        buffer += decoder.decode(value || new Uint8Array(), { stream: !done });
+        buffer = buffer.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+        let boundary;
+        while ((boundary = buffer.indexOf("\n\n")) >= 0) {
+          dispatch(buffer.slice(0, boundary));
+          buffer = buffer.slice(boundary + 2);
+        }
+        if (done) break;
+      }
+      if (buffer.trim()) dispatch(buffer);
+    } finally {
+      reader.releaseLock();
+    }
+  }
+
   function sessionOrderFromRows() {
     return Array.from(el("sessions-body").querySelectorAll("tr[data-session-id]"))
       .map((row) => row.dataset.sessionId)
@@ -594,6 +647,789 @@
       clearSessionDragClasses();
       render();
     });
+  }
+
+  function initDesktopCardCarousel() {
+    const body = el("sessions-body");
+    const dragThreshold = 6;
+    let drag = null;
+    let suppressClick = false;
+
+    function rowScrollLeft(row) {
+      const bodyBox = body.getBoundingClientRect();
+      const rowBox = row.getBoundingClientRect();
+      return body.scrollLeft + rowBox.left - bodyBox.left;
+    }
+
+    function snapToNearestCard() {
+      const rows = Array.from(body.querySelectorAll("tr[data-session-id]"));
+      if (!rows.length) return;
+      const nearest = rows.reduce((best, row) => {
+        const distance = Math.abs(rowScrollLeft(row) - body.scrollLeft);
+        return !best || distance < best.distance ? { row, distance } : best;
+      }, null);
+      if (nearest) {
+        body.scrollTo({ left: rowScrollLeft(nearest.row), behavior: "smooth" });
+      }
+    }
+
+    function endDrag(e) {
+      if (!drag || (e && e.pointerId !== drag.pointerId)) return;
+      const moved = drag.moved;
+      drag = null;
+      body.classList.remove("session-carousel-dragging");
+      if (!moved) return;
+      suppressClick = true;
+      window.setTimeout(() => { suppressClick = false; }, 0);
+      window.requestAnimationFrame(snapToNearestCard);
+    }
+
+    body.addEventListener("pointerdown", (e) => {
+      if (!desktopCardCarouselQuery.matches || e.pointerType === "touch" || e.button !== 0) {
+        return;
+      }
+      drag = {
+        pointerId: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        scrollLeft: body.scrollLeft,
+        moved: false,
+      };
+    });
+
+    window.addEventListener("pointermove", (e) => {
+      if (!drag || e.pointerId !== drag.pointerId) return;
+      const dx = e.clientX - drag.startX;
+      const dy = e.clientY - drag.startY;
+      if (!drag.moved) {
+        if (Math.abs(dx) < dragThreshold || Math.abs(dx) <= Math.abs(dy)) return;
+        drag.moved = true;
+        body.classList.add("session-carousel-dragging");
+      }
+      e.preventDefault();
+      body.scrollLeft = drag.scrollLeft - dx;
+    }, { passive: false });
+
+    window.addEventListener("pointerup", endDrag);
+    window.addEventListener("pointercancel", endDrag);
+    window.addEventListener("blur", () => endDrag());
+    desktopCardCarouselQuery.addEventListener("change", () => {
+      if (!desktopCardCarouselQuery.matches) endDrag();
+    });
+    body.addEventListener("click", (e) => {
+      if (!suppressClick) return;
+      suppressClick = false;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+    }, true);
+  }
+
+  // ---- AI chat (floating 🐸 button + panel) --------------------------------
+  const AI_CHAT_HISTORY_KEY = "aiChatMessages";
+  const AI_CHAT_CONVERSATION_KEY = "aiChatConversationId";
+  const AI_CHAT_FAB_POS_KEY = "aiChatFabPos";
+  const AI_CHAT_MAX_HISTORY = 12;
+  let aiMessages = [];
+  let aiConversationId = "";
+  let aiPending = false;
+  let aiStreamingResponse = false;
+  let aiRenderFrame = null;
+  let aiChatLockedScroll = false;
+  let aiStateSyncPromise = null;
+
+  function loadPersistentAiValue(key) {
+    try {
+      const saved = localStorage.getItem(key);
+      if (saved != null) return saved;
+      const legacy = sessionStorage.getItem(key);
+      if (legacy != null) {
+        localStorage.setItem(key, legacy);
+        sessionStorage.removeItem(key);
+        return legacy;
+      }
+    } catch {}
+    return null;
+  }
+
+  function loadAiMessages() {
+    try {
+      const parsed = JSON.parse(loadPersistentAiValue(AI_CHAT_HISTORY_KEY) || "[]");
+      if (Array.isArray(parsed)) {
+        aiMessages = parsed.filter((m) =>
+          m && (m.role === "user" || m.role === "assistant") && typeof m.content === "string")
+          .map((m) => ({
+            role: m.role,
+            content: m.content,
+            ...(m.error ? { error: true } : {}),
+          }));
+      }
+    } catch { aiMessages = []; }
+  }
+
+  function saveAiMessages() {
+    try { localStorage.setItem(AI_CHAT_HISTORY_KEY, JSON.stringify(aiMessages)); } catch {}
+  }
+
+  function loadAiConversationId() {
+    try { aiConversationId = loadPersistentAiValue(AI_CHAT_CONVERSATION_KEY) || ""; }
+    catch { aiConversationId = ""; }
+  }
+
+  function saveAiConversationId() {
+    try {
+      if (aiConversationId) localStorage.setItem(AI_CHAT_CONVERSATION_KEY, aiConversationId);
+      else localStorage.removeItem(AI_CHAT_CONVERSATION_KEY);
+    } catch {}
+  }
+
+  function applyAiChatState(state) {
+    const messages = Array.isArray(state && state.messages) ? state.messages : [];
+    aiMessages = messages.filter((m) =>
+      m && (m.role === "user" || m.role === "assistant") && typeof m.content === "string");
+    aiConversationId = state && typeof state.conversation_id === "string"
+      ? state.conversation_id
+      : "";
+    saveAiMessages();
+    saveAiConversationId();
+    renderAiMessages();
+  }
+
+  async function syncAiChatState({ allowImport = true } = {}) {
+    if (aiPending) return;
+    if (aiStateSyncPromise) return aiStateSyncPromise;
+    aiStateSyncPromise = (async () => {
+      let state = await api("/api/ai/chat");
+      const serverMessages = Array.isArray(state.messages) ? state.messages : [];
+      if (allowImport && !serverMessages.length && aiMessages.length) {
+        state = await api("/api/ai/chat/state", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            messages: aiMessages,
+            conversation_id: aiConversationId || null,
+          }),
+        });
+      }
+      if (!aiPending) applyAiChatState(state);
+    })().catch(() => {}).finally(() => {
+      aiStateSyncPromise = null;
+    });
+    return aiStateSyncPromise;
+  }
+
+  function scheduleAiRender() {
+    if (aiRenderFrame != null) return;
+    aiRenderFrame = requestAnimationFrame(() => {
+      aiRenderFrame = null;
+      renderAiMessages();
+    });
+  }
+
+  function renderAiMessages() {
+    const box = el("ai-chat-messages");
+    box.textContent = "";
+    if (!aiMessages.length && !aiPending) {
+      const empty = document.createElement("div");
+      empty.className = "ai-chat-empty";
+      empty.textContent = "Ask anything about your sessions.";
+      box.appendChild(empty);
+      return;
+    }
+    for (const msg of aiMessages) {
+      const div = document.createElement("div");
+      div.className = `ai-msg ai-msg-${msg.role === "user" ? "user" : "assistant"}`;
+      if (msg.error) div.classList.add("ai-msg-error");
+      if (msg.role === "assistant" && !msg.error && typeof msg.html === "string") {
+        div.classList.add("ai-msg-markdown");
+        div.innerHTML = msg.html;
+        for (const link of div.querySelectorAll("a")) {
+          link.target = "_blank";
+          link.rel = "noopener noreferrer";
+        }
+      } else {
+        div.textContent = msg.content;
+      }
+      if (msg.content || !msg.transient || msg.error) box.appendChild(div);
+      if (msg.role === "assistant" && msg.transient && typeof msg.workStatus === "string") {
+        const work = document.createElement("div");
+        work.className = "ai-msg-work";
+        work.textContent = msg.workStatus;
+        box.appendChild(work);
+      }
+    }
+    if (aiPending && !aiStreamingResponse) {
+      const div = document.createElement("div");
+      div.className = "ai-msg ai-msg-assistant ai-msg-pending";
+      div.innerHTML = '<span class="ai-dot">&#9679;</span><span class="ai-dot">&#9679;</span><span class="ai-dot">&#9679;</span>';
+      box.appendChild(div);
+    }
+    box.scrollTop = box.scrollHeight;
+  }
+
+  function isAiChatOpen() {
+    return !el("ai-chat-panel").classList.contains("hidden");
+  }
+
+  // Desktop: dock the panel to the face — right side when it fits, left side
+  // otherwise — and clamp so it never leaves the viewport. Mobile keeps the
+  // CSS bottom sheet (inline styles cleared so the stylesheet wins).
+  function positionAiChatPanel() {
+    const panel = el("ai-chat-panel");
+    if (!desktopReorderQuery.matches) {
+      panel.style.left = "";
+      panel.style.top = "";
+      panel.style.right = "";
+      panel.style.bottom = "";
+      panel.style.height = "";
+      panel.style.paddingBottom = "";
+      // iOS fires window.resize while the keyboard animates; without this
+      // re-pin, that resize handler would wipe the keyboard compensation
+      updateAiPanelForKeyboard();
+      return;
+    }
+    if (panel.classList.contains("hidden")) return;
+    const fab = el("ai-chat-fab");
+    const GAP = 10;
+    const MARGIN = 10;
+    // the face's center is invariant under the hover/drag scale transform, so
+    // rebuild its edges from the untransformed layout size
+    const rect = fab.getBoundingClientRect();
+    const cx = rect.left + rect.width / 2;
+    const cy = rect.top + rect.height / 2;
+    const half = fab.offsetWidth / 2;
+    const pw = panel.offsetWidth;
+    const ph = panel.offsetHeight;
+    let left = cx + half + GAP;
+    if (left + pw > window.innerWidth - MARGIN) left = cx - half - GAP - pw;
+    left = Math.min(Math.max(left, MARGIN), Math.max(window.innerWidth - pw - MARGIN, MARGIN));
+    let top = cy - ph / 2;
+    top = Math.min(Math.max(top, MARGIN), Math.max(window.innerHeight - ph - MARGIN, MARGIN));
+    panel.style.left = `${left}px`;
+    panel.style.top = `${top}px`;
+    panel.style.right = "auto";
+    panel.style.bottom = "auto";
+    panel.style.paddingBottom = ""; // in case a mobile keyboard pad survived a breakpoint switch
+  }
+
+  // Mobile keyboards overlay a fixed bottom sheet, and iOS additionally
+  // scrolls fixed elements out of view to reveal the focused input. While the
+  // keyboard is up, pin the sheet to the visual viewport so it spans from the
+  // top of the *visible* area down to the keyboard edge.
+  function updateAiPanelForKeyboard() {
+    const panel = el("ai-chat-panel");
+    const vv = window.visualViewport;
+    if (!vv || desktopReorderQuery.matches || panel.classList.contains("hidden")) return;
+    // iOS reveals the focused input by force-scrolling the window based on
+    // the PRE-keyboard layout, then leaves that scroll behind even after the
+    // layout viewport shrinks to fit (observed: innerHeight 844→389 with
+    // scrollY stuck at 310). While the keyboard is up, fixed elements are
+    // dragged along by that scroll, shoving the sheet off the top of the
+    // screen. The page is scroll-locked whenever the sheet is open, so ANY
+    // nonzero scroll here is that forced reveal — always undo it.
+    if (window.scrollY || window.pageYOffset) window.scrollTo(0, 0);
+    // On iOS versions where the layout viewport resizes with the keyboard,
+    // this stays 0 and the plain CSS (top + bottom:0) already fits; the
+    // pinning below only kicks in where the keyboard overlays the viewport.
+    // Don't subtract vv.offsetTop: it grows to ~the keyboard height while
+    // Safari pans, which would read as "keyboard gone" mid-pan. The 50px
+    // threshold ignores URL-bar wobble; real keyboards are far taller.
+    const keyboard = window.innerHeight - vv.height;
+    if (keyboard > 50) {
+      const gap = Math.max(10, vv.height * 0.03);
+      panel.style.top = `${vv.offsetTop + gap}px`;
+      // Stretch the sheet past the visual viewport down to the layout-viewport
+      // bottom: Safari's URL/accessory bars above the keyboard are floating
+      // and translucent, so anything shorter lets the dashboard (and the FAB)
+      // peek through the strip between the composer and the keyboard. The
+      // padding keeps the composer itself above that strip, at the bottom of
+      // the *visible* area.
+      panel.style.height = `${window.innerHeight - vv.offsetTop - gap}px`;
+      panel.style.paddingBottom = `${keyboard}px`;
+      panel.style.bottom = "auto";
+      const box = el("ai-chat-messages");
+      box.scrollTop = box.scrollHeight;
+    } else {
+      panel.style.top = "";
+      panel.style.height = "";
+      panel.style.bottom = "";
+      panel.style.paddingBottom = "";
+    }
+    updateAiChatDebug(keyboard);
+  }
+
+  // temporary: live viewport numbers so the iOS keyboard layout can be
+  // debugged on-device — remove once the sheet behaves
+  function updateAiChatDebug(keyboard) {
+    const dbg = el("ai-chat-debug");
+    if (!dbg) return;
+    const vv = window.visualViewport;
+    const panel = el("ai-chat-panel");
+    dbg.textContent =
+      `ih:${window.innerHeight}` +
+      ` vvh:${vv ? Math.round(vv.height) : "-"}` +
+      ` ot:${vv ? Math.round(vv.offsetTop) : "-"}` +
+      ` sy:${Math.round(window.scrollY || 0)}` +
+      ` kb:${Math.round(keyboard)}` +
+      ` top:${panel.style.top || "-"} h:${panel.style.height || "-"}`;
+  }
+
+  function openAiChat() {
+    el("ai-chat-panel").classList.remove("hidden");
+    el("ai-chat-panel").setAttribute("aria-hidden", "false");
+    el("ai-chat-fab").setAttribute("aria-expanded", "true");
+    positionAiChatPanel();
+    renderAiMessages();
+    syncAiChatState();
+    if (desktopReorderQuery.matches) {
+      // desktop only: on mobile a programmatic focus doesn't raise the
+      // keyboard (no user gesture), and iOS may then ignore the tap on the
+      // pre-focused input — leave focusing to the user's tap
+      el("ai-chat-input").focus();
+    } else {
+      // modal on mobile: background scroll would fight the sheet-drag gesture
+      // and lets iOS shove the sheet off-screen when the keyboard opens
+      lockBodyScroll();
+      aiChatLockedScroll = true;
+    }
+  }
+
+  function closeAiChat() {
+    if (!isAiChatOpen()) return;
+    const panel = el("ai-chat-panel");
+    panel.classList.add("hidden");
+    panel.setAttribute("aria-hidden", "true");
+    // drop any keyboard pin / sheet-drag offset
+    panel.style.top = "";
+    panel.style.height = "";
+    panel.style.bottom = "";
+    panel.style.paddingBottom = "";
+    panel.style.transform = "";
+    el("ai-chat-fab").setAttribute("aria-expanded", "false");
+    if (aiChatLockedScroll) {
+      unlockBodyScroll();
+      aiChatLockedScroll = false;
+    }
+  }
+
+  function autosizeAiInput() {
+    const input = el("ai-chat-input");
+    input.style.height = "auto";
+    // +2 for the top/bottom border (box-sizing: border-box); CSS max-height clamps
+    input.style.height = `${input.scrollHeight + 2}px`;
+  }
+
+  async function sendAiChatMessage() {
+    if (aiPending) return;
+    await syncAiChatState();
+    if (aiPending) return;
+    const input = el("ai-chat-input");
+    const message = input.value.trim();
+    if (!message) return;
+    const history = aiMessages
+      .filter((m) => !m.error)
+      .slice(-AI_CHAT_MAX_HISTORY)
+      .map((m) => ({ role: m.role, content: m.content }));
+    aiMessages.push({ role: "user", content: message });
+    saveAiMessages();
+    input.value = "";
+    autosizeAiInput();
+    aiPending = true;
+    aiStreamingResponse = false;
+    el("ai-chat-send").disabled = true;
+    renderAiMessages();
+    let assistantMessage = null;
+    let completed = false;
+    let finalAnswerStarted = false;
+    try {
+      await streamSse("/api/ai/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message, history, conversation_id: aiConversationId || null }),
+      }, (eventName, data) => {
+        if (eventName === "conversation") {
+          aiConversationId = data.conversation_id || aiConversationId;
+          saveAiConversationId();
+          return;
+        }
+        if (eventName === "status") {
+          if (finalAnswerStarted) return;
+          if (!assistantMessage) {
+            assistantMessage = { role: "assistant", content: "", transient: true };
+            aiMessages.push(assistantMessage);
+          }
+          assistantMessage.content = data.text || "...";
+          delete assistantMessage.html;
+          assistantMessage.transient = true;
+          aiStreamingResponse = true;
+          scheduleAiRender();
+          return;
+        }
+        if (eventName === "work_status") {
+          if (finalAnswerStarted) return;
+          if (!assistantMessage) {
+            assistantMessage = { role: "assistant", content: "", transient: true };
+            aiMessages.push(assistantMessage);
+          }
+          assistantMessage.workStatus = data.text || "Working...";
+          assistantMessage.transient = true;
+          aiStreamingResponse = true;
+          scheduleAiRender();
+          return;
+        }
+        if (eventName === "delta") {
+          if (!assistantMessage) {
+            assistantMessage = { role: "assistant", content: "" };
+            aiMessages.push(assistantMessage);
+          }
+          if (!finalAnswerStarted) {
+            assistantMessage.content = "";
+            delete assistantMessage.html;
+            delete assistantMessage.transient;
+            delete assistantMessage.workStatus;
+            finalAnswerStarted = true;
+          }
+          aiStreamingResponse = true;
+          assistantMessage.content += data.text || "";
+          if (typeof data.html === "string") assistantMessage.html = data.html;
+          scheduleAiRender();
+          return;
+        }
+        if (eventName === "done") {
+          if (!assistantMessage) {
+            assistantMessage = { role: "assistant", content: "" };
+            aiMessages.push(assistantMessage);
+          }
+          delete assistantMessage.transient;
+          delete assistantMessage.workStatus;
+          assistantMessage.content = data.answer || assistantMessage.content || "(empty response)";
+          if (typeof data.html === "string") assistantMessage.html = data.html;
+          else delete assistantMessage.html;
+          finalAnswerStarted = true;
+          completed = true;
+          return;
+        }
+        if (eventName === "stream_error") {
+          throw new Error(data.error || "AI stream failed");
+        }
+      });
+      if (!completed) throw new Error("AI stream ended before completion");
+    } catch (e) {
+      if (assistantMessage && assistantMessage.transient) {
+        assistantMessage.content = `AI call failed: ${e.message}`;
+        assistantMessage.error = true;
+        delete assistantMessage.html;
+        delete assistantMessage.transient;
+        delete assistantMessage.workStatus;
+      } else {
+        aiMessages.push({ role: "assistant", content: `AI call failed: ${e.message}`, error: true });
+      }
+    } finally {
+      aiPending = false;
+      aiStreamingResponse = false;
+      el("ai-chat-send").disabled = false;
+      saveAiMessages();
+      renderAiMessages();
+    }
+  }
+
+  function initAiChat() {
+    const fab = el("ai-chat-fab");
+    const FAB_MARGIN = 8;
+    const DRAG_THRESHOLD = 6; // px of travel before a tap becomes a drag
+    let drag = null;
+    let suppressClick = false;
+
+    function applyFabPos(left, top) {
+      const maxLeft = window.innerWidth - fab.offsetWidth - FAB_MARGIN;
+      const maxTop = window.innerHeight - fab.offsetHeight - FAB_MARGIN;
+      fab.style.left = `${Math.min(Math.max(left, FAB_MARGIN), Math.max(maxLeft, FAB_MARGIN))}px`;
+      fab.style.top = `${Math.min(Math.max(top, FAB_MARGIN), Math.max(maxTop, FAB_MARGIN))}px`;
+      fab.style.right = "auto";
+      fab.style.bottom = "auto";
+      positionAiChatPanel(); // keep an open panel docked to the face
+    }
+
+    function resetFabPos() {
+      fab.style.left = "";
+      fab.style.top = "";
+      fab.style.right = "";
+      fab.style.bottom = "";
+    }
+
+    function currentFabPos() {
+      // prefer the inline style: getBoundingClientRect() is skewed while the
+      // hover/drag scale transform is active
+      if (fab.style.left) {
+        return { left: parseFloat(fab.style.left), top: parseFloat(fab.style.top) };
+      }
+      const rect = fab.getBoundingClientRect();
+      return { left: rect.left, top: rect.top };
+    }
+
+    // mobile: the face always rests against the nearest side edge
+    function snappedFabLeft(left) {
+      const maxLeft = Math.max(window.innerWidth - fab.offsetWidth - FAB_MARGIN, FAB_MARGIN);
+      return left + fab.offsetWidth / 2 < window.innerWidth / 2 ? FAB_MARGIN : maxLeft;
+    }
+
+    let snapTimer = null;
+    function snapFabToSide() {
+      const pos = currentFabPos();
+      // inline style jumps straight to the resting spot (so currentFabPos()
+      // and persistence see the final value); .snapping animates the visual
+      fab.classList.add("snapping");
+      applyFabPos(snappedFabLeft(pos.left), pos.top);
+      clearTimeout(snapTimer);
+      snapTimer = setTimeout(() => fab.classList.remove("snapping"), 250);
+    }
+
+    function restoreFabPos() {
+      try {
+        const pos = JSON.parse(localStorage.getItem(AI_CHAT_FAB_POS_KEY) || "null");
+        if (pos && typeof pos.left === "number" && typeof pos.top === "number") {
+          // a spot saved on desktop may be mid-screen; mobile pulls it aside
+          const left = desktopReorderQuery.matches ? pos.left : snappedFabLeft(pos.left);
+          applyFabPos(left, pos.top);
+          return;
+        }
+      } catch {}
+      resetFabPos(); // no saved spot: fall back to the per-breakpoint CSS default
+    }
+
+    fab.addEventListener("pointerdown", (e) => {
+      if (!e.isPrimary) return;
+      // a fresh press starts a new tap/drag decision; without this, a drag
+      // whose trailing click never fired (touch) would swallow the next tap
+      suppressClick = false;
+      const pos = currentFabPos();
+      drag = {
+        id: e.pointerId,
+        startX: e.clientX,
+        startY: e.clientY,
+        left: pos.left,
+        top: pos.top,
+        moved: false,
+      };
+      try { fab.setPointerCapture(e.pointerId); } catch {}
+    });
+    fab.addEventListener("pointermove", (e) => {
+      if (!drag || e.pointerId !== drag.id) return;
+      const dx = e.clientX - drag.startX;
+      const dy = e.clientY - drag.startY;
+      if (!drag.moved && Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
+      drag.moved = true;
+      fab.classList.add("dragging");
+      applyFabPos(drag.left + dx, drag.top + dy);
+    });
+    function endFabDrag(e) {
+      if (!drag || e.pointerId !== drag.id) return;
+      if (drag.moved) {
+        suppressClick = true; // the click right after a drag must not toggle the panel
+        if (!desktopReorderQuery.matches) snapFabToSide();
+        try {
+          localStorage.setItem(AI_CHAT_FAB_POS_KEY, JSON.stringify(currentFabPos()));
+        } catch {}
+      }
+      drag = null;
+      fab.classList.remove("dragging");
+    }
+    fab.addEventListener("pointerup", endFabDrag);
+    fab.addEventListener("pointercancel", endFabDrag);
+
+    fab.addEventListener("click", () => {
+      if (suppressClick) { suppressClick = false; return; }
+      if (isAiChatOpen()) closeAiChat();
+      else openAiChat();
+    });
+
+    window.addEventListener("resize", () => {
+      if (fab.style.left) {
+        const left = parseFloat(fab.style.left);
+        // orientation change etc.: mobile re-docks to the nearest side
+        applyFabPos(
+          desktopReorderQuery.matches ? left : snappedFabLeft(left),
+          parseFloat(fab.style.top),
+        );
+      }
+      positionAiChatPanel();
+    });
+    // breakpoint change: re-clamp the saved spot (or fall back to that
+    // breakpoint's CSS default), then re-dock or reset the panel
+    if (desktopReorderQuery.addEventListener) {
+      desktopReorderQuery.addEventListener("change", () => {
+        restoreFabPos();
+        positionAiChatPanel();
+      });
+    }
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener("resize", updateAiPanelForKeyboard);
+      window.visualViewport.addEventListener("scroll", updateAiPanelForKeyboard);
+    }
+    // Safari's focus-reveal scroll doesn't always emit visualViewport events
+    window.addEventListener("scroll", updateAiPanelForKeyboard);
+    el("ai-chat-input").addEventListener("focus", () => {
+      setTimeout(updateAiPanelForKeyboard, 100);
+      setTimeout(updateAiPanelForKeyboard, 400); // after the keyboard animation settles
+    });
+    // last-resort self-heal: re-pin every 500ms while the sheet is open, so a
+    // missed/reordered viewport event can knock the sheet out for at most half
+    // a second (no-op on desktop or while closed)
+    setInterval(() => {
+      if (!desktopReorderQuery.matches && isAiChatOpen()) updateAiPanelForKeyboard();
+    }, 500);
+
+    // mobile: dragging the sheet down from the grabber/header closes it
+    const panel = el("ai-chat-panel");
+    const sheetHeader = panel.querySelector(".ai-chat-header");
+    let sheetDrag = null;
+    sheetHeader.addEventListener("pointerdown", (e) => {
+      if (desktopReorderQuery.matches || !e.isPrimary) return;
+      if (e.target && e.target.closest && e.target.closest("button")) return;
+      sheetDrag = { id: e.pointerId, startY: e.clientY, dy: 0 };
+      try { sheetHeader.setPointerCapture(e.pointerId); } catch {}
+    });
+    sheetHeader.addEventListener("pointermove", (e) => {
+      if (!sheetDrag || e.pointerId !== sheetDrag.id) return;
+      sheetDrag.dy = Math.max(0, e.clientY - sheetDrag.startY);
+      panel.style.transform = sheetDrag.dy > 0 ? `translateY(${sheetDrag.dy}px)` : "";
+    });
+    function endSheetDrag(e) {
+      if (!sheetDrag || e.pointerId !== sheetDrag.id) return;
+      const dy = sheetDrag.dy;
+      sheetDrag = null;
+      panel.style.transform = "";
+      if (dy > 100) closeAiChat();
+    }
+    sheetHeader.addEventListener("pointerup", endSheetDrag);
+    sheetHeader.addEventListener("pointercancel", endSheetDrag);
+
+    el("ai-chat-close").addEventListener("click", closeAiChat);
+    el("ai-chat-clear").addEventListener("click", () => {
+      const conversationId = aiConversationId;
+      aiConversationId = "";
+      saveAiConversationId();
+      aiMessages = [];
+      saveAiMessages();
+      renderAiMessages();
+      if (conversationId) {
+        api("/api/ai/chat/reset", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ conversation_id: conversationId }),
+        }).catch(() => {});
+      }
+    });
+    el("ai-chat-form").addEventListener("submit", (e) => {
+      e.preventDefault();
+      sendAiChatMessage();
+    });
+    const input = el("ai-chat-input");
+    let inputComposing = false;
+    let sendAfterComposition = false;
+    input.addEventListener("input", autosizeAiInput);
+    input.addEventListener("compositionstart", () => {
+      inputComposing = true;
+      sendAfterComposition = false;
+    });
+    input.addEventListener("compositionend", () => {
+      inputComposing = false;
+      if (!sendAfterComposition) return;
+      sendAfterComposition = false;
+      setTimeout(sendAiChatMessage, 0);
+    });
+    input.addEventListener("keydown", (e) => {
+      // Enter sends on desktop (Shift+Enter for a newline); mobile keyboards
+      // keep Enter as newline and send via the button.
+      if (e.key === "Enter" && !e.shiftKey && desktopReorderQuery.matches) {
+        if (e.isComposing || inputComposing || e.keyCode === 229) {
+          sendAfterComposition = true;
+          return;
+        }
+        e.preventDefault();
+        sendAiChatMessage();
+      }
+    });
+
+    loadAiMessages();
+    loadAiConversationId();
+    syncAiChatState();
+    restoreFabPos();
+  }
+
+  // ---- Pepe faces: random blink + pupils that follow the pointer -----------
+  function initPepeFaces() {
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+    const faces = Array.from(document.querySelectorAll("svg.pepe")).map((svg) => ({
+      svg,
+      pupils: Array.from(svg.querySelectorAll(".pepe-pupil")).map((node) => ({
+        node,
+        cx: parseFloat(node.getAttribute("cx")),
+        cy: parseFloat(node.getAttribute("cy")),
+      })),
+    }));
+    if (!faces.length) return;
+
+    function blinkOnce(svg, done) {
+      svg.classList.add("pepe-blink");
+      setTimeout(() => {
+        svg.classList.remove("pepe-blink");
+        done();
+      }, 130);
+    }
+    function scheduleBlink(svg) {
+      setTimeout(() => {
+        blinkOnce(svg, () => {
+          // occasional quick double blink reads more lifelike than a fixed beat
+          if (Math.random() < 0.2) {
+            setTimeout(() => blinkOnce(svg, () => scheduleBlink(svg)), 150);
+          } else {
+            scheduleBlink(svg);
+          }
+        });
+      }, 2200 + Math.random() * 4300);
+    }
+    faces.forEach((f) => scheduleBlink(f.svg));
+
+    const PEPE_VIEWBOX = 64;
+    // pupil travel in viewBox units, asymmetric so it stays on the eye white
+    // (less headroom up: the half-closed lid sits right above the pupil)
+    const RANGE_X = 3;
+    const RANGE_Y_UP = 1;
+    const RANGE_Y_DOWN = 1.2;
+    function lookAt(clientX, clientY) {
+      for (const face of faces) {
+        const rect = face.svg.getBoundingClientRect();
+        if (!rect.width) continue; // hidden (chat panel closed)
+        const scale = rect.width / PEPE_VIEWBOX;
+        for (const pupil of face.pupils) {
+          let dx = (clientX - (rect.left + pupil.cx * scale)) / scale;
+          let dy = (clientY - (rect.top + pupil.cy * scale)) / scale;
+          const ry = dy < 0 ? RANGE_Y_UP : RANGE_Y_DOWN;
+          const d = Math.hypot(dx / RANGE_X, dy / ry);
+          if (d > 1) {
+            dx /= d;
+            dy /= d;
+          }
+          pupil.node.setAttribute("transform", `translate(${dx.toFixed(2)} ${dy.toFixed(2)})`);
+        }
+      }
+    }
+    let lookFrame = null;
+    let lastX = 0;
+    let lastY = 0;
+    window.addEventListener(
+      "pointermove",
+      (e) => {
+        lastX = e.clientX;
+        lastY = e.clientY;
+        if (lookFrame !== null) return;
+        lookFrame = requestAnimationFrame(() => {
+          lookFrame = null;
+          lookAt(lastX, lastY);
+        });
+      },
+      { passive: true }
+    );
   }
 
   async function runnerAction(id, action) {
@@ -988,6 +1824,7 @@
     if (!el("log-modal").classList.contains("hidden")) closeLogs();
     if (!el("settings-modal").classList.contains("hidden")) closeSettings();
     if (!el("remove-modal").classList.contains("hidden")) closeRemoveConfirm();
+    closeAiChat();
   });
   document.addEventListener("click", (e) => {
     const scriptControl = el("script-select-control");
@@ -1281,6 +2118,7 @@
       if (ws !== hubWs || generation !== hubGeneration) return;
       clearTimeout(connectGuard);
       setHubStatus("syncing…");
+      if (!aiPending) syncAiChatState({ allowImport: false });
       refresh().then((ok) => {
         if (ws !== hubWs || generation !== hubGeneration || hubLive) return;
         if (ok) {
@@ -1302,6 +2140,8 @@
         const msg = JSON.parse(ev.data);
         if (msg.type === "sessions") {
           applySessions(msg.sessions || []);
+        } else if (msg.type === "ai_chat_updated" && !aiPending) {
+          syncAiChatState({ allowImport: false });
         }
       } catch {}
     };
@@ -1346,6 +2186,9 @@
   window.addEventListener("online", rebuildHub);
 
   initSessionReordering();
+  initDesktopCardCarousel();
+  initAiChat();
+  initPepeFaces();
   startHubClock();
   refresh();   // one-time initial load; thereafter the hub pushes via /ws/hub
   connect();

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -729,6 +729,7 @@
   const AI_CHAT_CONVERSATION_KEY = "aiChatConversationId";
   const AI_CHAT_FAB_POS_KEY = "aiChatFabPos";
   const AI_CHAT_MAX_HISTORY = 12;
+  let aiEnabled = false;
   let aiMessages = [];
   let aiConversationId = "";
   let aiPending = false;
@@ -737,6 +738,13 @@
   let aiRenderFrame = null;
   let aiChatLockedScroll = false;
   let aiStateSyncPromise = null;
+
+  function applyAiAvailability(enabled) {
+    if (typeof enabled !== "boolean") return;
+    aiEnabled = enabled;
+    el("ai-chat-fab").classList.toggle("hidden", !aiEnabled);
+    if (!aiEnabled && isAiChatOpen()) closeAiChat();
+  }
 
   function loadPersistentAiValue(key) {
     try {
@@ -1985,6 +1993,7 @@
   async function refresh() {
     try {
       const data = await api("/api/sessions");
+      applyAiAvailability(data.ai_enabled);
       applySessions(data.sessions || []);
       return true;
     } catch (e) {
@@ -2126,6 +2135,7 @@
       try {
         const msg = JSON.parse(ev.data);
         if (msg.type === "sessions") {
+          applyAiAvailability(msg.ai_enabled);
           applySessions(msg.sessions || []);
         } else if (msg.type === "ai_chat_updated" && !aiPending) {
           syncAiChatState({ allowImport: false });

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -1306,13 +1306,11 @@
       aiMessages = [];
       saveAiMessages();
       renderAiMessages();
-      if (conversationId) {
-        api("/api/ai/chat/reset", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ conversation_id: conversationId }),
-        }).catch(() => {});
-      }
+      api("/api/ai/chat/reset", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ conversation_id: conversationId || null }),
+      }).catch(() => {});
     });
     el("ai-chat-form").addEventListener("submit", (e) => {
       e.preventDefault();

--- a/pynecore/lib/strategy/__init__.py
+++ b/pynecore/lib/strategy/__init__.py
@@ -82,7 +82,7 @@ class Order:
 
     __slots__ = (
         "order_id", "size", "sign", "order_type", "limit", "stop", "exit_id", "oca_name", "oca_type",
-        "comment", "alert_message",
+        "comment", "alert_message", "ai_instruction",
         "trail_price", "trail_offset",
         "trail_triggered",
         "profit_ticks", "loss_ticks", "trail_points_ticks",  # Store tick values for later calculation
@@ -104,6 +104,7 @@ class Order:
             oca_type: _oca.Oca = _oca.none,
             comment: str | None = None,
             alert_message: str | None = None,
+            ai_instruction: str | None = None,
             trail_price: float | None = None,
             trail_offset: float | None = None,
             profit_ticks: float | None = None,
@@ -124,6 +125,7 @@ class Order:
 
         self.comment = comment
         self.alert_message = alert_message
+        self.ai_instruction = ai_instruction
 
         self.trail_price = trail_price
         self.trail_offset = trail_offset or 0  # in ticks
@@ -381,7 +383,7 @@ class Position:
         'risk_max_position_size',
         'risk_cons_loss_days', 'risk_last_day_index', 'risk_last_day_equity',
         'risk_intraday_filled_orders', 'risk_intraday_start_equity', 'risk_halt_trading',
-        'on_entry_callback', 'on_close_callback', 'on_alert_callback'
+        'on_entry_callback', 'on_close_callback', 'on_alert_callback', 'on_ai_callback'
     )
 
     def __init__(self):
@@ -453,6 +455,7 @@ class Position:
         self.on_entry_callback = None
         self.on_close_callback = None
         self.on_alert_callback = None
+        self.on_ai_callback = None
 
     @property
     def equity(self) -> float | NA[float]:
@@ -826,18 +829,28 @@ class Position:
                 # Use the saved original filled_size from the beginning of this method
                 self._reduce_oca_group(order.oca_name, filled_size)
 
+        self._dispatch_order_notifications(order)
+
+    def _dispatch_order_notifications(self, order: Order) -> None:
         if not realtime_trade() and order.alert_message:
             alert(order.alert_message)
-        elif realtime_trade() and not pre_run() and order.alert_message:
+        elif realtime_trade() and not pre_run():
             # print(f"order.bar_index: {order.bar_index}, last_bar_index: {last_bar_index()}")
-            # Real time trade 에서는 최종 봉이 확정되고 새로운 봉이 생길때에만 alert 이 울리도록 함
+            # Real time trade 에서는 최종 봉이 확정되고 새로운 봉이 생길때에만
+            # alert 및 AI instruction을 전달함.
             if order.bar_index == last_bar_index() - 1:
-                alert(order.alert_message)
-                if self.on_alert_callback:
+                if order.alert_message:
+                    alert(order.alert_message)
+                if order.alert_message and self.on_alert_callback:
                     try:
                         self.on_alert_callback(order.alert_message)
                     except Exception as e:
                         print(f"Error in on_alert_callback: {e}")
+                if order.ai_instruction and self.on_ai_callback:
+                    try:
+                        self.on_ai_callback(order.ai_instruction, order, lib._time)
+                    except Exception as e:
+                        print(f"Error in on_ai_callback: {e}")
 
     def fill_order(self, order: Order, price: float, h: float, l: float) -> bool:
         """
@@ -914,6 +927,9 @@ class Position:
             # Create a copy for closing existing position
             order1 = copy(order)
             order1.order_type = _order_type_close
+            # The AI instruction belongs to the requested entry, not the
+            # internal close leg used to reverse an existing position.
+            order1.ai_instruction = None
             order1.size = -self.size
             # Set order_id to None so it will close any open trades
             order1.order_id = None
@@ -1383,7 +1399,8 @@ def cancel_all():
 def close(id: str, comment: str | NA[str] = na_str, qty: float | NA[float] = na_float,
           qty_percent: float | NA[float] = na_float, alert_message: str | NA[str] = na_str,
           immediately: bool = False,
-          record: bool = False, record_data: str | None = None):
+          record: bool = False, record_data: str | None = None,
+          ai: str | NA[str] = na_str):
     """
     Creates an order to exit from the part of a position opened by entry orders with a specific identifier.
 
@@ -1394,6 +1411,7 @@ def close(id: str, comment: str | NA[str] = na_str, qty: float | NA[float] = na_
                         quantity to close when an exit order fills
     :param alert_message: Custom text for the alert that fires when an order fills.
     :param immediately: If true, the closing order executes on the same tick when the strategy places it
+    :param ai: Instruction sent to the configured AI service when the order fills
     """
     if lib._lib_semaphore:
         return
@@ -1419,9 +1437,11 @@ def close(id: str, comment: str | NA[str] = na_str, qty: float | NA[float] = na_
     exit_id = f"Close entry(s) order {id}"
     bar_time = lib._time
     alert_message = f'{{"timestamp": {bar_time}, "message": {alert_message}}}' if alert_message else None
+    ai_instruction = None if isinstance(ai, NA) else str(ai).strip() or None
     order = Order(id, size, exit_id=exit_id, order_type=_order_type_close,
                   comment=None if isinstance(comment, NA) else comment,
-                  alert_message=None if isinstance(alert_message, NA) else alert_message)
+                  alert_message=None if isinstance(alert_message, NA) else alert_message,
+                  ai_instruction=ai_instruction)
 
     # Add order to position (this will handle orderbook and exit_orders)
     position._add_order(order)
@@ -1469,7 +1489,8 @@ def entry(id: str, direction: direction.Direction, qty: int | float | NA[float] 
           limit: int | float | None = None, stop: int | float | None = None,
           oca_name: str | None = None, oca_type: _oca.Oca | None = None,
           comment: str | None = None, alert_message: str | None = None,
-          record: bool = False, record_data: str | None = None):
+          record: bool = False, record_data: str | None = None,
+          ai: str | None = None):
     """
     Creates a new order to open or add to a position. If an order with the same id already exists
     and is unfilled, this command will modify that order.
@@ -1485,6 +1506,7 @@ def entry(id: str, direction: direction.Direction, qty: int | float | NA[float] 
     :param alert_message: Custom text for the alert that fires when an order fills
     :param record: Whether to record the entry data or not
     :param record_data: Extra data to record
+    :param ai: Instruction sent to the configured AI service when the order fills
     """
     if lib._lib_semaphore:
         return
@@ -1587,10 +1609,12 @@ def entry(id: str, direction: direction.Direction, qty: int | float | NA[float] 
 
     bar_time = lib._time
     alert_message = f'{{"timestamp": {bar_time}, "message": {alert_message}}}' if alert_message else None
+    ai_instruction = str(ai).strip() if ai is not None else None
     order = Order(id, size, order_type=_order_type_entry, limit=limit, stop=stop,
                   oca_name=oca_name, oca_type=oca_type,
                   comment=None if isinstance(comment, NA) else comment,
-                  alert_message=None if isinstance(alert_message, NA) else alert_message)
+                  alert_message=None if isinstance(alert_message, NA) else alert_message,
+                  ai_instruction=ai_instruction or None)
     # Store in entry_orders dict
     position._add_order(order)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,18 @@ dependencies = []
 optional-dependencies.cli = ["typer", "rich", "tzdata"]
 
 # All optional dependencies for cli and all built-in providers
-optional-dependencies.all = ["typer", "rich", "httpx", "ccxt", "pycryptodome", "tzdata"]
+optional-dependencies.all = [
+    "typer",
+    "rich",
+    "markdown-it-py",
+    "httpx",
+    "ccxt",
+    "pycryptodome",
+    "tzdata",
+    "openai-codex==0.1.0b3",
+    "websockets>=15,<17",
+    "certifi",
+]
 
 #Optional dependencies for development
 optional-dependencies.dev = ["pytest", "pytest-spec"]
@@ -47,10 +58,16 @@ optional-dependencies.dev = ["pytest", "pytest-spec"]
 ### Providers
 
 # For all providers to work (CCXT, Capital.com)
-optional-dependencies.providers = ["httpx", "ccxt", "pycryptodome"]
+optional-dependencies.providers = [
+    "httpx",
+    "ccxt",
+    "pycryptodome",
+    "websockets>=15,<17",
+    "certifi",
+]
 
 # For CCXT provider to work
-optional-dependencies.ccxt = ["ccxt"]
+optional-dependencies.ccxt = ["ccxt", "websockets>=15,<17", "certifi"]
 
 # For Capital.com provider to work
 optional-dependencies.capitalcom = ["httpx", "pycryptodome"]

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import hashlib
 import json
 import os
 import sys
@@ -299,6 +300,37 @@ def on_alert_event(message: str, runner: ScriptRunner):
     )
 
 
+def on_ai_event(instruction: str, order, bar_time: int, runner: ScriptRunner):
+    """Queue one deterministic AI instruction event for a realtime order fill."""
+    instruction = str(instruction or "").strip()
+    if not instruction or getattr(runner.script, "pre_run", False):
+        return
+
+    action = "close" if getattr(order, "exit_id", None) else "entry"
+    identity = {
+        "session_id": SESSION_ID,
+        "action": action,
+        "bar_time": int(bar_time),
+        "bar_index": int(getattr(order, "bar_index", -1)),
+        "order_id": str(getattr(order, "order_id", "") or ""),
+        "exit_id": str(getattr(order, "exit_id", "") or ""),
+        "instruction": instruction,
+    }
+    event_id = hashlib.sha256(
+        json.dumps(identity, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    trade_event_queue.append({
+        "type": "ai_instruction",
+        "event_id": event_id,
+        "instruction": instruction,
+        "action": action,
+        "time": int(bar_time / 1000),
+        "bar_index": identity["bar_index"],
+        "order_id": identity["order_id"],
+        "comment": str(getattr(order, "comment", "") or ""),
+    })
+
+
 def hide_zero_volume_bars(exchange: str | None) -> bool:
     # TradingView policy differs by exchange:
     # - OKX/Binance/Bybit: zero-volume candles are hidden and excluded from calculations.
@@ -403,6 +435,7 @@ AppendableIterable[OHLCV], OHLCVReader] | None:
             runner.script.position.on_entry_callback = partial(on_entry_event, runner=runner)
             runner.script.position.on_close_callback = partial(on_close_event, runner=runner)
             runner.script.position.on_alert_callback = partial(on_alert_event, runner=runner)
+            runner.script.position.on_ai_callback = partial(on_ai_event, runner=runner)
             # Register plot event callback
             runner.script.on_plot_callback = on_plot_event
             # Register plotchar event callback

--- a/workdir/config/providers.example.toml
+++ b/workdir/config/providers.example.toml
@@ -20,6 +20,37 @@ password = ""
 # password = "your_okex_password"
 # isTestnet = true    # Add any custom parameter required by the exchange
 
+# Multiple accounts for the same exchange can be named under ccxt_accounts.
+# Each account must declare its own credentials. Account names may contain
+# lowercase letters, numbers, underscores, and hyphens.
+# [ccxt_accounts.binance_main]
+# exchange = "binance"
+# apiKey = "your_main_account_api_key"
+# secret = "your_main_account_secret"
+#
+# [ccxt_accounts.binance_sub1]
+# exchange = "binance"
+# apiKey = "your_subaccount_api_key"
+# secret = "your_subaccount_secret"
+#
+# [ccxt_accounts.bitget_sub1]
+# exchange = "bitget"
+# apiKey = "your_subaccount_api_key"
+# secret = "your_subaccount_secret"
+# password = "your_subaccount_passphrase"
+
+# Exchange-nested account tables are also supported. Their command-line account
+# names are prefixed with the exchange ID: bitget_main and bitget_sub1 below.
+# [ccxt.bitget.main]
+# apiKey = "your_main_account_api_key"
+# secret = "your_main_account_secret"
+# password = "your_main_account_passphrase"
+#
+# [ccxt.bitget.sub1]
+# apiKey = "your_subaccount_api_key"
+# secret = "your_subaccount_secret"
+# password = "your_subaccount_passphrase"
+
 [capitalcom]
 # If it is a demo account
 demo = false
@@ -27,4 +58,3 @@ demo = false
 user_email = ""
 api_key = ""
 api_password = ""
-

--- a/workdir/scripts/demo/demo_1m.py
+++ b/workdir/scripts/demo/demo_1m.py
@@ -36,7 +36,12 @@ def main():
         avgEntry = close
         # If the record option is true, it will write entry and close records to a file in the records directory.
         strategy.entry("Long 1", strategy.long, alert_message=f'{{"signal": "Long 1", "price": {close}}}',
-                       comment=f"Long 1 at rsi: {rsi}", record=False)
+                       comment=f"Long 1 at rsi: {rsi}", record=False,
+                       ai=(
+                           f"Remove all existing Manual Alert triggers and set a close all trigger "
+                           f"at {close * 1.002}. If the close all template does not exist, create it "
+                           'with {"signal": "CLOSE TP3"}. Send the result to Telegram.'
+                       ))
 
     if entered1 and (time - entered1Time) >= 1 * 60 * 1000 * 2:
         entered1 = False


### PR DESCRIPTION
## 개요

PyneReal 대시보드에서 Codex와 대화하며 세션, 거래소 계정, 포지션을 분석하고 Manual Alert 및 전략 이벤트 기반 작업을 수행할 수 있도록 AI Integration을 추가합니다.

Codex app-server를 장기 실행 서비스로 관리하고, 계정 조회와 상태 변경은 서버가 제공하는 전용 도구를 통해서만 수행하도록 구성했습니다.

## 주요 변경사항

### 대시보드 AI 채팅

- Codex app-server 기반 대화형 AI 채팅 추가
- SSE 스트리밍으로 진행 상태, 도구 실행 상태, 최종 답변을 실시간 표시
- 마크다운, 표, 외부 링크 새 탭 열기 지원
- 서버에 대화 이력을 저장해 브라우저와 기기 간 대화 내용 공유
- 모델과 추론 수준 선택 메뉴 추가
- 기본값을 `gpt-5.6-sol` 및 `medium`으로 설정
- 모델·추론 설정을 서버에 저장하고 WebSocket으로 데스크톱과 모바일에 동기화
- 데스크톱 입력창 내부 모델 선택 및 화살표 전송 버튼 구성
- 모바일에서는 `PyneReal Ai >` 제목을 눌러 선택 메뉴 표시
- AI 기능을 사용하지 않으면 대시보드에서 AI 채팅 버튼 숨김

### Codex 서비스 및 보안

- `openai-codex` SDK 기반 Codex 서비스 수명주기 관리
- Codex 미로그인 시 사용 여부를 먼저 선택하고, 활성화한 경우에만 디바이스 로그인 수행
- 사용자 채팅과 전략 자동 지시를 분리된 thread에서 처리
- 읽기 전용 Codex sandbox와 서버 제어형 dynamic tool 조합 적용
- 파일 읽기는 허용하되 수정 범위를 `workdir/`, `modules/`, `data_service/templates/`로 제한
- 새 파일은 저장소의 `tmp/` 아래에서만 생성하도록 제한
- API 키, 시크릿 및 설정 파일의 민감정보가 AI 응답에 노출되지 않도록 지침 추가

### AI 전용 도구

- 거래소별·계정별 자산 조회 도구 추가
- 현물, 선물, 마진, funding, earn 자산 통합 조회 지원
- 동일 거래소의 여러 계정 및 서브계정 설정 지원
- 거래소별 전체 선물 시장 포지션 조회 지원
- Hyperliquid 기본 perpetual과 HIP-3 포지션 조회 지원
- Telegram 메시지 전송 도구 추가
- Manual Alert 컨텍스트 조회, 템플릿 생성, 트리거 등록 및 삭제 도구 추가
- 심볼, 회사명, 전략명으로 세션을 식별하고 모호한 경우 사용자에게 구분 정보 요청
- 전체 트리거 교체 시 기존 Alert 템플릿 보존

### 전략 AI 지시

- `strategy.entry()`와 `strategy.close()`에 `ai` 파라미터 추가
- 체결 이벤트 발생 시 runner에서 AI 지시와 세션·주문 컨텍스트 전달
- pre-run 및 과거 봉에서는 실행하지 않고 실시간 확정봉 이벤트에서만 전달
- 사용자 채팅과 별도로 전략 지시를 실행해 긴 대화가 자동 작업을 막지 않도록 구성
- 세션별 실행 순서를 보존하면서 서로 다른 세션의 AI 작업은 병렬 처리
- 지시문 언어에 맞춰 AI 및 Telegram 응답 언어 유지

### 설정 및 문서

- `providers.toml`을 Git 추적에서 제외하고 `providers.example.toml` 제공
- 설정 파일이 없으면 예제 파일을 자동 복사해 초기화
- AI 디렉터리 구조, 전용 스크립트, 워크플로 및 스키마 문서 추가
- README에 AI 기능, Codex 계정 요구사항, 거래소 계정 조회 및 전략 AI 사용법 추가
- 데모 전략에 AI 지시 예제 추가