### PR TITLE
세션 데이터 re-sync 및 대시보드 스크롤 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,6 @@ symbol = "BTC/USDT:USDT"
 timeframe = "1m"
 history_since = "2026-06-10"
 script_name = "demo/demo_1m.py"
-autostart_runner = false
 
 [session.webhook]
 enabled = false

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -21,6 +21,7 @@ import ccxt.pro as ccxtpro
 
 from ai.provider.codex_service import CodexService
 from registry import (
+    HistoryNotReadyError,
     SessionExistsError,
     SessionLimitError,
     SessionNotFoundError,
@@ -33,6 +34,7 @@ from config import (
     default_webhook_url,
     sanitize_manual_alert_templates,
     sanitize_manual_alert_triggers,
+    validate_history_since,
 )
 from manual_alerts import send_manual_alert_payload
 from ohlcv_io import make_ccxt_pro_client
@@ -792,12 +794,28 @@ def build_control_router(registry: SessionRegistry, codex_service: CodexService)
             return JSONResponse({"error": f"failed to remove session: {e}"}, status_code=500)
         return JSONResponse({"ok": True})
 
+    @r.patch("/api/sessions/{session_id}/history-since")
+    async def update_history_since(session_id: str, payload: dict = Body(default_factory=dict)) -> JSONResponse:
+        try:
+            value = validate_history_since(payload.get("history_since"))
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
+        try:
+            await registry.update_history_since(session_id, value)
+        except SessionNotFoundError:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        except Exception as e:
+            return JSONResponse({"error": f"failed to update history_since: {e}"}, status_code=500)
+        return JSONResponse({"ok": True, "history_since": value})
+
     @r.post("/api/sessions/{session_id}/runner/start")
     async def runner_start(session_id: str) -> JSONResponse:
         try:
             await registry.start_runner(session_id)
         except SessionNotFoundError:
             return JSONResponse({"error": "session not found"}, status_code=404)
+        except HistoryNotReadyError:
+            return JSONResponse({"error": "market data is still preparing"}, status_code=409)
         return JSONResponse({"ok": True})
 
     @r.post("/api/sessions/{session_id}/runner/stop")
@@ -814,6 +832,8 @@ def build_control_router(registry: SessionRegistry, codex_service: CodexService)
             await registry.restart_runner(session_id)
         except SessionNotFoundError:
             return JSONResponse({"error": "session not found"}, status_code=404)
+        except HistoryNotReadyError:
+            return JSONResponse({"error": "market data is still preparing"}, status_code=409)
         return JSONResponse({"ok": True})
 
     @r.get("/api/sessions/{session_id}/runner/logs")

--- a/data_service/config.py
+++ b/data_service/config.py
@@ -8,6 +8,7 @@ import shutil
 import tomllib
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime
 from pathlib import Path
 
 from pynecore.cli.app import app_state
@@ -104,6 +105,25 @@ def sanitize_manual_alert_triggers(raw: object) -> list[dict]:
     return triggers
 
 
+def validate_history_since(raw: object) -> str:
+    """Validate a history_since value for the dashboard edit endpoint: a UTC
+    date or datetime only, e.g. '2026-05-01' or '2026-06-01 07:30'. Raises
+    ValueError otherwise.
+
+    The looser forms Add session accepts (a number of days back, 'continue',
+    empty) are intentionally rejected here — the edit UI is date-only. A naive
+    value is treated as UTC downstream (see file_update_loop)."""
+    value = str(raw or "").strip()
+    if not value:
+        raise ValueError("history_since is required (e.g. 2026-05-01 or 2026-06-01 07:30, UTC)")
+    try:
+        datetime.fromisoformat(value)
+    except ValueError:
+        raise ValueError(
+            "history_since must be a UTC date like 2026-05-01 or 2026-06-01 07:30")
+    return value
+
+
 def sanitize_market_type(raw: object) -> str:
     value = str(raw or "").strip().lower()
     if value in {"spot", "linear", "inverse"}:
@@ -122,7 +142,6 @@ class SessionSpec:
     history_since: str
     script_name: str
     webhook: dict  # {"enabled": bool, "telegram_notification": bool}  (decision 8-1)
-    autostart_runner: bool = False  # start the runner automatically on hub boot
     market_type: str = ""
     manual_alert_templates: list[dict] = field(default_factory=list)
     manual_alert_triggers: list[dict] = field(default_factory=list)
@@ -155,7 +174,6 @@ class SessionSpec:
                 "telegram_token": (webhook.get("telegram_token") or ""),
                 "telegram_chat_id": (webhook.get("telegram_chat_id") or ""),
             },
-            autostart_runner=bool(d.get("autostart_runner", False)),
             market_type=sanitize_market_type(d.get("market_type")),
             manual_alert_templates=sanitize_manual_alert_templates(d.get("manual_alert_templates")),
             manual_alert_triggers=sanitize_manual_alert_triggers(d.get("manual_alert_triggers")),
@@ -181,7 +199,18 @@ class SessionSpec:
             id=self.id, provider=self.provider, exchange=self.exchange,
             symbol=self.symbol, timeframe=self.timeframe,
             history_since=self.history_since, script_name=self.script_name,
-            webhook=wh, autostart_runner=self.autostart_runner,
+            webhook=wh,
+            market_type=self.market_type,
+            manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
+            manual_alert_triggers=[dict(t) for t in self.manual_alert_triggers],
+        )
+
+    def with_history_since(self, history_since: str) -> "SessionSpec":
+        return SessionSpec(
+            id=self.id, provider=self.provider, exchange=self.exchange,
+            symbol=self.symbol, timeframe=self.timeframe,
+            history_since=history_since, script_name=self.script_name,
+            webhook=dict(self.webhook),
             market_type=self.market_type,
             manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
             manual_alert_triggers=[dict(t) for t in self.manual_alert_triggers],
@@ -192,7 +221,7 @@ class SessionSpec:
             id=self.id, provider=self.provider, exchange=self.exchange,
             symbol=self.symbol, timeframe=self.timeframe,
             history_since=self.history_since, script_name=self.script_name,
-            webhook=dict(self.webhook), autostart_runner=self.autostart_runner,
+            webhook=dict(self.webhook),
             market_type=self.market_type,
             manual_alert_templates=sanitize_manual_alert_templates(templates),
             manual_alert_triggers=[dict(t) for t in self.manual_alert_triggers],
@@ -203,7 +232,7 @@ class SessionSpec:
             id=self.id, provider=self.provider, exchange=self.exchange,
             symbol=self.symbol, timeframe=self.timeframe,
             history_since=self.history_since, script_name=self.script_name,
-            webhook=dict(self.webhook), autostart_runner=self.autostart_runner,
+            webhook=dict(self.webhook),
             market_type=self.market_type,
             manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
             manual_alert_triggers=sanitize_manual_alert_triggers(triggers),
@@ -219,7 +248,6 @@ class SessionSpec:
             "history_since": self.history_since,
             "script_name": self.script_name,
             "webhook": dict(self.webhook),
-            "autostart_runner": self.autostart_runner,
             "manual_alert_templates": [dict(t) for t in self.manual_alert_templates],
             "manual_alert_triggers": [dict(t) for t in self.manual_alert_triggers],
         }

--- a/data_service/file_update_loop.py
+++ b/data_service/file_update_loop.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
 import asyncio
-from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, UTC
 from dateutil.relativedelta import relativedelta
 from pathlib import Path
-from typing import Awaitable, Callable, Optional
+from typing import Any, Awaitable, Callable, Optional, TypeVar
 
 from config import FeedSpec
 from pynecore.cli.commands.data import parse_date_or_days
@@ -35,11 +34,26 @@ from state import DataState
 from log_utils import log_with_time
 
 
+T = TypeVar("T")
+
+
+async def _to_thread_cancel_safe(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
+    worker = asyncio.create_task(asyncio.to_thread(func, *args, **kwargs))
+    try:
+        return await asyncio.shield(worker)
+    except asyncio.CancelledError:
+        try:
+            await worker
+        except Exception:
+            pass
+        raise
+
+
 async def _retry_ohlcv_update(label: str, call: Callable[[], list | None]) -> list | None:
     delays = (1.0, 2.0, 4.0, 8.0)
     attempts = len(delays) + 1
     for attempt in range(1, attempts + 1):
-        res = await asyncio.to_thread(call)
+        res = await _to_thread_cancel_safe(call)
         if res:
             if attempt > 1:
                 log_with_time(f"[data_service] {label} succeeded on retry {attempt}/{attempts}")
@@ -60,6 +74,7 @@ async def file_update_loop(
     state: DataState,
     emit_event: Callable[[dict], Awaitable[None]],
     poll_sec: float = 0.1,
+    history_ready_event: asyncio.Event | None = None,
 ) -> None:
     provider = config.provider
     exchange = config.exchange
@@ -135,17 +150,16 @@ async def file_update_loop(
                 min_ts = get_min_ts(cache_path, provider, exchange, symbol, timeframe)
                 if min_ts is not None and desired_ts < min_ts:
                     print(f"[data_service] backfilling cache: {desired_ts} -> {min_ts}")
-                    with ThreadPoolExecutor() as ex:
-                        ok = ex.submit(
-                            download_history_range_into_cache,
-                            cache_path=cache_path,
-                            provider=provider,
-                            exchange=exchange,
-                            symbol=symbol,
-                            timeframe=timeframe,
-                            time_from=desired_dt,
-                            time_to=datetime.fromtimestamp(min_ts, UTC),
-                        ).result()
+                    ok = await _to_thread_cancel_safe(
+                        download_history_range_into_cache,
+                        cache_path=cache_path,
+                        provider=provider,
+                        exchange=exchange,
+                        symbol=symbol,
+                        timeframe=timeframe,
+                        time_from=desired_dt,
+                        time_to=datetime.fromtimestamp(min_ts, UTC),
+                    )
                     if ok:
                         print("[data_service] backfill updated cache via download_history")
                 else:
@@ -155,25 +169,25 @@ async def file_update_loop(
         # Refresh cache from last_ts (include last bar to finalize).
         last_ts = get_last_ts(cache_path, provider, exchange, symbol, timeframe)
         if last_ts is not None:
-            with ThreadPoolExecutor() as ex:
-                ok = ex.submit(
-                    download_history_range_into_cache,
-                    cache_path=cache_path,
-                    provider=provider,
-                    exchange=exchange,
-                    symbol=symbol,
-                    timeframe=timeframe,
-                    time_from=datetime.fromtimestamp(
-                        int(last_ts) - int(convert_timeframe(timeframe, to_ms=True) / 1000),
-                        UTC,
-                    ),
-                    time_to=datetime.now(UTC),
-                ).result()
+            ok = await _to_thread_cancel_safe(
+                download_history_range_into_cache,
+                cache_path=cache_path,
+                provider=provider,
+                exchange=exchange,
+                symbol=symbol,
+                timeframe=timeframe,
+                time_from=datetime.fromtimestamp(
+                    int(last_ts) - int(convert_timeframe(timeframe, to_ms=True) / 1000),
+                    UTC,
+                ),
+                time_to=datetime.now(UTC),
+            )
             if ok:
                 print("[data_service] sqlite cache updated via download_history")
         # Export cache into ohlcv for runner consumption.
         if export_start_ts is not None:
-            export_to_ohlcv_since(
+            await _to_thread_cancel_safe(
+                export_to_ohlcv_since,
                 cache_path,
                 provider,
                 exchange,
@@ -183,16 +197,27 @@ async def file_update_loop(
                 export_start_ts,
             )
         else:
-            export_to_ohlcv(cache_path, provider, exchange, symbol, timeframe, ohlcv_path)
+            await _to_thread_cancel_safe(
+                export_to_ohlcv,
+                cache_path,
+                provider,
+                exchange,
+                symbol,
+                timeframe,
+                ohlcv_path,
+            )
         if ohlcv_path.exists():
             print("[data_service] ohlcv regenerated from sqlite cache")
             history_download_complete = True
-            state.pending_prerun_event = {
-                "type": "prerun_ready_after_history_download",
-                "ohlcv_path": str(ohlcv_path),
-                "toml_path": str(toml_path),
-                "confirmed_bar_and_new_bar": None
-            }
+            async with state.lock:
+                state.pending_prerun_event = {
+                    "type": "prerun_ready_after_history_download",
+                    "ohlcv_path": str(ohlcv_path),
+                    "toml_path": str(toml_path),
+                    "confirmed_bar_and_new_bar": None,
+                }
+            if history_ready_event is not None:
+                history_ready_event.set()
     if not cache_ready:
         # No cache: start history download flow.
         print("[data_service] sqlite cache missing; starting history download")
@@ -247,15 +272,14 @@ async def file_update_loop(
                 elif history_since != "":
                     since = history_since
 
-                with ThreadPoolExecutor() as ex:
-                    ok = ex.submit(
-                        download_history,
-                        provider,
-                        exchange,
-                        symbol,
-                        timeframe,
-                        since,
-                    ).result()
+                ok = await _to_thread_cancel_safe(
+                    download_history,
+                    provider,
+                    exchange,
+                    symbol,
+                    timeframe,
+                    since,
+                )
 
                 if not ok:
                     for fp in (ohlcv_path, toml_path):
@@ -265,7 +289,15 @@ async def file_update_loop(
                 else:
                     history_download_complete = True
                     first_fetch_after_download_done = False
-                    import_from_ohlcv(cache_path, provider, exchange, symbol, timeframe, ohlcv_path)
+                    await _to_thread_cancel_safe(
+                        import_from_ohlcv,
+                        cache_path,
+                        provider,
+                        exchange,
+                        symbol,
+                        timeframe,
+                        ohlcv_path,
+                    )
                     # print("[data_service] sqlite cache populated from downloaded ohlcv")
 
                     # Store pending event instead of emitting immediately
@@ -274,8 +306,10 @@ async def file_update_loop(
                         "type": "prerun_ready_after_history_download",
                         "ohlcv_path": str(ohlcv_path),
                         "toml_path": str(toml_path),
-                        "confirmed_bar_and_new_bar": None
+                        "confirmed_bar_and_new_bar": None,
                     }
+                    if history_ready_event is not None:
+                        history_ready_event.set()
                     # print("[file_update_loop] History download complete. Event will be sent when client connects.")
 
                 fixed_open_price = 0.0
@@ -339,7 +373,7 @@ async def file_update_loop(
                         ]
                         upsert_bars(cache_path, provider, exchange, symbol, timeframe, cache_rows)
                     # Current candle open price fix if needed
-                    fixed_open_price = await asyncio.to_thread(
+                    fixed_open_price = await _to_thread_cancel_safe(
                         fix_last_open_if_needed,
                         str(ohlcv_path),
                         exchange=exchange,

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import shutil
 import traceback
+from dataclasses import replace
 from typing import Awaitable, Callable, Dict, List, Optional
 
 from config import MAX_SESSIONS, FeedSpec, SessionSpec, save_sessions
@@ -23,6 +24,10 @@ class SessionExistsError(Exception):
 
 
 class SessionNotFoundError(Exception):
+    pass
+
+
+class HistoryNotReadyError(Exception):
     pass
 
 
@@ -117,18 +122,32 @@ class SessionRegistry:
     # ------------------------------------------------------------------
     # Feed lifecycle (shared data layer)
     # ------------------------------------------------------------------
+    def _start_file_update_task(
+        self,
+        feed: Feed,
+        *,
+        history_ready_event: asyncio.Event | None = None,
+    ) -> asyncio.Task:
+        spec = feed.spec
+        history_ready_event = history_ready_event or feed.history_ready_event
+        task = asyncio.create_task(self._guard_feed(feed, "file_update_loop", file_update_loop(
+            config=spec, ohlcv_path=feed.paths.ohlcv_path, toml_path=feed.paths.toml_path,
+            state=feed.state, emit_event=feed.emit_event,
+            history_ready_event=history_ready_event,
+        )))
+        feed.tasks["file_update_loop"] = task
+        return task
+
     def _start_feed_tasks(self, feed: Feed) -> None:
         spec = feed.spec
-        feed.tasks = [
-            asyncio.create_task(self._guard_feed(feed, "watch_trades_loop", watch_trades_loop(
+        feed.tasks = {
+            "watch_trades_loop": asyncio.create_task(self._guard_feed(feed, "watch_trades_loop", watch_trades_loop(
                 spec.exchange, spec.symbol, spec.timeframe, feed.state, feed.broadcast_bar,
                 market_type=spec.market_type))),
-            asyncio.create_task(self._guard_feed(feed, "fix_missing_bars_loop", fix_missing_bars_loop(
+            "fix_missing_bars_loop": asyncio.create_task(self._guard_feed(feed, "fix_missing_bars_loop", fix_missing_bars_loop(
                 spec.exchange, spec.timeframe, feed.state))),
-            asyncio.create_task(self._guard_feed(feed, "file_update_loop", file_update_loop(
-                config=spec, ohlcv_path=feed.paths.ohlcv_path, toml_path=feed.paths.toml_path,
-                state=feed.state, emit_event=feed.emit_event))),
-        ]
+        }
+        self._start_file_update_task(feed)
 
     async def _guard_feed(self, feed: Feed, name: str, coro) -> None:
         try:
@@ -154,12 +173,44 @@ class SessionRegistry:
     async def _teardown_feed_if_idle(self, feed: Feed) -> None:
         if feed.subscribers:
             return
-        for t in feed.tasks:
+        tasks = list(feed.tasks.values())
+        for t in tasks:
             t.cancel()
-        if feed.tasks:
-            await asyncio.gather(*feed.tasks, return_exceptions=True)
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        feed.tasks.clear()
         self.feeds.pop(feed.spec.id, None)
         print(f"[registry] feed torn down (idle): {feed.spec.id}")
+
+    async def _restart_file_update(self, feed: Feed) -> None:
+        task = feed.tasks.pop("file_update_loop", None)
+        if task is not None:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        if (feed.collector_error or "").startswith("file_update_loop:"):
+            feed.collector_error = None
+        async with feed.state.lock:
+            feed.state.pending_prerun_event = None
+
+        feed.history_ready_event.clear()
+        task = self._start_file_update_task(
+            feed,
+            history_ready_event=feed.history_ready_event,
+        )
+        ready_wait = asyncio.create_task(feed.history_ready_event.wait())
+        try:
+            done, _ = await asyncio.wait(
+                {task, ready_wait},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if ready_wait not in done:
+                raise RuntimeError(feed.collector_error or "file update stopped before history was ready")
+        finally:
+            if not ready_wait.done():
+                ready_wait.cancel()
+            await asyncio.gather(ready_wait, return_exceptions=True)
+        print(f"[registry] file updater restarted: {feed.spec.id}")
 
     # ------------------------------------------------------------------
     # Session lifecycle
@@ -237,6 +288,45 @@ class SessionRegistry:
         await session.push_webhook_config()
         await self.notify_hub()
         return dict(session.spec.webhook)
+
+    async def update_history_since(self, session_id: str, history_since: str) -> None:
+        session = self.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFoundError(session_id)
+        feed = session.feed
+        # The ohlcv file is shared per feed, so every session on this market
+        # has to move to the new start together.
+        targets = list(feed.subscribers.values())
+        if all(s.spec.history_since == history_since for s in targets):
+            return
+
+        previous = [(s, s.spec) for s in targets]
+        for s in targets:
+            s.spec = s.spec.with_history_since(history_since)
+        try:
+            self._persist()
+        except Exception:
+            for s, spec in previous:
+                s.spec = spec
+            raise
+
+        # Runners must not hold the ohlcv file while file_update_loop
+        # regenerates it, and the strategies have to recompute over the new
+        # window anyway — stop them, restart only the file updater, bring them back.
+        running = [
+            s for s in targets
+            if self.supervisor.status(s.spec.id) in ("running", "starting")
+        ]
+        for s in running:
+            await self.supervisor.stop(s.spec.id)
+
+        feed.spec = replace(feed.spec, history_since=history_since)
+        await self._restart_file_update(feed)
+
+        for s in running:
+            s.history_resync_pending = True
+            await self.supervisor.start(s.spec, s.paths)
+        await self.notify_hub()
 
     async def update_manual_alert_templates(self, session_id: str, templates: list[dict]) -> list[dict]:
         session = self.sessions.get(session_id)
@@ -350,6 +440,8 @@ class SessionRegistry:
         session = self.sessions.get(session_id)
         if session is None:
             raise SessionNotFoundError(session_id)
+        if not session.feed.history_ready():
+            raise HistoryNotReadyError(session_id)
         await self.supervisor.start(session.spec, session.paths)
 
     async def stop_runner(self, session_id: str) -> None:
@@ -363,6 +455,8 @@ class SessionRegistry:
         session = self.sessions.get(session_id)
         if session is None:
             raise SessionNotFoundError(session_id)
+        if not session.feed.history_ready():
+            raise HistoryNotReadyError(session_id)
         await self.supervisor.restart(session.spec, session.paths)
 
     # ------------------------------------------------------------------
@@ -379,13 +473,6 @@ class SessionRegistry:
             self._persist()
         except Exception as e:
             print(f"[registry] initial persist failed: {e}")
-        # Autostart runners for sessions flagged autostart_runner (decision: boot restore).
-        for s in list(self.sessions.values()):
-            if s.spec.autostart_runner:
-                try:
-                    await self.start_runner(s.spec.id)
-                except Exception as e:
-                    print(f"[registry] autostart runner failed for {s.spec.id}: {e}")
 
     async def shutdown(self) -> None:
         await self.supervisor.shutdown()
@@ -395,7 +482,7 @@ class SessionRegistry:
             t.cancel()
         if logo_tasks:
             await asyncio.gather(*logo_tasks, return_exceptions=True)
-        all_tasks = [t for feed in self.feeds.values() for t in feed.tasks]
+        all_tasks = [t for feed in self.feeds.values() for t in feed.tasks.values()]
         for t in all_tasks:
             t.cancel()
         if all_tasks:

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -64,7 +64,8 @@ class Feed:
         self.spec = spec
         self.paths = FeedPaths.build(spec)
         self.state = DataState()
-        self.tasks: List[Any] = []
+        self.tasks: Dict[str, Any] = {}
+        self.history_ready_event = asyncio.Event()
         self.collector_error: Optional[str] = None
         self._history_start_mtime: Optional[float] = None
         self._history_start_time: Optional[int] = None
@@ -96,7 +97,7 @@ class Feed:
             await session.send_to_runners(payload)
 
     def history_ready(self) -> bool:
-        return self.paths.ohlcv_path.exists()
+        return self.history_ready_event.is_set()
 
     def history_start_time(self) -> Optional[int]:
         path = self.paths.ohlcv_path
@@ -134,7 +135,7 @@ class Feed:
     def collector_status(self) -> str:
         if self.collector_error:
             return "error"
-        if self.tasks and any(not t.done() for t in self.tasks):
+        if self.tasks and any(not t.done() for t in self.tasks.values()):
             return "running"
         return "stopped"
 
@@ -161,6 +162,7 @@ class Session:
         # Drives the dashboard LED: connected-but-prerunning = "starting" (amber),
         # ready = "running" (green).
         self.runner_ready = False
+        self.history_resync_pending = False
         self.chart_info: Dict[str, Any] = {
             "exchange": spec.exchange,
             "symbol": spec.symbol,
@@ -245,6 +247,9 @@ class Session:
                 async with self.feed.state.lock:
                     pending_prerun_event = self.feed.state.pending_prerun_event
                 if pending_prerun_event is not None:
+                    pending_prerun_event = dict(pending_prerun_event)
+                    if self.history_resync_pending:
+                        pending_prerun_event["history_resync"] = True
                     await ws_manager.send(ws, pending_prerun_event)
 
                 self.client_roles[ws] = role
@@ -269,6 +274,7 @@ class Session:
         elif msg_type == "runner_ready":
             # Runner finished its first pre_run -> flip the LED to green.
             self.runner_ready = True
+            self.history_resync_pending = False
             await self._notify_status()
 
         elif msg_type == "last_bar_open_fix":
@@ -396,6 +402,13 @@ class Session:
                 self.chart_info["script_source_name"] = None
                 self.chart_info["script_source"] = ""
                 await self.send_to_charts({"type": "script_modified"})
+
+        elif msg_type == "chart_reset":
+            # Data window changed (history_since edit): the runner has finished
+            # regenerating plot.csv and re-emitting markers, so tell chart pages to
+            # drop stale series and reload from the fresh files. Caches were already
+            # cleared via the reset_history above.
+            await self.send_to_charts({"type": "chart_reset"})
 
         elif msg_type == "ack_prerun_ready_after_history_download":
             # No-op: with a shared feed the pending event must reach every session's

--- a/data_service/templates/chart.js
+++ b/data_service/templates/chart.js
@@ -876,6 +876,9 @@ App.chart = {
     const collections = App.collections;
     state.initialLoadDone = false;
     state.initialLoadInProgress = false;
+    // invalidate any loadInitialWithRetry still in flight so it won't append to
+    // (or race with) the reload that typically follows this reset
+    state.loadGeneration++;
     if (resetCandles) {
       this.candleSeries.setData([]);
       this.volumeSeries.setData([]);

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -141,13 +141,13 @@ body {
   border-radius: 6px;
   min-width: 150px;
 }
-.add-form input:not([type="checkbox"]):focus,
+.add-form input:focus,
 .add-form select:focus,
 .script-select-button:focus { outline: none; border-color: var(--accent); }
 .field-error { color: var(--danger); font-size: 12px; min-height: 12px; margin-top: 2px; }
 .field-error.checking { color: var(--muted); }
 .field-error.warn { color: #e0a300; }
-/* script_name select + autostart grouped together */
+/* script selector and refresh action */
 .script-row { display: flex; align-items: center; gap: 8px; flex-wrap: nowrap; }
 .script-select {
   position: relative;
@@ -255,15 +255,6 @@ body {
   font-size: 13px;
 }
 #script-refresh { flex: 0 0 auto; }
-.autostart-label { display: inline-flex; align-items: center; gap: 6px; color: var(--muted); font-size: 13px; white-space: nowrap; }
-.autostart-label input[type="checkbox"] {
-  flex: 0 0 auto;
-  width: 13px;
-  height: 13px;
-  min-width: 0;
-  margin: 0;
-  padding: 0;
-}
 
 .btn {
   background: #21262d;
@@ -275,6 +266,7 @@ body {
   font-size: 13px;
 }
 .btn:hover { border-color: var(--accent); }
+.btn:disabled { cursor: not-allowed; opacity: 0.45; }
 .btn-primary { background: var(--accent); border-color: var(--accent); color: #fff; }
 .btn-danger { color: var(--danger); border-color: transparent; }
 .btn-danger:hover { border-color: var(--danger); }
@@ -419,6 +411,14 @@ tr:last-child td { border-bottom: none; }
 .data-badge {
   cursor: help;
 }
+/* badge + pencil (+ transient "loading") ride together as one group so the
+   surrounding cell layout can't spread them apart — notably the mobile card
+   layout, where the Data cell is a space-between flex row */
+.data-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
 .data-since-popover {
   position: absolute;
   z-index: 20;
@@ -533,7 +533,18 @@ tr:last-child td { border-bottom: none; }
 
 /* webhook/telegram cell: checkbox + gear button */
 .cell-inline { display: inline-flex; align-items: center; gap: 8px; }
-.btn-icon { padding: 4px 9px; line-height: 1; }
+/* icon buttons (data-edit pencil, webhook/telegram gears, remove ×) are a fixed
+   square so all three render at identical width and height, regardless of their
+   glyph vs SVG content */
+.btn-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  line-height: 1;
+}
 .btn-icon .icon {
   display: block;
   width: 16px;
@@ -543,6 +554,13 @@ tr:last-child td { border-bottom: none; }
   stroke-width: 2;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+/* match the webhook/telegram gear buttons: same .btn-icon padding, and the
+   13px icon lines up with their 13px ⚙ glyph (must come after .btn-icon .icon
+   or the 16px default wins the cascade) */
+.data-edit-btn .icon {
+  width: 13px;
+  height: 13px;
 }
 #script-refresh.btn-icon {
   display: inline-flex;
@@ -562,6 +580,26 @@ tr:last-child td { border-bottom: none; }
 }
 .settings-body input:focus { outline: none; border-color: var(--accent); }
 .settings-label { color: var(--muted); font-size: 12px; margin-top: 4px; }
+.settings-body input:disabled { opacity: 0.55; cursor: not-allowed; }
+.settings-loading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 6px;
+  color: var(--muted);
+  font-size: 13px;
+}
+.settings-loading[hidden] { display: none; }
+.settings-spinner {
+  width: 14px;
+  height: 14px;
+  border: 2px solid var(--border);
+  border-top-color: var(--accent);
+  border-radius: 50%;
+  animation: settings-spin 0.7s linear infinite;
+  flex: none;
+}
+@keyframes settings-spin { to { transform: rotate(360deg); } }
 .settings-footer {
   padding: 12px 14px; border-top: 1px solid var(--border);
   display: flex; justify-content: flex-end;
@@ -1038,16 +1076,14 @@ tr:last-child td { border-bottom: none; }
 
   .add-form { flex-direction: column; align-items: stretch; }
   .add-form .field,
-  .add-form input:not([type="checkbox"]),
+  .add-form input,
   .add-form select,
   .add-form .script-select,
-  .add-form .btn,
-  .add-form .autostart-label { width: 100%; min-width: 0; }
+  .add-form .btn { width: 100%; min-width: 0; }
   .script-row { flex-wrap: wrap; }
   .script-row .script-select { flex: 1 1 calc(100% - 50px); }
   .script-select-button { min-width: 0; }
   #script-refresh { width: auto; min-width: 42px; }
-  .add-form .autostart-label input[type="checkbox"] { width: 18px; min-width: 18px; }
 
   table thead { display: none; }
   table { display: block; width: 100%; }
@@ -1119,6 +1155,18 @@ tr:last-child td { border-bottom: none; }
   }
   /* bigger touch targets on mobile */
   .btn { padding: 8px 12px; }
+  /* re-assert the square (this block's .btn padding would otherwise distort the
+     icon buttons) and enlarge them to a comfortable touch size */
+  .btn-icon { width: 34px; height: 34px; padding: 0; }
+  /* uniform width for the Chart "Open" link and runner Start/Stop/Restart/Logs
+     buttons — mobile only. On desktop the runner column is a fixed 190px and a
+     forced per-button min-width would overflow it in the running state and
+     shake the column, so this stays scoped to the mobile card layout. */
+  .btn-chart,
+  .runner-actions .btn {
+    min-width: 72px;
+    text-align: center;
+  }
   input[type="checkbox"] { width: 18px; height: 18px; }
 
   @media (hover: hover) and (pointer: fine) {

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -18,6 +18,43 @@ body {
   font-size: 14px;
 }
 
+@media (hover: hover) and (pointer: fine) {
+  html,
+  body,
+  .log-content {
+    scrollbar-color: #3a4350 #0b0e13;
+    scrollbar-width: thin;
+  }
+  html::-webkit-scrollbar,
+  body::-webkit-scrollbar,
+  .log-content::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  html::-webkit-scrollbar-track,
+  body::-webkit-scrollbar-track,
+  .log-content::-webkit-scrollbar-track {
+    background: #0b0e13;
+  }
+  html::-webkit-scrollbar-thumb,
+  body::-webkit-scrollbar-thumb,
+  .log-content::-webkit-scrollbar-thumb {
+    background: #3a4350;
+    border: 2px solid #0b0e13;
+    border-radius: 999px;
+  }
+  html::-webkit-scrollbar-thumb:hover,
+  body::-webkit-scrollbar-thumb:hover,
+  .log-content::-webkit-scrollbar-thumb:hover {
+    background: #4a5565;
+  }
+  html::-webkit-scrollbar-corner,
+  body::-webkit-scrollbar-corner,
+  .log-content::-webkit-scrollbar-corner {
+    background: #0b0e13;
+  }
+}
+
 .topbar {
   position: relative;
   display: flex;

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=23" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=24" />
 </head>
 <body>
   <header class="topbar">

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=13" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=23" />
 </head>
 <body>
   <header class="topbar">
@@ -57,7 +57,6 @@
               <path d="M3 21v-5h5" />
             </svg>
           </button>
-          <label class="autostart-label"><input type="checkbox" name="autostart_runner" /> autostart runner</label>
         </div>
       </div>
       <button type="submit" class="btn btn-primary">Add</button>
@@ -209,6 +208,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=22"></script>
+  <script src="/static/dashboard.js?v=28"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -88,6 +88,14 @@
       `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}:${pad(d.getUTCSeconds())} UTC`;
   }
 
+  // "YYYY-MM-DD HH:MM" in UTC — the editable form the data-since input expects
+  function formatUtcInput(epochSec) {
+    const d = new Date(epochSec * 1000);
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${d.getUTCFullYear()}-${pad(d.getUTCMonth() + 1)}-${pad(d.getUTCDate())} ` +
+      `${pad(d.getUTCHours())}:${pad(d.getUTCMinutes())}`;
+  }
+
   function parseDateAsUtc(raw) {
     const value = String(raw || "").trim();
     if (!value) return null;
@@ -96,6 +104,15 @@
     const normalized = hasZone ? iso : (iso.length <= 10 ? `${iso}T00:00:00Z` : `${iso}Z`);
     const d = new Date(normalized);
     return Number.isNaN(d.getTime()) ? null : d;
+  }
+
+  function isSameUtcDateInput(left, right) {
+    const a = String(left || "").trim();
+    const b = String(right || "").trim();
+    if (a === b) return true;
+    const da = parseDateAsUtc(a);
+    const db = parseDateAsUtc(b);
+    return !!da && !!db && da.getTime() === db.getTime();
   }
 
   function historySinceText(s) {
@@ -149,11 +166,12 @@
 
   function runnerButtons(s) {
     const r = s.runner || "stopped";
+    const dataReady = !!s.history_ready;
     if (r === "running" || r === "starting") {
       return `<button class="btn" data-runner="stop">Stop</button>` +
-             `<button class="btn" data-runner="restart">Restart</button>`;
+             `<button class="btn" data-runner="restart"${dataReady ? "" : " disabled"}>Restart</button>`;
     }
-    return `<button class="btn btn-primary" data-runner="start">Start</button>`;
+    return `<button class="btn btn-primary" data-runner="start"${dataReady ? "" : " disabled"}>Start</button>`;
   }
 
   function esc(s) {
@@ -341,12 +359,20 @@
       `<td data-label="TF" data-field="timeframe"></td>` +
       `<td data-label="Exchange"><span data-field="exchange-cell" class="exchange-cell"></span></td>` +
       `<td data-label="Script" class="mono" data-field="script-name"></td>` +
-      `<td data-label="Data" class="data-cell"><span class="data-badge-wrap">` +
-        `<span data-field="collector-badge" class="badge data-badge" ` +
-        `data-act="data-since"></span>` +
-        `<span data-field="data-since-popover" class="data-since-popover"></span></span>` +
-        ` <span data-field="history-loading" class="muted">loading</span>` +
-        `</td>` +
+      `<td data-label="Data" class="data-cell"><span class="data-controls">` +
+        `<span class="data-badge-wrap">` +
+          `<span data-field="collector-badge" class="badge data-badge" ` +
+          `data-act="data-since"></span>` +
+          `<span data-field="data-since-popover" class="data-since-popover"></span></span>` +
+        `<button class="btn btn-icon data-edit-btn" data-act="data-edit" ` +
+        `title="Edit data start" aria-label="Edit data start">` +
+          `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">` +
+            `<path d="M12 20h9"></path>` +
+            `<path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"></path>` +
+          `</svg>` +
+        `</button>` +
+        `<span data-field="history-loading" class="muted">loading</span>` +
+        `</span></td>` +
       `<td data-label="Last bar" class="muted">${lastBarCell({})}</td>` +
       `<td data-label="Webhook"><span class="cell-inline">` +
         `<input type="checkbox" data-act="webhook">` +
@@ -356,7 +382,7 @@
         `<button class="btn btn-icon" data-act="telegram-settings" title="Telegram bot">&#9881;</button></span></td>` +
       `<td data-label="Runner" class="runner-cell" data-field="runner-cell"></td>` +
       `<td data-label="Chart"><a data-field="chart-link" class="btn btn-chart" target="_blank">Open</a></td>` +
-      `<td data-label="Remove"><button class="btn btn-danger" data-act="delete" title="Delete session">&times;</button></td>`;
+      `<td data-label="Remove"><button class="btn btn-danger btn-icon" data-act="delete" title="Delete session">&times;</button></td>`;
 
     tr.addEventListener("change", (e) => {
       const target = e.target;
@@ -387,7 +413,8 @@
           e.stopPropagation();
           toggleDataSinceTooltip(tr);
         }
-      } else if (act === "delete") openRemoveConfirm(id);
+      } else if (act === "data-edit") openSettings(id, "data-since");
+      else if (act === "delete") openRemoveConfirm(id);
       else if (act === "logs") openLogs(id);
       else if (act === "webhook-settings") openSettings(id, "webhook");
       else if (act === "telegram-settings") openSettings(id, "telegram");
@@ -398,6 +425,7 @@
   function patchSessionRow(tr, s) {
     const id = sessionId(s);
     const runner = s.runner || "stopped";
+    const runnerControlsKey = `${runner}:${s.history_ready ? "ready" : "preparing"}`;
     const collector = s.collector || "stopped";
     const wh = s.webhook || {};
     const exchange = (s.exchange || "").toUpperCase();
@@ -446,12 +474,12 @@
     setChecked(tr.querySelector('[data-act="webhook"]'), !!wh.enabled);
     setChecked(tr.querySelector('[data-act="telegram"]'), !!wh.telegram_notification);
 
-    if (tr.dataset.runnerControlsKey !== runner) {
+    if (tr.dataset.runnerControlsKey !== runnerControlsKey) {
       setHTML(
         tr.querySelector('[data-field="runner-cell"]'),
         `<span class="runner-actions">${runnerButtons(s)}<button class="btn" data-act="logs">Logs</button></span>`,
       );
-      tr.dataset.runnerControlsKey = runner;
+      tr.dataset.runnerControlsKey = runnerControlsKey;
     }
 
     const chart = tr.querySelector('[data-field="chart-link"]');
@@ -1750,9 +1778,6 @@
       const val = String(v).trim();
       if (val !== "") payload[k] = val;
     });
-    // Checkbox -> real boolean (absent from FormData when unchecked).
-    const autostartEl = e.target.querySelector('[name="autostart_runner"]');
-    payload.autostart_runner = !!(autostartEl && autostartEl.checked);
     if (payload.symbol) payload.symbol = payload.symbol.toUpperCase();
     // Block Add when exchange/symbol are confirmed invalid.
     const exOk = await checkExchange();
@@ -1993,16 +2018,51 @@
   // ---- per-session webhook/telegram settings modal ------------------------
   let settingsSession = null;
   let settingsMode = null; // "webhook" | "telegram"
+  let settingsOriginalHistorySince = null;
 
   async function openSettings(id, mode) {
     settingsSession = id;
     settingsMode = mode;
+    settingsOriginalHistorySince = null;
     el("settings-error").textContent = "";
     el("settings-title").textContent =
-      (mode === "webhook" ? "Webhook URL — " : "Telegram bot — ") + id;
+      (mode === "webhook" ? "Webhook URL — "
+        : mode === "telegram" ? "Telegram bot — "
+        : "Data since — ") + id;
     el("settings-fields").innerHTML = "loading…";
     el("settings-modal").classList.remove("hidden");
     lockBodyScroll();
+    if (mode === "data-since") {
+      const s = sessions.find((x) => sessionId(x) === id) || {};
+      const shared = sessions
+        .filter((x) => x.feed_id && x.feed_id === s.feed_id && sessionId(x) !== id)
+        .map((x) => sessionId(x));
+      // prefill with the current effective UTC start (from the ohlcv file); fall
+      // back to the raw history_since only if it is itself a date
+      const since = Number(s.data_since_time);
+      let initial = "";
+      if (Number.isFinite(since) && since > 0) {
+        initial = formatUtcInput(since);
+      } else if (parseDateAsUtc(s.history_since)) {
+        initial = String(s.history_since);
+      }
+      settingsOriginalHistorySince = initial;
+      el("settings-fields").innerHTML =
+        `<label class="settings-label">Data start (UTC)</label>` +
+        `<input id="settings-history-since" type="text" ` +
+        `placeholder="YYYY-MM-DD or YYYY-MM-DD HH:MM" value="${esc(initial)}">` +
+        `<div class="muted">UTC date or datetime, e.g. 2026-05-01 or 2026-06-01 07:30.</div>` +
+        `<div class="muted">Saving re-syncs market data and restarts the running strategy.</div>` +
+        (shared.length
+          ? `<div class="muted">Shares this market's data, so it changes too: ` +
+            `<span class="mono">${esc(shared.join(", "))}</span></div>`
+          : "") +
+        `<div id="settings-loading" class="settings-loading" hidden>` +
+          `<span class="settings-spinner" aria-hidden="true"></span>` +
+          `<span class="settings-loading-text">Re-syncing data…</span>` +
+        `</div>`;
+      return;
+    }
     try {
       const cfg = await api(`/api/${encodeURIComponent(id)}/webhook-config`);
       if (mode === "webhook") {
@@ -2027,12 +2087,54 @@
     if (el("settings-modal").classList.contains("hidden")) return;
     el("settings-modal").classList.add("hidden");
     unlockBodyScroll();
+    const saveBtn = el("settings-save");
+    if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = "Save"; }
     settingsSession = null;
     settingsMode = null;
+    settingsOriginalHistorySince = null;
+  }
+
+  function setDataSinceLoading(on) {
+    const saveBtn = el("settings-save");
+    const inputEl = el("settings-history-since");
+    const status = el("settings-loading");
+    if (saveBtn) {
+      saveBtn.disabled = on;
+      saveBtn.textContent = on ? "Applying…" : "Save";
+    }
+    if (inputEl) inputEl.disabled = on;
+    if (status) status.hidden = !on;
   }
 
   async function saveSettings() {
     if (!settingsSession) return;
+    if (settingsMode === "data-since") {
+      const inputEl = el("settings-history-since");
+      const value = (inputEl ? inputEl.value : "").trim();
+      const sid = settingsSession;
+      if (isSameUtcDateInput(value, settingsOriginalHistorySince)) {
+        closeSettings();
+        return;
+      }
+      el("settings-error").textContent = "";
+      setDataSinceLoading(true); // feed + runner restart takes a moment; no double-submit
+      try {
+        await api(`/api/sessions/${encodeURIComponent(sid)}/history-since`, {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ history_since: value }),
+        });
+      } catch (e) {
+        el("settings-error").textContent = e.message;
+        setDataSinceLoading(false);
+        return;
+      }
+      if (settingsSession === sid && settingsMode === "data-since") {
+        setDataSinceLoading(false);
+        closeSettings();
+      }
+      return;
+    }
     const payload = {};
     if (settingsMode === "webhook") {
       const urlEl = el("settings-url");

--- a/data_service/templates/data.js
+++ b/data_service/templates/data.js
@@ -181,21 +181,22 @@ App.data = {
     controller.activeSeries.update(linePoint);
     controller.lastHadValue = true;
   },
-  async loadTradeHistory() {
+  async loadTradeHistory(generation = App.state.loadGeneration) {
     const state = App.state;
     const collections = App.collections;
     const chart = App.chart;
-    if (!state.runnerConnected) return;
+    if (!state.runnerConnected || generation !== state.loadGeneration) return;
     try {
+      const resp = await fetch(`${App.config.apiBase}/trades`);
+      const trades = await resp.json();
+      if (generation !== state.loadGeneration) return;
+
       collections.markers.length = 0;
       collections.markerKeys.clear();
       collections.entryMarkerData.length = 0;
       collections.closeMarkerData.length = 0;
       collections.entryPriceKeys.clear();
       collections.closePriceKeys.clear();
-
-      const resp = await fetch(`${App.config.apiBase}/trades`);
-      const trades = await resp.json();
 
       trades.forEach(msg => {
         if (state.firstBarTime !== null && msg.time < state.firstBarTime) {
@@ -261,17 +262,18 @@ App.data = {
       console.error("Failed to load trade history:", e);
     }
   },
-  async loadPlotcharHistory() {
+  async loadPlotcharHistory(generation = App.state.loadGeneration) {
     const state = App.state;
     const collections = App.collections;
     const chart = App.chart;
-    if (!state.runnerConnected) return;
+    if (!state.runnerConnected || generation !== state.loadGeneration) return;
     try {
-      collections.plotcharMarkers.length = 0;
-      collections.plotcharMarkerKeys.clear();
-
       const resp = await fetch(`${App.config.apiBase}/plotchar`);
       const plotchars = await resp.json();
+      if (generation !== state.loadGeneration) return;
+
+      collections.plotcharMarkers.length = 0;
+      collections.plotcharMarkerKeys.clear();
 
       plotchars.forEach(msg => {
         if (state.firstBarTime !== null && msg.time < state.firstBarTime) {
@@ -309,15 +311,17 @@ App.data = {
       console.error("Failed to load plotchar history:", e);
     }
   },
-  async loadPlotData() {
+  async loadPlotData(generation = App.state.loadGeneration) {
     const state = App.state;
     const collections = App.collections;
     const chart = App.chart;
-    if (!state.runnerConnected) return;
+    if (!state.runnerConnected || generation !== state.loadGeneration) return;
     for (let i = 0; i < 30; i++) {
+      if (generation !== state.loadGeneration) return;
       try {
         const resp = await fetch(`${App.config.apiBase}/plot?limit=100000`);
         const plots = await resp.json();
+        if (generation !== state.loadGeneration) return;
 
         if (Array.isArray(plots) && plots.length > 0) {
           const pendingSeriesData = [];
@@ -354,10 +358,19 @@ App.data = {
       return;
     }
     state.initialLoadInProgress = true;
+    // snapshot the generation; a resetChartState (e.g. chart_reset) bumps it and
+    // this loop bails so only the newest loader touches the chart
+    const gen = state.loadGeneration;
     for (let i = 0; i < 30; i++) {
+      if (gen !== state.loadGeneration) {
+        return;
+      }
       try {
         const resp = await fetch(`${App.config.apiBase}/ohlcv?limit=100000`);
         const data = await resp.json();
+        if (gen !== state.loadGeneration) {
+          return;
+        }
         if (Array.isArray(data) && data.length > 0) {
           const cleanData = data.filter(d => d && d.time != null && d.open != null && d.high != null &&
             d.low != null && d.close != null);
@@ -414,9 +427,17 @@ App.data = {
             state.lastOhlcv = data[data.length - 1];
           }
 
-          await this.loadTradeHistory();
-          await this.loadPlotcharHistory();
-          await this.loadPlotData();
+          if (gen !== state.loadGeneration) {
+            return;
+          }
+          await this.loadTradeHistory(gen);
+          if (gen !== state.loadGeneration) return;
+          await this.loadPlotcharHistory(gen);
+          if (gen !== state.loadGeneration) return;
+          await this.loadPlotData(gen);
+          if (gen !== state.loadGeneration) {
+            return;
+          }
           if (App.ui && App.ui.applyManualAlertTriggerState) {
             App.ui.applyManualAlertTriggerState(App.state.manualAlertTriggers || []);
           }

--- a/data_service/templates/index.html
+++ b/data_service/templates/index.html
@@ -152,12 +152,12 @@
     </div>
   </section>
   <!--RUNTIME_CONFIG-->
-  <script src="/static/state.js"></script>
+  <script src="/static/state.js?v=2"></script>
   <script src="/static/ui.js"></script>
-  <script src="/static/chart.js"></script>
+  <script src="/static/chart.js?v=2"></script>
   <script src="/static/measure.js"></script>
-  <script src="/static/data.js"></script>
-  <script src="/static/ws.js"></script>
+  <script src="/static/data.js?v=2"></script>
+  <script src="/static/ws.js?v=2"></script>
   <script src="/static/main.js"></script>
 </body>
 </html>

--- a/data_service/templates/state.js
+++ b/data_service/templates/state.js
@@ -19,6 +19,10 @@ window.App.state = {
   runnerConnected: false,
   initialLoadInProgress: false,
   initialLoadDone: false,
+  // bumped by resetChartState so an in-flight loadInitialWithRetry started
+  // before a reset bails out instead of racing the fresh reload (which would
+  // otherwise duplicate plot series or draw stale data)
+  loadGeneration: 0,
   firstBarTime: null,
   timeframeInterval: 60,
   // Timeframe from /api/info (seconds). Source of truth for the countdown:

--- a/data_service/templates/ws.js
+++ b/data_service/templates/ws.js
@@ -25,6 +25,11 @@ App.ws = {
           }
           chart.resetChartState(false);
           App.data.loadInitialWithRetry();
+        } else if (msg.type === "chart_reset") {
+          // data window changed (history_since edit): drop stale series and
+          // reload the freshly regenerated ohlcv/plot/markers
+          chart.resetChartState(false);
+          App.data.loadInitialWithRetry();
         } else if (msg.type === "runner_disconnected") {
           state.runnerConnected = false;
           chart.resetChartState(false);

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -40,6 +40,7 @@ TELEGRAM_ENABLED: bool = False
 WEBHOOK_URL: str = ""
 TELEGRAM_TOKEN: str = ""
 TELEGRAM_CHAT_ID: str = ""
+SUPPRESS_EXTERNAL_NOTIFICATIONS: bool = False
 DEFAULT_WEBHOOK_REQUEST_TIMEOUT = (5, 10)
 HYPERLIQUID_WEBHOOK_REQUEST_TIMEOUT = (5, 30)
 TELEGRAM_REQUEST_TIMEOUT = (5, 10)
@@ -270,6 +271,8 @@ def on_plotchar_event(plotchar_data):
 
 def on_alert_event(message: str, runner: ScriptRunner):
     """Callback for alert events - webhook/telegram notifications"""
+    if SUPPRESS_EXTERNAL_NOTIFICATIONS:
+        return
     script = runner.script
 
     # Per-session overrides (from the hub's webhook_config WS message) take
@@ -302,6 +305,8 @@ def on_alert_event(message: str, runner: ScriptRunner):
 
 def on_ai_event(instruction: str, order, bar_time: int, runner: ScriptRunner):
     """Queue one deterministic AI instruction event for a realtime order fill."""
+    if SUPPRESS_EXTERNAL_NOTIFICATIONS:
+        return
     instruction = str(instruction or "").strip()
     if not instruction or getattr(runner.script, "pre_run", False):
         return
@@ -643,6 +648,7 @@ async def main():
 
     global SCRIPT_PATH, SCRIPT_HASH_PATH, DATA_WS, PLOT_PATH, SESSION_ID
     global WEBHOOK_ENABLED, TELEGRAM_ENABLED, WEBHOOK_URL, TELEGRAM_TOKEN, TELEGRAM_CHAT_ID
+    global SUPPRESS_EXTERNAL_NOTIFICATIONS
     SCRIPT_PATH = script_path
     SESSION_ID = _resolve(args.session_id, "PYNEREAL_SESSION_ID", None, default="default")
 
@@ -751,8 +757,17 @@ async def main():
                     await ws.send(json.dumps({"type": "script_modified"}))
                     clear_local_state()
                     write_script_hashes(SCRIPT_HASH_PATH, current_hashes)
+                elif (
+                    mtype == "prerun_ready_after_history_download"
+                    and msg.get("history_resync")
+                ):
+                    # The data window changed with an unchanged script. Drop the
+                    # hub's cached markers so this full replay rebuilds only the
+                    # markers inside the new window.
+                    await ws.send(json.dumps({"type": "reset_history"}))
+                    clear_local_state()
             except Exception as e:
-                print(f"[runner] Failed to send script_modified (prerun): {e}")
+                print(f"[runner] Failed to prepare chart refresh (prerun): {e}")
 
             # Ready runner + stream
             result = ready_scrip_runner(script_path, ohlcv_path, toml_path)
@@ -790,8 +805,26 @@ async def main():
                 # markers. prerun_range stays size-1: the last open bar is still left for
                 # run_ready, so no spurious last-bar alert fires (its fill bar isn't stepped).
                 runner.script.pre_run = False
-            await asyncio.to_thread(run_prerun_steps, runner, prerun_range)
+            SUPPRESS_EXTERNAL_NOTIFICATIONS = bool(
+                mtype == "prerun_ready_after_history_download"
+                and msg.get("history_resync")
+            )
+            try:
+                await asyncio.to_thread(run_prerun_steps, runner, prerun_range)
+            finally:
+                SUPPRESS_EXTERNAL_NOTIFICATIONS = False
             pending_full_reemit = False
+
+            # The re-sync plot.csv and historical markers are complete. Reload chart
+            # pages now so an earlier runner-connected reload cannot leave stale data.
+            if (
+                mtype == "prerun_ready_after_history_download"
+                and msg.get("history_resync")
+            ):
+                try:
+                    await ws.send(json.dumps({"type": "chart_reset"}))
+                except Exception as e:
+                    print(f"[runner] Failed to send chart_reset: {e}")
 
             # First pre_run done -> tell the hub the chart plots are ready (LED green).
             if not ready_sent:


### PR DESCRIPTION
## 주요 변경사항

- 대시보드 Data 열에서 세션의 데이터 시작 시점(history_since)을 변경할 수 있도록 추가
- UTC 날짜 및 시간 입력을 검증하고, 같은 feed를 공유하는 모든 세션에 변경값을 함께 적용
- Save 실행 후에만 re-sync 진행 상태를 표시하고 완료 후 설정 모달을 닫도록 개선
- 동일한 시작 시점을 다시 저장하는 경우 불필요한 re-sync 없이 모달 종료
- re-sync 전에 실행 중인 Runner를 정지하고 OHLCV 파일 갱신이 완료된 후 다시 시작
- 기존 파일 작업이 끝난 뒤 새 파일 갱신 작업을 시작하도록 취소 및 재시작 순서 보장
- 데이터 준비가 완료되기 전에는 Runner Start 및 Restart를 제한
- 변경된 데이터 범위 전체를 pre-run으로 다시 계산하고 차트 데이터와 전략 마커를 재구성
- re-sync 재계산 중 Webhook, Telegram, AI 지시 전송을 억제
- 차트 재로딩 시 이전 비동기 응답이 새 차트 상태를 덮어쓰지 않도록 generation 검증 추가
- 사용 빈도가 낮은 Runner autostart 설정 제거
- 데스크톱 대시보드 세션 목록과 Logs 영역의 스크롤바 스타일 통일

## 동작 방식

- 같은 거래소, 심볼, 타임프레임 데이터를 공유하는 세션은 동일한 시작 시점으로 함께 변경됩니다.
- re-sync 전 실행 중이던 Runner만 완료 후 자동으로 다시 시작됩니다.
- 정지 상태였던 Runner는 re-sync 후에도 정지 상태를 유지합니다.
- re-sync 중 과거 전략 계산에서 발생하는 외부 알림은 전송하지 않으며, 완료 후 일반 실시간 알림 동작으로 복귀합니다.