### PR TITLE
세션 일정 캘린더와 AI 이벤트 전망 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ workdir/config/providers.toml
 # Ignore runtime session state and per-session output (hub)
 workdir/config/sessions.json
 workdir/config/ai_chat.json
+workdir/config/calendar_events.json
 workdir/output/realtime/
 
 # Ignore SQLite cache files but keep the directory

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The AI copilot can:
 - inspect exchange assets and derivative positions — every configured account
   at once when you don't name one;
 - set or remove persisted Manual Alert price triggers straight from chat;
+- research and maintain a shared calendar for every active trading session;
 - analyze repository files, running sessions, and public market information;
 - send a finished result to Telegram when you ask for it.
 
@@ -338,6 +339,19 @@ values:
 {"signal":"CLOSE TP3","ticker":"{{ticker}}","timeframe":"{{timeframe}}"}
 ```
 
+## Session Calendar
+
+Open the Hub menu beside the PyneReal Hub title and select **Calendar**. The
+monthly view marks dates that have schedules for active sessions; select a date
+to see the related symbol, title, details, time, and source.
+
+Calendar events are stored by data-service and shared across desktop and mobile
+browsers. Ask Dashboard AI to check or refresh schedules to populate it. A
+request without a named session covers every active session and defaults to the
+next 90 days. The AI uses SaveTicker calendar titles as discovery leads, searches
+the web when no matching title exists, and stores only events whose dates and
+details can be supported by a public source.
+
 ## AI Setup & Details
 
 PyneReal currently integrates OpenAI Codex through a local Codex app-server and
@@ -358,6 +372,8 @@ Dashboard AI can:
   information;
 - set or remove persisted Manual Alert price triggers, including adding a
   missing template when its title and JSON message are explicitly supplied;
+- research verified schedules for active sessions and persist them in the
+  shared Hub calendar;
 - send a completed result to the fixed Telegram destination when explicitly
   requested; and
 - edit existing files only under `workdir/`, `modules/`, and

--- a/README.md
+++ b/README.md
@@ -345,6 +345,12 @@ Open the Hub menu beside the PyneReal Hub title and select **Calendar**. The
 monthly view marks dates that have schedules for active sessions; select a date
 to see the related symbol, title, details, time, and source.
 
+Each event card includes a Pepe forecast control. Select it to run a read-only
+AI outlook for that event without opening or modifying the main chat. Pepe's
+eyes move while the analysis is running and the face shakes when a new result
+is ready. Select the face again to open the Markdown response, or use the
+refresh control in the response bubble to run a new outlook.
+
 Calendar events are stored by data-service and shared across desktop and mobile
 browsers. Ask Dashboard AI to check or refresh schedules to populate it. A
 request without a named session covers every active session and defaults to the

--- a/ai/INSTRUCTIONS.md
+++ b/ai/INSTRUCTIONS.md
@@ -109,6 +109,26 @@ internals when an existing script already provides the required data.
 - Setting a trigger does not send an alert immediately. The existing data
   service fires and removes it when market price touches the persisted line.
 
+## Session Calendar
+
+- For every calendar or schedule request, call `get_calendar_context` first.
+- Resolve company, asset, symbol, exchange, timeframe, or strategy descriptions
+  to active sessions yourself. Never ask the user to provide a session ID.
+- If the user asks to check schedules without naming a target, research every
+  active session. Unless a period is specified, use today through 90 days ahead.
+- Start with `https://www.saveticker.com/calendar` as a discovery source. A
+  logged-out title is only a lead: verify the date and details through public web
+  search or an authoritative company IR, filing, exchange, or economic-calendar
+  source before saving it.
+- If SaveTicker has no relevant event for a session, search the web directly.
+- Never invent an event, date, time, or source. Omit uncertain events and state
+  uncertainty in the chat response when it matters.
+- Save researched results with `replace_calendar_events`. Include an empty
+  `events` array for a researched session with no relevant event so stale entries
+  in that date range are removed. Events outside the requested range are kept.
+- Calendar changes are allowed only when the user asks to check, refresh, add,
+  update, or remove schedules. Report success only from the tool result.
+
 ## Script Contract
 
 - Put reusable Python tools in `ai/scripts/`.

--- a/ai/INSTRUCTIONS.md
+++ b/ai/INSTRUCTIONS.md
@@ -128,6 +128,10 @@ internals when an existing script already provides the required data.
   in that date range are removed. Events outside the requested range are kept.
 - Calendar changes are allowed only when the user asks to check, refresh, add,
   update, or remove schedules. Report success only from the tool result.
+- A calendar-card event forecast is read-only analysis for the exact persisted
+  event and session supplied by data-service. Research current public sources,
+  distinguish facts from inference, and assess scenarios and symbol impact.
+  Do not call calendar mutation tools or change account, strategy, or file state.
 
 ## Script Contract
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -65,6 +65,11 @@ filing, exchange, or economic-calendar sources and records the supporting URL
 with every event. A general schedule request covers all active sessions and uses
 today through 90 days ahead unless the user specifies another range.
 
+Calendar event cards can start isolated read-only forecast turns. These turns
+use the shared dashboard model and effort selection but do not append messages
+to the main chat. Completed Markdown answers are persisted by event ID and
+removed automatically when the associated event no longer exists.
+
 ## Strategy Instructions
 
 Realtime `strategy.entry` and `strategy.close` orders can provide an `ai`

--- a/ai/README.md
+++ b/ai/README.md
@@ -52,6 +52,19 @@ message format are persisted as a new session template together with the price
 trigger. A combined "delete all in this session, then set this trigger" request
 uses the setting tool's atomic replacement option.
 
+## Session Calendar
+
+Dashboard Codex threads use `get_calendar_context` to resolve natural-language
+symbols and company names to active sessions. `replace_calendar_events` then
+replaces only the researched date range for those sessions and broadcasts the
+new state to every open dashboard.
+
+SaveTicker calendar titles are discovery leads rather than sufficient evidence.
+The AI verifies dates and details through public search or authoritative company,
+filing, exchange, or economic-calendar sources and records the supporting URL
+with every event. A general schedule request covers all active sessions and uses
+today through 90 days ahead unless the user specifies another range.
+
 ## Strategy Instructions
 
 Realtime `strategy.entry` and `strategy.close` orders can provide an `ai`

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -67,8 +67,9 @@ DEFAULT_DEVELOPER_INSTRUCTIONS = (
     "In the final response, do not list the procedure; present the lookup result immediately. "
     "Only when the user explicitly asks to send the result to Telegram, complete the lookup and "
     "then call send_telegram_message with a concise plain-text result. Report successful Telegram "
-    "delivery only when the tool returns success. For every calendar or schedule request, first "
-    "call get_calendar_context. If the user does not name a session, research every active session. "
+    "delivery only when the tool returns success. For requests to check, refresh, add, update, or "
+    "remove calendar schedules, first call get_calendar_context. If the user does not name a "
+    "session, research every active session. "
     "Resolve company, asset, symbol, exchange, timeframe, or strategy descriptions to the exact "
     "session IDs returned by the tool and never ask the user for a session ID. Treat "
     "https://www.saveticker.com/calendar as a discovery source for event titles, then verify dates "
@@ -76,7 +77,9 @@ DEFAULT_DEVELOPER_INSTRUCTIONS = (
     "calendar sources. If SaveTicker has no relevant item, search the web directly. Never invent an "
     "event or date. Unless the user specifies a period, refresh today through 90 days ahead. After "
     "research, call replace_calendar_events for every requested session, including an empty event "
-    "array for a researched session with no relevant schedule, and report only tool-confirmed saves."
+    "array for a researched session with no relevant schedule, and report only tool-confirmed saves. "
+    "A server-provided calendar event forecast request is analysis-only: research and assess the "
+    "specified event without calling calendar mutation tools or changing any account or repository state."
 )
 _MAX_PERSISTED_MESSAGES = 200
 _MAX_CONTEXT_MESSAGES = 12

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -67,7 +67,16 @@ DEFAULT_DEVELOPER_INSTRUCTIONS = (
     "In the final response, do not list the procedure; present the lookup result immediately. "
     "Only when the user explicitly asks to send the result to Telegram, complete the lookup and "
     "then call send_telegram_message with a concise plain-text result. Report successful Telegram "
-    "delivery only when the tool returns success."
+    "delivery only when the tool returns success. For every calendar or schedule request, first "
+    "call get_calendar_context. If the user does not name a session, research every active session. "
+    "Resolve company, asset, symbol, exchange, timeframe, or strategy descriptions to the exact "
+    "session IDs returned by the tool and never ask the user for a session ID. Treat "
+    "https://www.saveticker.com/calendar as a discovery source for event titles, then verify dates "
+    "and details with public web search or authoritative company, exchange, filing, or economic "
+    "calendar sources. If SaveTicker has no relevant item, search the web directly. Never invent an "
+    "event or date. Unless the user specifies a period, refresh today through 90 days ahead. After "
+    "research, call replace_calendar_events for every requested session, including an empty event "
+    "array for a researched session with no relevant schedule, and report only tool-confirmed saves."
 )
 _MAX_PERSISTED_MESSAGES = 200
 _MAX_CONTEXT_MESSAGES = 12
@@ -146,6 +155,7 @@ class CodexService:
         self,
         project_root: Path,
         session_registry: Any,
+        calendar_store: Any,
         developer_instructions: str = DEFAULT_DEVELOPER_INSTRUCTIONS,
         timeout_seconds: float = 180,
         chat_state_path: Path | None = None,
@@ -155,6 +165,7 @@ class CodexService:
         self.dynamic_tools = AIDynamicTools(
             self.project_root,
             session_registry=session_registry,
+            calendar_store=calendar_store,
         )
         self.file_tools = self.dynamic_tools.file_tools
         self.developer_instructions = (

--- a/ai/scripts/README.md
+++ b/ai/scripts/README.md
@@ -8,6 +8,7 @@ tools used by Dashboard AI workflows under `ai/workflows/`.
 - `dynamic_tools.py` routes app-server tool calls.
 - `file_tools.py` restricts explicit file edits to approved repository paths.
 - `manual_alert_tool.py` manages persisted Manual Alert templates and triggers.
+- `calendar_tool.py` manages verified, persisted session calendar events.
 - `telegram_tool.py` sends explicitly requested results through server-held
   credentials.
 

--- a/ai/scripts/calendar_tool.py
+++ b/ai/scripts/calendar_tool.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from concurrent.futures import TimeoutError as FutureTimeoutError
+from pathlib import Path
+from typing import Any
+
+from data_service.calendar_store import CalendarEventStore, CalendarStoreError
+
+
+_CONTEXT_TOOL_NAME = "get_calendar_context"
+_REPLACE_TOOL_NAME = "replace_calendar_events"
+_MAX_SESSIONS_PER_UPDATE = 20
+_MAX_EVENTS_PER_UPDATE = 500
+
+
+class CalendarToolError(ValueError):
+    """A calendar tool request was rejected before changing persisted data."""
+
+
+class CalendarRegistryBridge:
+    def __init__(
+        self,
+        registry: Any,
+        store: CalendarEventStore,
+        *,
+        timeout_seconds: float = 20.0,
+    ) -> None:
+        self._registry = registry
+        self._store = store
+        self._timeout_seconds = timeout_seconds
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._loop_thread_id: int | None = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+        self._loop_thread_id = threading.get_ident()
+
+    def unbind_loop(self) -> None:
+        self._loop = None
+        self._loop_thread_id = None
+
+    def execute(self, operation: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        loop = self._loop
+        if loop is None or not loop.is_running():
+            raise CalendarToolError("Calendar service is not running")
+        if threading.get_ident() == self._loop_thread_id:
+            raise CalendarToolError("Calendar tool cannot block the data-service event loop")
+        future = asyncio.run_coroutine_threadsafe(
+            self._execute_on_loop(operation, arguments),
+            loop,
+        )
+        try:
+            return future.result(timeout=self._timeout_seconds)
+        except FutureTimeoutError:
+            future.cancel()
+            raise CalendarToolError("Calendar operation timed out") from None
+
+    async def _execute_on_loop(
+        self,
+        operation: str,
+        arguments: dict[str, Any],
+    ) -> dict[str, Any]:
+        if operation == "context":
+            return self._context()
+        if operation == "replace":
+            return await self._replace(arguments)
+        raise CalendarToolError(f"Unknown Calendar operation: {operation}")
+
+    def _context(self) -> dict[str, Any]:
+        active_ids = list(self._registry.sessions)
+        events = self._store.list_events(active_session_ids=active_ids)
+        events_by_session: dict[str, list[dict[str, Any]]] = {}
+        for event in events:
+            events_by_session.setdefault(event["session_id"], []).append(event)
+
+        sessions: list[dict[str, Any]] = []
+        for session in self._registry.sessions.values():
+            spec = session.spec
+            script_title = str(session.chart_info.get("script_title") or "").strip()
+            if not script_title and spec.script_name:
+                script_title = Path(spec.script_name).stem
+            sessions.append({
+                "session_id": spec.id,
+                "exchange": spec.exchange,
+                "symbol": spec.symbol,
+                "base_asset": str(spec.symbol).split("/", 1)[0],
+                "timeframe": spec.timeframe,
+                "script_name": spec.script_name,
+                "script_title": script_title,
+                "tv_symbol": str(session.logo_info.get("tv_symbol") or ""),
+                "existing_events": events_by_session.get(spec.id, []),
+            })
+        return {
+            "session_count": len(sessions),
+            "sessions": sessions,
+            "calendar_updated_at": self._store.updated_at,
+        }
+
+    async def _replace(self, arguments: dict[str, Any]) -> dict[str, Any]:
+        result = self._store.replace_range(
+            start=arguments["range_start"],
+            end=arguments["range_end"],
+            session_events=arguments["session_events"],
+            active_session_ids=self._registry.sessions,
+        )
+        await self._registry.hub_ws.broadcast_json({"type": "calendar_updated"})
+        result["updated_sessions"] = [
+            self._session_summary(session_id)
+            for session_id in result["updated_session_ids"]
+        ]
+        return result
+
+    def _session_summary(self, session_id: str) -> dict[str, Any]:
+        session = self._registry.get(session_id)
+        return {
+            "session_id": session_id,
+            "exchange": session.spec.exchange if session is not None else "",
+            "symbol": session.spec.symbol if session is not None else "",
+            "timeframe": session.spec.timeframe if session is not None else "",
+        }
+
+
+class CalendarTools:
+    def __init__(self, registry: Any, store: CalendarEventStore) -> None:
+        self.bridge = CalendarRegistryBridge(registry, store)
+
+    @property
+    def names(self) -> set[str]:
+        return {_CONTEXT_TOOL_NAME, _REPLACE_TOOL_NAME}
+
+    @property
+    def specs(self) -> list[dict[str, Any]]:
+        event_properties = {
+            "date": {
+                "type": "string",
+                "description": "Verified event date in YYYY-MM-DD format.",
+            },
+            "time": {
+                "type": "string",
+                "description": "Optional verified local event time in HH:MM 24-hour format.",
+            },
+            "timezone": {
+                "type": "string",
+                "description": "Timezone for time, such as Asia/Seoul or America/New_York.",
+            },
+            "title": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 200,
+                "description": "Short user-facing schedule title.",
+            },
+            "details": {
+                "type": "string",
+                "maxLength": 4000,
+                "description": "Verified details and why the event matters to this session.",
+            },
+            "category": {
+                "type": "string",
+                "enum": ["earnings", "economic", "company", "market", "dividend", "other"],
+            },
+            "source_name": {
+                "type": "string",
+                "maxLength": 120,
+                "description": "Concise source name.",
+            },
+            "source_url": {
+                "type": "string",
+                "minLength": 1,
+                "maxLength": 2048,
+                "description": "Public URL used to verify the date and details.",
+            },
+        }
+        return [
+            {
+                "type": "function",
+                "name": _CONTEXT_TOOL_NAME,
+                "description": (
+                    "List all active PyneReal sessions and their existing calendar events. "
+                    "Call this first for every calendar lookup or refresh. Resolve company, "
+                    "asset, symbol, exchange, timeframe, or strategy descriptions to the exact "
+                    "session IDs returned here; never ask the user to provide a session ID."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": _REPLACE_TOOL_NAME,
+                "description": (
+                    "Atomically replace verified calendar events inside one date range for one or "
+                    "more active sessions. Include a session with an empty events array when the "
+                    "range was researched and no relevant events were found, so stale entries are "
+                    "removed. Events outside the range and events for omitted sessions are preserved."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "range_start": {"type": "string", "description": "YYYY-MM-DD inclusive."},
+                        "range_end": {"type": "string", "description": "YYYY-MM-DD inclusive."},
+                        "session_events": {
+                            "type": "array",
+                            "minItems": 1,
+                            "maxItems": _MAX_SESSIONS_PER_UPDATE,
+                            "items": {
+                                "type": "object",
+                                "properties": {
+                                    "session_id": {
+                                        "type": "string",
+                                        "minLength": 1,
+                                        "description": "Exact active session ID from get_calendar_context.",
+                                    },
+                                    "events": {
+                                        "type": "array",
+                                        "maxItems": _MAX_EVENTS_PER_UPDATE,
+                                        "items": {
+                                            "type": "object",
+                                            "properties": event_properties,
+                                            "required": ["date", "title", "source_url"],
+                                            "additionalProperties": False,
+                                        },
+                                    },
+                                },
+                                "required": ["session_id", "events"],
+                                "additionalProperties": False,
+                            },
+                        },
+                    },
+                    "required": ["range_start", "range_end", "session_events"],
+                    "additionalProperties": False,
+                },
+            },
+        ]
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self.bridge.bind_loop(loop)
+
+    def unbind_loop(self) -> None:
+        self.bridge.unbind_loop()
+
+    def handle_server_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        if method != "item/tool/call" or not isinstance(params, dict):
+            return {}
+        tool = params.get("tool")
+        if tool not in self.names:
+            return {}
+        try:
+            arguments = params.get("arguments")
+            if not isinstance(arguments, dict):
+                raise CalendarToolError("Tool arguments must be an object")
+            if tool == _CONTEXT_TOOL_NAME:
+                if arguments:
+                    raise CalendarToolError("get_calendar_context does not accept arguments")
+                result = self.bridge.execute("context", arguments)
+            else:
+                validated = self._validate_replace(arguments)
+                result = self.bridge.execute("replace", validated)
+        except (CalendarToolError, CalendarStoreError) as exc:
+            return self._tool_response(False, {"error": str(exc)})
+        except Exception as exc:
+            print(f"[ai] Calendar tool failed: {type(exc).__name__}")
+            return self._tool_response(
+                False,
+                {"error": f"Calendar operation failed ({type(exc).__name__})"},
+            )
+        if tool == _REPLACE_TOOL_NAME:
+            print(
+                f"[ai] Calendar updated sessions={len(result['updated_session_ids'])} "
+                f"events={result['saved_event_count']} range={result['range_start']}..{result['range_end']}"
+            )
+        return self._tool_response(True, result)
+
+    @staticmethod
+    def _validate_replace(arguments: dict[str, Any]) -> dict[str, Any]:
+        unexpected = sorted(set(arguments) - {"range_start", "range_end", "session_events"})
+        if unexpected:
+            raise CalendarToolError(f"Unexpected argument field(s): {', '.join(unexpected)}")
+        for field in ("range_start", "range_end"):
+            if not isinstance(arguments.get(field), str) or not arguments[field].strip():
+                raise CalendarToolError(f"{field} must be a non-empty string")
+        session_events = arguments.get("session_events")
+        if not isinstance(session_events, list) or not session_events:
+            raise CalendarToolError("session_events must be a non-empty array")
+        if len(session_events) > _MAX_SESSIONS_PER_UPDATE:
+            raise CalendarToolError(
+                f"session_events can contain at most {_MAX_SESSIONS_PER_UPDATE} sessions"
+            )
+        total_events = 0
+        for item in session_events:
+            if not isinstance(item, dict):
+                raise CalendarToolError("each session_events item must be an object")
+            if set(item) - {"session_id", "events"}:
+                raise CalendarToolError("session_events items contain unsupported fields")
+            if not isinstance(item.get("session_id"), str) or not item["session_id"].strip():
+                raise CalendarToolError("session_id must be a non-empty string")
+            events = item.get("events")
+            if not isinstance(events, list):
+                raise CalendarToolError("events must be an array")
+            total_events += len(events)
+            for event in events:
+                if not isinstance(event, dict):
+                    raise CalendarToolError("each event must be an object")
+                if not isinstance(event.get("source_url"), str) or not event["source_url"].strip():
+                    raise CalendarToolError("each event requires a source_url")
+        if total_events > _MAX_EVENTS_PER_UPDATE:
+            raise CalendarToolError(
+                f"one update can contain at most {_MAX_EVENTS_PER_UPDATE} events"
+            )
+        validated = dict(arguments)
+        validated["range_start"] = arguments["range_start"].strip()
+        validated["range_end"] = arguments["range_end"].strip()
+        return validated
+
+    @staticmethod
+    def _tool_response(success: bool, payload: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "success": success,
+            "contentItems": [{
+                "type": "inputText",
+                "text": json.dumps(payload, ensure_ascii=False),
+            }],
+        }

--- a/ai/scripts/dynamic_tools.py
+++ b/ai/scripts/dynamic_tools.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from .calendar_tool import CalendarTools
 from .file_tools import RestrictedFileTools
 from .manual_alert_tool import ManualAlertTools
 from .telegram_tool import TelegramMessageTool
@@ -12,20 +13,28 @@ from .telegram_tool import TelegramMessageTool
 class AIDynamicTools:
     """Route app-server dynamic tool calls to server-controlled handlers."""
 
-    def __init__(self, project_root: Path, *, session_registry: Any) -> None:
+    def __init__(self, project_root: Path, *, session_registry: Any, calendar_store: Any) -> None:
         self.file_tools = RestrictedFileTools(project_root)
         self.manual_alert = ManualAlertTools(session_registry)
+        self.calendar = CalendarTools(session_registry, calendar_store)
         self.telegram = TelegramMessageTool()
 
     @property
     def specs(self) -> list[dict[str, Any]]:
-        return [*self.file_tools.specs, *self.manual_alert.specs, self.telegram.spec]
+        return [
+            *self.file_tools.specs,
+            *self.manual_alert.specs,
+            *self.calendar.specs,
+            self.telegram.spec,
+        ]
 
     def bind_loop(self, loop: Any) -> None:
         self.manual_alert.bind_loop(loop)
+        self.calendar.bind_loop(loop)
 
     def unbind_loop(self) -> None:
         self.manual_alert.unbind_loop()
+        self.calendar.unbind_loop()
 
     def handle_server_request(
         self,
@@ -43,6 +52,8 @@ class AIDynamicTools:
             return self.file_tools.handle_server_request(method, params)
         if tool in self.manual_alert.names:
             return self.manual_alert.handle_server_request(method, params)
+        if tool in self.calendar.names:
+            return self.calendar.handle_server_request(method, params)
         if tool == self.telegram.name:
             return self.telegram.handle_server_request(method, params)
         return self._error_response(f"Unknown AI tool: {tool!r}")

--- a/ai/workflows/update_calendar.md
+++ b/ai/workflows/update_calendar.md
@@ -1,0 +1,13 @@
+# Update Session Calendar
+
+1. Call `get_calendar_context` and resolve the user's natural-language scope to
+   active sessions. If no scope was given, select every active session.
+2. Resolve the requested date range. Default to today through 90 days ahead.
+3. Review `https://www.saveticker.com/calendar` for relevant event titles.
+4. Verify each candidate date and detail with public web search or an
+   authoritative company IR, filing, exchange, or economic-calendar source.
+5. Search the web directly for sessions with no relevant SaveTicker item.
+6. Call `replace_calendar_events` once with every researched session. Include
+   empty event arrays for sessions with no verified events in the range.
+7. Report the covered date range, updated sessions, and saved event count from
+   the tool response. Do not claim that an event was saved without tool success.

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -20,6 +20,7 @@ from pynecore.core.csv_file import CSVReader
 import ccxt.pro as ccxtpro
 
 from ai.provider.codex_service import CodexService
+from calendar_store import CalendarEventStore, CalendarStoreError
 from registry import (
     HistoryNotReadyError,
     SessionExistsError,
@@ -586,7 +587,11 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
 # ----------------------------------------------------------------------
 # Control-plane router:  /api/sessions ...
 # ----------------------------------------------------------------------
-def build_control_router(registry: SessionRegistry, codex_service: CodexService) -> APIRouter:
+def build_control_router(
+    registry: SessionRegistry,
+    codex_service: CodexService,
+    calendar_store: CalendarEventStore,
+) -> APIRouter:
     r = APIRouter()
 
     @r.get("/api/ai/chat")
@@ -747,6 +752,39 @@ def build_control_router(registry: SessionRegistry, codex_service: CodexService)
         )
         await registry.hub_ws.broadcast_json({"type": "ai_chat_updated"})
         return JSONResponse({"ok": True})
+
+    @r.get("/api/calendar/events")
+    async def list_calendar_events(
+        start: str | None = None,
+        end: str | None = None,
+    ) -> JSONResponse:
+        try:
+            events = calendar_store.list_events(
+                active_session_ids=registry.sessions,
+                start=start,
+                end=end,
+            )
+        except CalendarStoreError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+
+        result = []
+        for event in events:
+            session = registry.get(event["session_id"])
+            if session is None:
+                continue
+            item = dict(event)
+            item.update({
+                "exchange": session.spec.exchange,
+                "symbol": session.spec.symbol,
+                "timeframe": session.spec.timeframe,
+                "script_name": session.spec.script_name,
+                "script_title": str(session.chart_info.get("script_title") or ""),
+            })
+            result.append(item)
+        return JSONResponse({
+            "events": result,
+            "updated_at": calendar_store.updated_at,
+        })
 
     @r.get("/api/sessions")
     def list_sessions() -> JSONResponse:

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -96,6 +96,36 @@ def _render_ai_markdown(content: str) -> str:
     )
 
 
+def _calendar_forecast_prompt(event: dict[str, Any], session: Session) -> str:
+    context = {
+        "event_id": event["id"],
+        "date": event["date"],
+        "time": event.get("time"),
+        "timezone": event.get("timezone"),
+        "title": event["title"],
+        "details": event.get("details"),
+        "category": event.get("category"),
+        "source_name": event.get("source_name"),
+        "source_url": event.get("source_url"),
+        "session_id": session.spec.id,
+        "exchange": session.spec.exchange,
+        "symbol": session.spec.symbol,
+        "timeframe": session.spec.timeframe,
+        "strategy": session.chart_info.get("script_title") or session.spec.script_name,
+    }
+    return (
+        "This is a read-only forecast request launched from a verified PyneReal calendar event. "
+        "Do not add, update, or remove calendar events, do not call calendar mutation tools, and "
+        "do not change any account, file, or strategy state. Use current public information and "
+        "authoritative sources to assess the most likely outcome, meaningful upside/downside "
+        "scenarios, uncertainty, and the potential impact on the exact session symbol below. "
+        "Distinguish confirmed facts from inference. Respond in Korean Markdown and include concise "
+        "source links. Do not describe your internal procedure.\n\n"
+        f"Calendar event and session context:\n{json.dumps(context, ensure_ascii=False)}\n\n"
+        f"User request:\n{event['title']} 전망을 분석해줘."
+    )
+
+
 def _present_ai_chat_state(state: dict[str, Any]) -> dict[str, Any]:
     presented = dict(state)
     messages: list[dict[str, Any]] = []
@@ -593,6 +623,7 @@ def build_control_router(
     calendar_store: CalendarEventStore,
 ) -> APIRouter:
     r = APIRouter()
+    calendar_forecast_runs: dict[str, int] = {}
 
     @r.get("/api/ai/chat")
     async def get_ai_chat() -> JSONResponse:
@@ -773,6 +804,13 @@ def build_control_router(
             if session is None:
                 continue
             item = dict(event)
+            item["forecast_running"] = calendar_forecast_runs.get(event["id"], 0) > 0
+            forecast = calendar_store.get_forecast(event["id"])
+            if forecast is not None:
+                item["forecast"] = {
+                    **forecast,
+                    "html": _render_ai_markdown(forecast["answer"]),
+                }
             item.update({
                 "exchange": session.spec.exchange,
                 "symbol": session.spec.symbol,
@@ -785,6 +823,121 @@ def build_control_router(
             "events": result,
             "updated_at": calendar_store.updated_at,
         })
+
+    @r.post("/api/calendar/events/{event_id}/forecast")
+    async def forecast_calendar_event(event_id: str):
+        if not codex_service.enabled:
+            return JSONResponse({"error": "AI service is disabled"}, status_code=503)
+        event = calendar_store.get_event(
+            event_id,
+            active_session_ids=registry.sessions,
+        )
+        if event is None:
+            return JSONResponse({"error": "calendar event not found"}, status_code=404)
+        session = registry.get(event["session_id"])
+        if session is None:
+            return JSONResponse({"error": "calendar session is not active"}, status_code=409)
+
+        try:
+            preferences = await codex_service.chat_preferences()
+        except Exception:
+            preferences = {}
+        if not isinstance(preferences, dict):
+            preferences = {}
+        model = preferences.get("model")
+        effort = preferences.get("effort")
+        message = f"{event['title']} 전망을 분석해줘."
+        prompt = _calendar_forecast_prompt(event, session)
+
+        async def stream() -> AsyncIterator[str]:
+            conversation_id: str | None = None
+            calendar_forecast_runs[event_id] = calendar_forecast_runs.get(event_id, 0) + 1
+            try:
+                # Tell open dashboards immediately; dashboards opened later read
+                # the same state from GET /api/calendar/events.
+                await registry.hub_ws.broadcast_json({
+                    "type": "calendar_forecast_running",
+                    "event_id": event_id,
+                })
+                async for stream_event in codex_service.stream_chat(
+                    message,
+                    conversation_id=None,
+                    initial_context=prompt,
+                    model=model,
+                    effort=effort,
+                ):
+                    payload = stream_event.payload
+                    if stream_event.event == "conversation":
+                        conversation_id = str(payload.get("conversation_id") or "") or None
+                    elif stream_event.event == "done":
+                        answer = str(payload.get("answer") or "").strip()
+                        if not answer:
+                            yield _sse_event("stream_error", {"error": "AI returned an empty forecast"})
+                            return
+                        try:
+                            forecast = calendar_store.set_forecast(
+                                event_id,
+                                answer,
+                                active_session_ids=registry.sessions,
+                            )
+                        except CalendarStoreError as exc:
+                            yield _sse_event("stream_error", {"error": str(exc)})
+                            return
+                        payload = {
+                            **payload,
+                            "event_id": event_id,
+                            "answer": answer,
+                            "html": _render_ai_markdown(answer),
+                            "updated_at": forecast["updated_at"],
+                        }
+                    yield _sse_event(stream_event.event, payload)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                print(f"[calendar] forecast failed event={event_id[:8]}: {type(exc).__name__}")
+                yield _sse_event(
+                    "stream_error",
+                    {"error": f"Calendar forecast failed ({type(exc).__name__})"},
+                )
+            finally:
+                remaining = calendar_forecast_runs.get(event_id, 1) - 1
+                if remaining > 0:
+                    calendar_forecast_runs[event_id] = remaining
+                else:
+                    calendar_forecast_runs.pop(event_id, None)
+                try:
+                    await registry.hub_ws.broadcast_json({
+                        "type": "calendar_forecast_updated",
+                        "event_id": event_id,
+                    })
+                except Exception:
+                    pass
+                if conversation_id:
+                    await codex_service.reset(conversation_id)
+
+        return StreamingResponse(
+            stream(),
+            media_type="text/event-stream",
+            headers={
+                "Cache-Control": "no-cache, no-transform",
+                "X-Accel-Buffering": "no",
+            },
+        )
+
+    @r.post("/api/calendar/events/{event_id}/forecast/viewed")
+    async def mark_calendar_forecast_viewed(event_id: str) -> JSONResponse:
+        try:
+            forecast = calendar_store.mark_forecast_viewed(
+                event_id,
+                active_session_ids=registry.sessions,
+            )
+        except CalendarStoreError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=404)
+        await registry.hub_ws.broadcast_json({
+            "type": "calendar_forecast_updated",
+            "event_id": event_id,
+        })
+        return JSONResponse({"event_id": event_id, "viewed_at": forecast["viewed_at"]})
 
     @r.get("/api/sessions")
     def list_sessions() -> JSONResponse:

--- a/data_service/calendar_store.py
+++ b/data_service/calendar_store.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import UTC, date, datetime
+from pathlib import Path
+from typing import Any, Iterable
+from urllib.parse import urlparse
+
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+_TIME_RE = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d$")
+_EVENT_ID_RE = re.compile(r"^[A-Za-z0-9_-]{8,64}$")
+_CATEGORIES = {"earnings", "economic", "company", "market", "dividend", "other"}
+_MAX_EVENTS = 2000
+
+
+class CalendarStoreError(ValueError):
+    """Calendar data was invalid or could not be persisted."""
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _date_value(raw: object, field: str) -> str:
+    value = str(raw or "").strip()
+    if not _DATE_RE.fullmatch(value):
+        raise CalendarStoreError(f"{field} must use YYYY-MM-DD")
+    try:
+        date.fromisoformat(value)
+    except ValueError:
+        raise CalendarStoreError(f"{field} is not a valid date") from None
+    return value
+
+
+def _text(raw: object, field: str, *, required: bool, max_length: int) -> str:
+    if raw is None:
+        value = ""
+    elif isinstance(raw, str):
+        value = raw.strip()
+    else:
+        raise CalendarStoreError(f"{field} must be a string")
+    if required and not value:
+        raise CalendarStoreError(f"{field} is required")
+    if len(value) > max_length:
+        raise CalendarStoreError(f"{field} exceeds {max_length} characters")
+    return value
+
+
+def _event_id(event: dict[str, Any]) -> str:
+    raw = event.get("id")
+    if isinstance(raw, str) and _EVENT_ID_RE.fullmatch(raw.strip()):
+        return raw.strip()
+    identity = "\x1f".join(
+        str(event.get(key) or "")
+        for key in ("session_id", "date", "time", "title", "source_url")
+    )
+    return hashlib.sha256(identity.encode("utf-8")).hexdigest()[:24]
+
+
+def _sanitize_event(raw: object, *, session_id: str | None = None) -> dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise CalendarStoreError("each calendar event must be an object")
+
+    resolved_session_id = session_id or _text(
+        raw.get("session_id"), "session_id", required=True, max_length=200
+    )
+    event_date = _date_value(raw.get("date"), "event date")
+    event_time = _text(raw.get("time"), "time", required=False, max_length=5)
+    if event_time and not _TIME_RE.fullmatch(event_time):
+        raise CalendarStoreError("time must use HH:MM in 24-hour format")
+
+    source_url = _text(raw.get("source_url"), "source_url", required=False, max_length=2048)
+    if source_url:
+        parsed = urlparse(source_url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise CalendarStoreError("source_url must be an http or https URL")
+
+    category = _text(raw.get("category"), "category", required=False, max_length=32).lower()
+    if category not in _CATEGORIES:
+        category = "other"
+
+    event: dict[str, Any] = {
+        "session_id": resolved_session_id,
+        "date": event_date,
+        "time": event_time,
+        "timezone": _text(raw.get("timezone"), "timezone", required=False, max_length=64),
+        "title": _text(raw.get("title"), "title", required=True, max_length=200),
+        "details": _text(raw.get("details"), "details", required=False, max_length=4000),
+        "category": category,
+        "source_name": _text(raw.get("source_name"), "source_name", required=False, max_length=120),
+        "source_url": source_url,
+        "updated_at": _text(raw.get("updated_at"), "updated_at", required=False, max_length=40) or _utc_now(),
+    }
+    event["id"] = _event_id(event | {"id": raw.get("id")})
+    return event
+
+
+class CalendarEventStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path.resolve()
+        self._events: list[dict[str, Any]] = []
+        self.updated_at = ""
+        self._load()
+
+    def list_events(
+        self,
+        *,
+        active_session_ids: Iterable[str] | None = None,
+        start: str | None = None,
+        end: str | None = None,
+    ) -> list[dict[str, Any]]:
+        allowed = set(active_session_ids) if active_session_ids is not None else None
+        start_date = _date_value(start, "start") if start else None
+        end_date = _date_value(end, "end") if end else None
+        if start_date and end_date and start_date > end_date:
+            raise CalendarStoreError("start must not be after end")
+
+        return [
+            dict(event)
+            for event in self._events
+            if (allowed is None or event["session_id"] in allowed)
+            and (start_date is None or event["date"] >= start_date)
+            and (end_date is None or event["date"] <= end_date)
+        ]
+
+    def replace_range(
+        self,
+        *,
+        start: str,
+        end: str,
+        session_events: list[dict[str, Any]],
+        active_session_ids: Iterable[str],
+    ) -> dict[str, Any]:
+        start_date = _date_value(start, "range_start")
+        end_date = _date_value(end, "range_end")
+        if start_date > end_date:
+            raise CalendarStoreError("range_start must not be after range_end")
+        if not isinstance(session_events, list) or not session_events:
+            raise CalendarStoreError("session_events must be a non-empty array")
+
+        active = set(active_session_ids)
+        target_ids: set[str] = set()
+        replacements: list[dict[str, Any]] = []
+        for item in session_events:
+            if not isinstance(item, dict):
+                raise CalendarStoreError("each session_events item must be an object")
+            session_id = _text(item.get("session_id"), "session_id", required=True, max_length=200)
+            if session_id not in active:
+                raise CalendarStoreError(f"session_id is not active: {session_id}")
+            if session_id in target_ids:
+                raise CalendarStoreError(f"session_id appears more than once: {session_id}")
+            target_ids.add(session_id)
+
+            raw_events = item.get("events")
+            if not isinstance(raw_events, list):
+                raise CalendarStoreError("events must be an array")
+            for raw_event in raw_events:
+                event = _sanitize_event(raw_event, session_id=session_id)
+                if not start_date <= event["date"] <= end_date:
+                    raise CalendarStoreError(
+                        f"event date {event['date']} is outside the replacement range"
+                    )
+                replacements.append(event)
+
+        retained = [
+            event for event in self._events
+            if not (
+                event["session_id"] in target_ids
+                and start_date <= event["date"] <= end_date
+            )
+        ]
+        combined = retained + replacements
+        unique: dict[str, dict[str, Any]] = {event["id"]: event for event in combined}
+        if len(unique) > _MAX_EVENTS:
+            raise CalendarStoreError(f"calendar can contain at most {_MAX_EVENTS} events")
+
+        next_events = sorted(
+            unique.values(),
+            key=lambda event: (
+                event["date"], event.get("time") or "", event["session_id"], event["title"]
+            ),
+        )
+        next_updated_at = _utc_now()
+        previous_events = self._events
+        previous_updated_at = self.updated_at
+        self._events = next_events
+        self.updated_at = next_updated_at
+        try:
+            self._save()
+        except Exception:
+            self._events = previous_events
+            self.updated_at = previous_updated_at
+            raise
+        return {
+            "range_start": start_date,
+            "range_end": end_date,
+            "updated_session_ids": sorted(target_ids),
+            "saved_event_count": len(replacements),
+            "events": [dict(event) for event in replacements],
+            "updated_at": self.updated_at,
+        }
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+            raw_events = payload.get("events", []) if isinstance(payload, dict) else []
+            events: list[dict[str, Any]] = []
+            if isinstance(raw_events, list):
+                for raw in raw_events[:_MAX_EVENTS]:
+                    try:
+                        events.append(_sanitize_event(raw))
+                    except CalendarStoreError as exc:
+                        print(f"[calendar] skipped invalid stored event: {exc}")
+            self._events = sorted(
+                events,
+                key=lambda event: (
+                    event["date"], event.get("time") or "", event["session_id"], event["title"]
+                ),
+            )
+            self.updated_at = str(payload.get("updated_at") or "") if isinstance(payload, dict) else ""
+        except Exception as exc:
+            print(f"[calendar] failed to load {self.path.name}: {exc}")
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": 1,
+            "updated_at": self.updated_at,
+            "events": self._events,
+        }
+        tmp = self.path.with_name(self.path.name + ".tmp")
+        tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+        tmp.replace(self.path)

--- a/data_service/calendar_store.py
+++ b/data_service/calendar_store.py
@@ -14,6 +14,7 @@ _TIME_RE = re.compile(r"^(?:[01]\d|2[0-3]):[0-5]\d$")
 _EVENT_ID_RE = re.compile(r"^[A-Za-z0-9_-]{8,64}$")
 _CATEGORIES = {"earnings", "economic", "company", "market", "dividend", "other"}
 _MAX_EVENTS = 2000
+_MAX_FORECAST_CHARS = 40_000
 
 
 class CalendarStoreError(ValueError):
@@ -22,6 +23,10 @@ class CalendarStoreError(ValueError):
 
 def _utc_now() -> str:
     return datetime.now(UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _utc_now_precise() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
 
 
 def _date_value(raw: object, field: str) -> str:
@@ -98,10 +103,36 @@ def _sanitize_event(raw: object, *, session_id: str | None = None) -> dict[str, 
     return event
 
 
+def _sanitize_forecast(raw: object) -> dict[str, str]:
+    if not isinstance(raw, dict):
+        raise CalendarStoreError("forecast must be an object")
+    return {
+        "answer": _text(
+            raw.get("answer"),
+            "forecast answer",
+            required=True,
+            max_length=_MAX_FORECAST_CHARS,
+        ),
+        "updated_at": _text(
+            raw.get("updated_at"),
+            "forecast updated_at",
+            required=False,
+            max_length=40,
+        ) or _utc_now_precise(),
+        "viewed_at": _text(
+            raw.get("viewed_at"),
+            "forecast viewed_at",
+            required=False,
+            max_length=40,
+        ),
+    }
+
+
 class CalendarEventStore:
     def __init__(self, path: Path) -> None:
         self.path = path.resolve()
         self._events: list[dict[str, Any]] = []
+        self._forecasts: dict[str, dict[str, str]] = {}
         self.updated_at = ""
         self._load()
 
@@ -125,6 +156,74 @@ class CalendarEventStore:
             and (start_date is None or event["date"] >= start_date)
             and (end_date is None or event["date"] <= end_date)
         ]
+
+    def get_event(
+        self,
+        event_id: str,
+        *,
+        active_session_ids: Iterable[str] | None = None,
+    ) -> dict[str, Any] | None:
+        allowed = set(active_session_ids) if active_session_ids is not None else None
+        for event in self._events:
+            if event["id"] != event_id:
+                continue
+            if allowed is not None and event["session_id"] not in allowed:
+                return None
+            return dict(event)
+        return None
+
+    def get_forecast(self, event_id: str) -> dict[str, str] | None:
+        forecast = self._forecasts.get(event_id)
+        return dict(forecast) if forecast is not None else None
+
+    def set_forecast(
+        self,
+        event_id: str,
+        answer: str,
+        *,
+        active_session_ids: Iterable[str],
+    ) -> dict[str, str]:
+        event = self.get_event(event_id, active_session_ids=active_session_ids)
+        if event is None:
+            raise CalendarStoreError("calendar event is not active or no longer exists")
+        forecast = _sanitize_forecast({"answer": answer})
+        previous_forecasts = self._forecasts
+        previous_updated_at = self.updated_at
+        self._forecasts = {**self._forecasts, event_id: forecast}
+        self.updated_at = _utc_now()
+        try:
+            self._save()
+        except Exception:
+            self._forecasts = previous_forecasts
+            self.updated_at = previous_updated_at
+            raise
+        return dict(forecast)
+
+    def mark_forecast_viewed(
+        self,
+        event_id: str,
+        *,
+        active_session_ids: Iterable[str],
+    ) -> dict[str, str]:
+        event = self.get_event(event_id, active_session_ids=active_session_ids)
+        forecast = self._forecasts.get(event_id)
+        if event is None or forecast is None:
+            raise CalendarStoreError("calendar forecast is not active or no longer exists")
+        if forecast.get("viewed_at"):
+            return dict(forecast)
+
+        viewed_forecast = {**forecast, "viewed_at": _utc_now_precise()}
+        previous_forecasts = self._forecasts
+        previous_updated_at = self.updated_at
+        self._forecasts = {**self._forecasts, event_id: viewed_forecast}
+        self.updated_at = _utc_now()
+        try:
+            self._save()
+        except Exception:
+            self._forecasts = previous_forecasts
+            self.updated_at = previous_updated_at
+            raise
+        return dict(viewed_forecast)
 
     def replace_range(
         self,
@@ -183,15 +282,23 @@ class CalendarEventStore:
                 event["date"], event.get("time") or "", event["session_id"], event["title"]
             ),
         )
+        next_forecasts = {
+            event_id: forecast
+            for event_id, forecast in self._forecasts.items()
+            if event_id in unique
+        }
         next_updated_at = _utc_now()
         previous_events = self._events
+        previous_forecasts = self._forecasts
         previous_updated_at = self.updated_at
         self._events = next_events
+        self._forecasts = next_forecasts
         self.updated_at = next_updated_at
         try:
             self._save()
         except Exception:
             self._events = previous_events
+            self._forecasts = previous_forecasts
             self.updated_at = previous_updated_at
             raise
         return {
@@ -222,6 +329,18 @@ class CalendarEventStore:
                     event["date"], event.get("time") or "", event["session_id"], event["title"]
                 ),
             )
+            valid_event_ids = {event["id"] for event in self._events}
+            raw_forecasts = payload.get("forecasts", {}) if isinstance(payload, dict) else {}
+            forecasts: dict[str, dict[str, str]] = {}
+            if isinstance(raw_forecasts, dict):
+                for event_id, raw_forecast in raw_forecasts.items():
+                    if event_id not in valid_event_ids:
+                        continue
+                    try:
+                        forecasts[event_id] = _sanitize_forecast(raw_forecast)
+                    except CalendarStoreError as exc:
+                        print(f"[calendar] skipped invalid stored forecast: {exc}")
+            self._forecasts = forecasts
             self.updated_at = str(payload.get("updated_at") or "") if isinstance(payload, dict) else ""
         except Exception as exc:
             print(f"[calendar] failed to load {self.path.name}: {exc}")
@@ -229,9 +348,10 @@ class CalendarEventStore:
     def _save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
-            "schema_version": 1,
+            "schema_version": 3,
             "updated_at": self.updated_at,
             "events": self._events,
+            "forecasts": self._forecasts,
         }
         tmp = self.path.with_name(self.path.name + ".tmp")
         tmp.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -12,6 +12,7 @@ import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from ai.provider.codex_service import CodexService
+from calendar_store import CalendarEventStore
 from config import ensure_provider_config, load_hub_config, load_initial_sessions
 from registry import SessionRegistry
 from api import build_session_api_router, build_control_router, build_validation_router
@@ -27,10 +28,14 @@ _BANNER = r"""
 """
 
 
-def build_app(registry: SessionRegistry, codex_service: CodexService) -> FastAPI:
+def build_app(
+    registry: SessionRegistry,
+    codex_service: CodexService,
+    calendar_store: CalendarEventStore,
+) -> FastAPI:
     app = FastAPI()
     app.include_router(build_ui_router())
-    app.include_router(build_control_router(registry, codex_service))
+    app.include_router(build_control_router(registry, codex_service, calendar_store))
     app.include_router(build_validation_router())
     app.include_router(build_session_api_router(registry))
 
@@ -120,16 +125,20 @@ async def main() -> None:
     cfg = load_hub_config()
     specs = load_initial_sessions()
     registry = SessionRegistry(port=cfg.port)
+    calendar_store = CalendarEventStore(
+        _PROJECT_ROOT / "workdir" / "config" / "calendar_events.json"
+    )
     codex_service = CodexService(
         project_root=_PROJECT_ROOT,
         session_registry=registry,
+        calendar_store=calendar_store,
     )
     registry.set_ai_instruction_handler(codex_service.handle_strategy_instruction)
     try:
         await codex_service.start()
     except Exception as e:
         print(f"[ai] Codex app-server startup failed: {e}")
-    app = build_app(registry, codex_service)
+    app = build_app(registry, codex_service, calendar_store)
 
     await registry.start_all(specs)
     heartbeat = asyncio.create_task(_hub_status_heartbeat(registry))

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -21,36 +21,42 @@ body {
 @media (hover: hover) and (pointer: fine) {
   html,
   body,
-  .log-content {
+  .log-content,
+  .calendar-body {
     scrollbar-color: #3a4350 #0b0e13;
     scrollbar-width: thin;
   }
   html::-webkit-scrollbar,
   body::-webkit-scrollbar,
-  .log-content::-webkit-scrollbar {
+  .log-content::-webkit-scrollbar,
+  .calendar-body::-webkit-scrollbar {
     width: 10px;
     height: 10px;
   }
   html::-webkit-scrollbar-track,
   body::-webkit-scrollbar-track,
-  .log-content::-webkit-scrollbar-track {
+  .log-content::-webkit-scrollbar-track,
+  .calendar-body::-webkit-scrollbar-track {
     background: #0b0e13;
   }
   html::-webkit-scrollbar-thumb,
   body::-webkit-scrollbar-thumb,
-  .log-content::-webkit-scrollbar-thumb {
+  .log-content::-webkit-scrollbar-thumb,
+  .calendar-body::-webkit-scrollbar-thumb {
     background: #3a4350;
     border: 2px solid #0b0e13;
     border-radius: 999px;
   }
   html::-webkit-scrollbar-thumb:hover,
   body::-webkit-scrollbar-thumb:hover,
-  .log-content::-webkit-scrollbar-thumb:hover {
+  .log-content::-webkit-scrollbar-thumb:hover,
+  .calendar-body::-webkit-scrollbar-thumb:hover {
     background: #4a5565;
   }
   html::-webkit-scrollbar-corner,
   body::-webkit-scrollbar-corner,
-  .log-content::-webkit-scrollbar-corner {
+  .log-content::-webkit-scrollbar-corner,
+  .calendar-body::-webkit-scrollbar-corner {
     background: #0b0e13;
   }
 }
@@ -66,6 +72,101 @@ body {
   background: var(--panel);
 }
 .topbar h1 { font-size: 18px; margin: 0; letter-spacing: 0.5px; }
+
+.hub-menu-button,
+.hub-menu-close {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+}
+.hub-menu-button svg {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+}
+.hub-menu-button:hover,
+.hub-menu-close:hover { color: #ffffff; }
+
+.hub-menu-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 69;
+  background: rgba(0, 0, 0, 0.5);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 160ms ease, visibility 160ms ease;
+}
+.hub-menu-backdrop.open {
+  opacity: 1;
+  visibility: visible;
+}
+.hub-menu-backdrop.dragging { transition: none; }
+.hub-menu {
+  position: fixed;
+  inset: 0 auto 0 0;
+  z-index: 70;
+  width: min(280px, 82vw);
+  display: flex;
+  flex-direction: column;
+  background: var(--panel);
+  border-right: 1px solid var(--border);
+  box-shadow: 12px 0 30px rgba(0, 0, 0, 0.35);
+  transform: translateX(-102%);
+  transition: transform 180ms ease;
+}
+.hub-menu.open { transform: translateX(0); }
+.hub-menu.dragging { transition: none; }
+.hub-menu-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  min-height: 53px;
+  padding: 12px 16px 12px 20px;
+  border-bottom: 1px solid var(--border);
+  color: #f2f5f8;
+  font-size: 14px;
+  font-weight: 600;
+}
+.hub-menu-close { font-size: 24px; line-height: 1; }
+.hub-menu-nav { padding: 10px; }
+.hub-menu-item {
+  width: 100%;
+  min-height: 42px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.hub-menu-item:hover,
+.hub-menu-item:focus-visible {
+  background: #21262d;
+  color: #ffffff;
+  outline: none;
+}
+.hub-menu-emoji {
+  width: 24px;
+  font-size: 18px;
+  line-height: 1;
+  text-align: center;
+}
 
 .conn {
   font-size: 12px;
@@ -550,6 +651,197 @@ tr:last-child td { border-bottom: none; }
 }
 .modal-header .mono { font-size: 13px; word-break: break-all; }
 .modal-actions { display: flex; gap: 6px; flex-shrink: 0; }
+
+/* ---- session calendar ---- */
+.calendar-modal { z-index: 80; }
+.calendar-modal-box {
+  width: min(920px, 100%);
+  max-height: calc(100vh - 32px);
+}
+.calendar-modal-header { min-height: 50px; }
+.calendar-modal-header > span { font-size: 14px; font-weight: 600; }
+.calendar-modal button { touch-action: manipulation; }
+.calendar-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 16px;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+.calendar-toolbar {
+  position: relative;
+  min-height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
+}
+.calendar-month-nav {
+  position: absolute;
+  left: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.calendar-month-nav .btn-icon {
+  font-size: 22px;
+  line-height: 1;
+}
+.calendar-toolbar h2 {
+  margin: 0;
+  font-size: 17px;
+  font-weight: 600;
+}
+.calendar-updated {
+  position: absolute;
+  right: 0;
+  color: var(--muted);
+  font-size: 11px;
+}
+.calendar-weekdays,
+.calendar-grid {
+  display: grid;
+  grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+.calendar-weekdays {
+  border: 1px solid var(--border);
+  border-bottom: 0;
+  background: #11161d;
+}
+.calendar-weekdays span {
+  padding: 7px 4px;
+  color: var(--muted);
+  font-size: 11px;
+  text-align: center;
+}
+.calendar-grid {
+  border-top: 1px solid var(--border);
+  border-left: 1px solid var(--border);
+}
+.calendar-grid.calendar-month-next {
+  animation: calendar-month-next 180ms ease-out;
+}
+.calendar-grid.calendar-month-prev {
+  animation: calendar-month-prev 180ms ease-out;
+}
+@keyframes calendar-month-next {
+  from { opacity: 0.55; transform: translateX(18px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes calendar-month-prev {
+  from { opacity: 0.55; transform: translateX(-18px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+.calendar-day {
+  position: relative;
+  min-width: 0;
+  min-height: 88px;
+  padding: 8px;
+  border: 0;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: #11161d;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.calendar-day:hover { background: #181f29; }
+.calendar-day.outside { color: #59616d; background: #0d1218; }
+.calendar-day.today .calendar-day-number {
+  color: #ffffff;
+  background: var(--accent);
+}
+.calendar-day.selected {
+  z-index: 1;
+  background: #1b2533;
+  box-shadow: inset 0 0 0 1px #58a6ff;
+}
+.calendar-day-number {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  font-size: 12px;
+}
+.calendar-day-event-row {
+  position: absolute;
+  left: 8px;
+  right: 8px;
+  bottom: 9px;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+}
+.calendar-event-dot {
+  width: 7px;
+  height: 7px;
+  flex: none;
+  border-radius: 50%;
+  background: var(--event-color, #58a6ff);
+}
+.calendar-event-count {
+  margin-left: auto;
+  color: var(--muted);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.calendar-details {
+  margin-top: 18px;
+  padding-top: 16px;
+  border-top: 1px solid var(--border);
+}
+.calendar-details h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+  font-weight: 600;
+}
+.calendar-detail-events {
+  display: grid;
+  gap: 8px;
+}
+.calendar-event-card {
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--event-color, #58a6ff);
+  border-radius: 6px;
+  background: #11161d;
+}
+.calendar-event-session {
+  color: var(--muted);
+  font-size: 11px;
+}
+.calendar-event-title {
+  margin-top: 4px;
+  color: #f2f5f8;
+  font-size: 13px;
+  font-weight: 600;
+}
+.calendar-event-time {
+  margin-left: 7px;
+  color: #aeb7c2;
+  font-size: 11px;
+  font-weight: 400;
+}
+.calendar-event-details {
+  margin-top: 5px;
+  color: #c5ccd5;
+  font-size: 12px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+.calendar-event-source {
+  display: inline-block;
+  margin-top: 7px;
+  color: #58a6ff;
+  font-size: 11px;
+  text-decoration: none;
+}
+.calendar-event-source:hover { text-decoration: underline; }
+.calendar-empty-day { color: var(--muted); font-size: 12px; }
 .log-content {
   margin: 0;
   padding: 12px 14px;
@@ -1101,11 +1393,76 @@ tr:last-child td { border-bottom: none; }
     padding: 12px 14px;
     padding-right: 58px;
   }
+  .hub-menu-button { width: 28px; height: 28px; }
+  .hub-menu { touch-action: pan-y; }
+  .hub-menu-header { min-height: 53px; }
   .hub-clock {
     --clock-size: 30px;
     --clock-center-fade: 53%;
     right: 14px;
   }
+  .calendar-modal {
+    padding: 0;
+  }
+  .calendar-modal-box {
+    position: relative;
+    width: 100%;
+    height: 100dvh;
+    max-height: none;
+    border: 0;
+    border-radius: 0;
+  }
+  .calendar-modal.calendar-opening {
+    animation: calendar-backdrop-in 220ms ease-out;
+  }
+  .calendar-modal.calendar-opening .calendar-modal-box {
+    animation: calendar-sheet-in 220ms cubic-bezier(0.22, 0.75, 0.25, 1);
+  }
+  .calendar-modal.calendar-dragging .calendar-modal-box {
+    animation: none;
+    transition: none;
+  }
+  .calendar-modal.calendar-closing {
+    animation: calendar-backdrop-out 220ms ease-in forwards;
+  }
+  .calendar-modal.calendar-closing .calendar-modal-box {
+    animation: calendar-sheet-out 220ms cubic-bezier(0.55, 0, 1, 0.45) forwards;
+  }
+  .calendar-modal.calendar-closing.calendar-swipe-closing .calendar-modal-box {
+    animation: none;
+  }
+  .calendar-modal-header {
+    position: relative;
+    padding-top: calc(18px + env(safe-area-inset-top));
+    touch-action: none;
+  }
+  .calendar-modal-header::before {
+    content: "";
+    position: absolute;
+    top: calc(7px + env(safe-area-inset-top));
+    left: 50%;
+    width: 40px;
+    height: 4px;
+    margin-left: -20px;
+    border-radius: 999px;
+    background: var(--border);
+  }
+  .calendar-body { padding: 12px; }
+  .calendar-toolbar {
+    justify-content: flex-end;
+    min-height: 62px;
+    padding-top: 28px;
+  }
+  .calendar-month-nav { top: 0; left: 0; }
+  .calendar-toolbar h2 { font-size: 15px; }
+  .calendar-updated { top: 7px; right: 0; }
+  .calendar-weekdays span { padding: 6px 2px; font-size: 10px; }
+  .calendar-grid { touch-action: pan-y; }
+  .calendar-day { min-height: 58px; padding: 5px; }
+  .calendar-day-number { width: 21px; height: 21px; font-size: 11px; }
+  .calendar-day-event-row { left: 5px; right: 5px; bottom: 6px; gap: 3px; }
+  .calendar-event-dot { width: 5px; height: 5px; }
+  .calendar-event-count { font-size: 9px; }
   .clock-hour { height: 8px; }
   .clock-minute { height: 11px; }
   .clock-second { height: 13px; }
@@ -1296,4 +1653,21 @@ tr:last-child td { border-bottom: none; }
   .ai-msg-markdown tr td:last-child { border: 1px solid #3a4350; }
   /* keep Send above the iPhone home indicator */
   .ai-chat-form { padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px)); }
+}
+
+@keyframes calendar-sheet-in {
+  from { transform: translateY(100%); }
+  to { transform: translateY(0); }
+}
+@keyframes calendar-sheet-out {
+  from { transform: translateY(0); }
+  to { transform: translateY(100%); }
+}
+@keyframes calendar-backdrop-in {
+  from { background: rgba(0, 0, 0, 0); }
+  to { background: rgba(0, 0, 0, 0.6); }
+}
+@keyframes calendar-backdrop-out {
+  from { background: rgba(0, 0, 0, 0.6); }
+  to { background: rgba(0, 0, 0, 0); }
 }

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -22,27 +22,35 @@ body {
   html,
   body,
   .log-content,
-  .calendar-body {
+  .calendar-body,
+  .calendar-forecast-content,
+  .calendar-forecast-error {
     scrollbar-color: #3a4350 #0b0e13;
     scrollbar-width: thin;
   }
   html::-webkit-scrollbar,
   body::-webkit-scrollbar,
   .log-content::-webkit-scrollbar,
-  .calendar-body::-webkit-scrollbar {
+  .calendar-body::-webkit-scrollbar,
+  .calendar-forecast-content::-webkit-scrollbar,
+  .calendar-forecast-error::-webkit-scrollbar {
     width: 10px;
     height: 10px;
   }
   html::-webkit-scrollbar-track,
   body::-webkit-scrollbar-track,
   .log-content::-webkit-scrollbar-track,
-  .calendar-body::-webkit-scrollbar-track {
+  .calendar-body::-webkit-scrollbar-track,
+  .calendar-forecast-content::-webkit-scrollbar-track,
+  .calendar-forecast-error::-webkit-scrollbar-track {
     background: #0b0e13;
   }
   html::-webkit-scrollbar-thumb,
   body::-webkit-scrollbar-thumb,
   .log-content::-webkit-scrollbar-thumb,
-  .calendar-body::-webkit-scrollbar-thumb {
+  .calendar-body::-webkit-scrollbar-thumb,
+  .calendar-forecast-content::-webkit-scrollbar-thumb,
+  .calendar-forecast-error::-webkit-scrollbar-thumb {
     background: #3a4350;
     border: 2px solid #0b0e13;
     border-radius: 999px;
@@ -50,7 +58,9 @@ body {
   html::-webkit-scrollbar-thumb:hover,
   body::-webkit-scrollbar-thumb:hover,
   .log-content::-webkit-scrollbar-thumb:hover,
-  .calendar-body::-webkit-scrollbar-thumb:hover {
+  .calendar-body::-webkit-scrollbar-thumb:hover,
+  .calendar-forecast-content::-webkit-scrollbar-thumb:hover,
+  .calendar-forecast-error::-webkit-scrollbar-thumb:hover {
     background: #4a5565;
   }
   html::-webkit-scrollbar-corner,
@@ -804,12 +814,175 @@ tr:last-child td { border-bottom: none; }
   gap: 8px;
 }
 .calendar-event-card {
+  position: relative;
   padding: 10px 12px;
   border: 1px solid var(--border);
   border-left: 3px solid var(--event-color, #58a6ff);
   border-radius: 6px;
   background: #11161d;
 }
+.calendar-event-card.has-forecast { padding-right: 54px; }
+.calendar-forecast-pepe {
+  position: absolute;
+  top: 7px;
+  right: 8px;
+  z-index: 2;
+  width: 38px;
+  height: 38px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: pointer;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.45));
+  -webkit-tap-highlight-color: transparent;
+}
+.calendar-forecast-pepe:disabled {
+  cursor: default;
+  filter: grayscale(0.7) opacity(0.45);
+}
+.calendar-forecast-pepe .pepe {
+  display: block;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+.calendar-forecast-pepe.forecast-running .pepe-pupil {
+  transform-box: fill-box;
+  transform-origin: center;
+  animation: calendar-pepe-eye-roll 600ms linear infinite;
+}
+.calendar-forecast-pepe.forecast-unread {
+  animation: calendar-pepe-ready-shake 480ms ease-in-out infinite;
+}
+@keyframes calendar-pepe-eye-roll {
+  0%, 100% { transform: translate(0, 0); }
+  25% { transform: translate(2.5px, -0.7px); }
+  50% { transform: translate(0, 1.1px); }
+  75% { transform: translate(-2.5px, -0.7px); }
+}
+@keyframes calendar-pepe-ready-shake {
+  0%, 100% { transform: rotate(0deg); }
+  20% { transform: rotate(-7deg); }
+  40% { transform: rotate(7deg); }
+  60% { transform: rotate(-5deg); }
+  80% { transform: rotate(5deg); }
+}
+/* tiny "alien speech" bubble floating above a ready Pepe — signals he has a
+   forecast to say. Lives inside the button, so it shakes along while unread
+   and sits still once viewed. Green ties it to Pepe; tail points down at him. */
+.pepe-say {
+  position: absolute;
+  bottom: calc(100% - 8px);
+  right: 1px;
+  z-index: 3;
+  padding: 1px 6px 2px;
+  border: 1px solid #2f5c28;
+  border-radius: 9px 9px 9px 3px;
+  background: #5b9e4d;
+  color: #f2fbec;
+  font-size: 10px;
+  line-height: 1.35;
+  letter-spacing: 1.5px;
+  white-space: nowrap;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+}
+.pepe-say::after {
+  content: "";
+  position: absolute;
+  left: 3px;
+  bottom: -4px;
+  width: 9px;
+  height: 7px;
+  background: #5b9e4d;
+  /* straight edge on the right, slanted edge on the left (apex bottom-right) */
+  clip-path: polygon(0 0, 100% 0, 100% 100%);
+}
+.calendar-forecast-bubble {
+  position: absolute;
+  right: 50px;
+  bottom: calc(100% - 20px);
+  z-index: 12;
+  width: min(430px, calc(100% - 16px));
+  padding: 11px 12px;
+  overflow: visible;
+  border: 1px solid #3a4350;
+  border-radius: 6px;
+  background: #1b222c;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.5);
+  color: var(--text);
+  font-size: 12px;
+  text-align: left;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+/* tail leaning toward the Pepe button, which sits below-right of the bubble.
+   An asymmetric right-triangle (vertical right edge, slanted left edge) reads
+   as a directional lean toward the face — a rotated square only ever looks
+   like a symmetric nub, however much it is turned. */
+.calendar-forecast-bubble::before {
+  content: "";
+  position: absolute;
+  right: 10px;
+  bottom: -11px;
+  width: 22px;
+  height: 14px;
+  background: #1b222c;
+  clip-path: polygon(0 0, 100% 0, 100% 100%);
+}
+.calendar-forecast-bubble-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 9px;
+  padding-bottom: 8px;
+  /* divider separating the title from the forecast body */
+  border-bottom: 1px solid rgba(255, 255, 255, 0.09);
+  color: #f2f5f8;
+  font-size: 11px;
+  font-weight: 600;
+}
+.calendar-forecast-refresh {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  padding: 0;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--muted);
+  cursor: pointer;
+  transition: color 120ms ease, background 120ms ease;
+}
+.calendar-forecast-refresh svg {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.calendar-forecast-refresh:hover {
+  color: #f2f5f8;
+  background: rgba(255, 255, 255, 0.07);
+}
+.calendar-forecast-bubble .calendar-forecast-content,
+.calendar-forecast-bubble .calendar-forecast-error {
+  max-height: min(350px, 48vh);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overflow-wrap: anywhere;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+.calendar-forecast-content { min-width: 0; }
+.calendar-forecast-error { color: #ff7b72; line-height: 1.45; }
 .calendar-event-session {
   color: var(--muted);
   font-size: 11px;
@@ -1463,6 +1636,10 @@ tr:last-child td { border-bottom: none; }
   .calendar-day-event-row { left: 5px; right: 5px; bottom: 6px; gap: 3px; }
   .calendar-event-dot { width: 5px; height: 5px; }
   .calendar-event-count { font-size: 9px; }
+  .calendar-forecast-bubble {
+    right: 44px;
+    width: calc(100% - 62px);
+  }
   .clock-hour { height: 8px; }
   .clock-minute { height: 11px; }
   .clock-second { height: 13px; }

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,10 +4,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=24" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=28" />
 </head>
 <body>
   <header class="topbar">
+    <button id="hub-menu-button" class="hub-menu-button" type="button"
+            aria-label="Open menu" aria-expanded="false" aria-controls="hub-menu">
+      <svg viewBox="0 0 24 24" aria-hidden="true">
+        <path d="M4 6h16M4 12h16M4 18h16" />
+      </svg>
+    </button>
     <h1>PyneReal&nbsp;Hub</h1>
     <span id="conn-status" class="conn">connecting…</span>
     <div id="hub-clock" class="hub-clock" aria-label="Local time">
@@ -17,6 +23,20 @@
       <span class="clock-center" aria-hidden="true"></span>
     </div>
   </header>
+
+  <div id="hub-menu-backdrop" class="hub-menu-backdrop" aria-hidden="true"></div>
+  <aside id="hub-menu" class="hub-menu" aria-hidden="true">
+    <div class="hub-menu-header">
+      <span>PyneReal Hub</span>
+      <button id="hub-menu-close" class="hub-menu-close" type="button" aria-label="Close menu">&times;</button>
+    </div>
+    <nav class="hub-menu-nav" aria-label="Hub menu">
+      <button id="hub-calendar-open" class="hub-menu-item" type="button">
+        <span class="hub-menu-emoji" aria-hidden="true">&#x1f4c5;</span>
+        <span>Calendar</span>
+      </button>
+    </nav>
+  </aside>
 
   <section class="card collapsible collapsed" id="add-card">
     <h2 class="card-toggle" id="add-toggle" role="button" tabindex="0" aria-expanded="false" aria-controls="add-body">
@@ -88,6 +108,35 @@
     </table>
     <div id="empty" class="muted">No sessions yet. Add one above.</div>
   </section>
+
+  <div id="calendar-modal" class="modal calendar-modal hidden" aria-hidden="true">
+    <div class="modal-box calendar-modal-box" role="dialog" aria-modal="true" aria-labelledby="calendar-title">
+      <div class="modal-header calendar-modal-header">
+        <span id="calendar-title">Calendar</span>
+        <button id="calendar-close" class="btn" type="button" title="Close" aria-label="Close">&times;</button>
+      </div>
+      <div class="calendar-body">
+        <div class="calendar-toolbar">
+          <div class="calendar-month-nav">
+            <button id="calendar-prev" class="btn btn-icon" type="button" title="Previous month" aria-label="Previous month">&#8249;</button>
+            <button id="calendar-today" class="btn" type="button">Today</button>
+            <button id="calendar-next" class="btn btn-icon" type="button" title="Next month" aria-label="Next month">&#8250;</button>
+          </div>
+          <h2 id="calendar-month-title"></h2>
+          <span id="calendar-updated" class="calendar-updated"></span>
+        </div>
+        <div class="calendar-weekdays" aria-hidden="true">
+          <span>Sun</span><span>Mon</span><span>Tue</span><span>Wed</span>
+          <span>Thu</span><span>Fri</span><span>Sat</span>
+        </div>
+        <div id="calendar-grid" class="calendar-grid"></div>
+        <section id="calendar-details" class="calendar-details hidden" aria-live="polite">
+          <h3 id="calendar-detail-date"></h3>
+          <div id="calendar-detail-events" class="calendar-detail-events"></div>
+        </section>
+      </div>
+    </div>
+  </div>
 
   <div id="log-modal" class="modal hidden" aria-hidden="true">
     <div class="modal-box">
@@ -208,6 +257,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=28"></script>
+  <script src="/static/dashboard.js?v=32"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=28" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=38" />
 </head>
 <body>
   <header class="topbar">
@@ -257,6 +257,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=32"></script>
+  <script src="/static/dashboard.js?v=41"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -16,8 +16,504 @@
     "(max-width: 720px) and (hover: hover) and (pointer: fine)",
   );
   const mobileAiQuery = window.matchMedia("(max-width: 720px)");
+  const mobileHubQuery = window.matchMedia("(max-width: 720px)");
+  const calendarColors = [
+    "#58a6ff", "#3fb950", "#f2cc60", "#f778ba", "#bc8cff",
+    "#ff7b72", "#56d4dd", "#d29922", "#a5d6ff", "#7ee787",
+  ];
+  let calendarMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
+  let calendarEvents = [];
+  let calendarSelectedDate = null;
+  let calendarRequestSeq = 0;
+  let lastCalendarTouchAt = 0;
+  let calendarSuppressTapUntil = 0;
+  let calendarOpenTimer = null;
+  let calendarCloseTimer = null;
 
   const el = (id) => document.getElementById(id);
+
+  function calendarDateKey(value) {
+    const d = value instanceof Date ? value : new Date(value);
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`;
+  }
+
+  function calendarDateFromKey(key) {
+    const parts = String(key || "").split("-").map(Number);
+    if (parts.length !== 3 || parts.some((part) => !Number.isFinite(part))) return null;
+    return new Date(parts[0], parts[1] - 1, parts[2]);
+  }
+
+  function calendarGridRange() {
+    const start = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth(), 1);
+    start.setDate(start.getDate() - start.getDay());
+    const end = new Date(start);
+    end.setDate(end.getDate() + 41);
+    return { start, end };
+  }
+
+  function calendarSessionColor(sessionId) {
+    let hash = 0;
+    const value = String(sessionId || "");
+    for (let i = 0; i < value.length; i++) hash = ((hash << 5) - hash + value.charCodeAt(i)) | 0;
+    return calendarColors[Math.abs(hash) % calendarColors.length];
+  }
+
+  function isCalendarOpen() {
+    return !el("calendar-modal").classList.contains("hidden");
+  }
+
+  function openHubMenu() {
+    const menu = el("hub-menu");
+    const backdrop = el("hub-menu-backdrop");
+    menu.classList.remove("dragging");
+    menu.style.transform = "";
+    backdrop.classList.remove("dragging");
+    backdrop.style.opacity = "";
+    menu.classList.add("open");
+    backdrop.classList.add("open");
+    menu.setAttribute("aria-hidden", "false");
+    backdrop.setAttribute("aria-hidden", "false");
+    el("hub-menu-button").setAttribute("aria-expanded", "true");
+  }
+
+  function closeHubMenu() {
+    const menu = el("hub-menu");
+    const backdrop = el("hub-menu-backdrop");
+    menu.classList.remove("dragging", "open");
+    menu.style.transform = "";
+    backdrop.classList.remove("dragging", "open");
+    backdrop.style.opacity = "";
+    menu.setAttribute("aria-hidden", "true");
+    backdrop.setAttribute("aria-hidden", "true");
+    el("hub-menu-button").setAttribute("aria-expanded", "false");
+  }
+
+  async function openCalendar() {
+    closeHubMenu();
+    closeAiChat();
+    if (calendarCloseTimer !== null) {
+      clearTimeout(calendarCloseTimer);
+      calendarCloseTimer = null;
+    }
+    if (calendarOpenTimer !== null) {
+      clearTimeout(calendarOpenTimer);
+      calendarOpenTimer = null;
+    }
+    calendarSelectedDate = null;
+    const modal = el("calendar-modal");
+    const box = modal.querySelector(".calendar-modal-box");
+    modal.classList.remove(
+      "calendar-closing",
+      "calendar-dragging",
+      "calendar-swipe-closing",
+      "calendar-opening",
+      "hidden",
+    );
+    modal.classList.add("calendar-opening");
+    calendarOpenTimer = window.setTimeout(finishCalendarOpening, 230);
+    modal.style.background = "";
+    box.style.transform = "";
+    box.style.transition = "";
+    el("calendar-details").classList.add("hidden");
+    modal.setAttribute("aria-hidden", "false");
+    lockBodyScroll();
+    renderCalendar();
+    await loadCalendarEvents();
+  }
+
+  function finishCalendarOpening() {
+    if (calendarOpenTimer !== null) {
+      clearTimeout(calendarOpenTimer);
+      calendarOpenTimer = null;
+    }
+    el("calendar-modal").classList.remove("calendar-opening");
+  }
+
+  function finishCalendarClose() {
+    const modal = el("calendar-modal");
+    const box = modal.querySelector(".calendar-modal-box");
+    modal.classList.remove(
+      "calendar-closing",
+      "calendar-dragging",
+      "calendar-swipe-closing",
+      "calendar-opening",
+    );
+    modal.classList.add("hidden");
+    modal.style.background = "";
+    box.style.transform = "";
+    box.style.transition = "";
+    modal.setAttribute("aria-hidden", "true");
+    calendarCloseTimer = null;
+    calendarOpenTimer = null;
+    unlockBodyScroll();
+  }
+
+  function closeCalendar(options = {}) {
+    if (!isCalendarOpen()) return;
+    const modal = el("calendar-modal");
+    if (modal.classList.contains("calendar-closing")) return;
+    const fromDrag = options && options.fromDrag === true;
+    finishCalendarOpening();
+    calendarRequestSeq += 1;
+    if (!mobileHubQuery.matches) {
+      finishCalendarClose();
+      return;
+    }
+    const box = modal.querySelector(".calendar-modal-box");
+    modal.classList.remove("calendar-dragging");
+    if (fromDrag) {
+      modal.classList.add("calendar-swipe-closing");
+      box.style.transition = "transform 220ms cubic-bezier(0.55, 0, 1, 0.45)";
+      window.requestAnimationFrame(() => {
+        box.style.transform = "translateY(100dvh)";
+      });
+    } else {
+      box.style.transform = "";
+      box.style.transition = "";
+    }
+    modal.classList.add("calendar-closing");
+    calendarCloseTimer = window.setTimeout(finishCalendarClose, 220);
+  }
+
+  async function loadCalendarEvents() {
+    const seq = ++calendarRequestSeq;
+    const range = calendarGridRange();
+    const query = new URLSearchParams({
+      start: calendarDateKey(range.start),
+      end: calendarDateKey(range.end),
+    });
+    try {
+      const payload = await api(`/api/calendar/events?${query}`);
+      if (seq !== calendarRequestSeq) return;
+      calendarEvents = Array.isArray(payload.events) ? payload.events : [];
+      const updated = String(payload.updated_at || "").trim();
+      el("calendar-updated").textContent = updated
+        ? `Updated ${new Date(updated).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}`
+        : "";
+      renderCalendar();
+    } catch (error) {
+      if (seq !== calendarRequestSeq) return;
+      calendarEvents = [];
+      el("calendar-updated").textContent = "Unavailable";
+      renderCalendar();
+    }
+  }
+
+  function renderCalendar() {
+    const title = calendarMonth.toLocaleDateString([], { year: "numeric", month: "long" });
+    el("calendar-month-title").textContent = title;
+
+    const byDate = new Map();
+    calendarEvents.forEach((event) => {
+      const key = String(event.date || "");
+      if (!byDate.has(key)) byDate.set(key, []);
+      byDate.get(key).push(event);
+    });
+
+    const range = calendarGridRange();
+    const todayKey = calendarDateKey(new Date());
+    const cells = [];
+    for (let offset = 0; offset < 42; offset++) {
+      const day = new Date(range.start);
+      day.setDate(day.getDate() + offset);
+      const key = calendarDateKey(day);
+      const events = byDate.get(key) || [];
+      const outside = day.getMonth() !== calendarMonth.getMonth();
+      const classes = [
+        "calendar-day",
+        outside ? "outside" : "",
+        key === todayKey ? "today" : "",
+        key === calendarSelectedDate ? "selected" : "",
+      ].filter(Boolean).join(" ");
+      const sessionIds = [...new Set(events.map((event) => String(event.session_id || "")))];
+      const dots = sessionIds.slice(0, 4).map((sessionId) => (
+        `<span class="calendar-event-dot" style="--event-color:${calendarSessionColor(sessionId)}"></span>`
+      )).join("");
+      const eventRow = events.length
+        ? `<span class="calendar-day-event-row">${dots}<span class="calendar-event-count">${events.length}</span></span>`
+        : "";
+      cells.push(
+        `<button class="${classes}" type="button" data-calendar-date="${key}" ` +
+        `aria-label="${esc(day.toLocaleDateString())}, ${events.length} events">` +
+        `<span class="calendar-day-number">${day.getDate()}</span>${eventRow}</button>`,
+      );
+    }
+    el("calendar-grid").innerHTML = cells.join("");
+    renderCalendarDetails();
+  }
+
+  function renderCalendarDetails() {
+    const section = el("calendar-details");
+    if (!calendarSelectedDate) {
+      section.classList.add("hidden");
+      return;
+    }
+    const selected = calendarDateFromKey(calendarSelectedDate);
+    el("calendar-detail-date").textContent = selected
+      ? selected.toLocaleDateString([], { weekday: "long", year: "numeric", month: "long", day: "numeric" })
+      : calendarSelectedDate;
+    const events = calendarEvents.filter((event) => event.date === calendarSelectedDate);
+    if (!events.length) {
+      el("calendar-detail-events").innerHTML = `<div class="calendar-empty-day">No events</div>`;
+      section.classList.remove("hidden");
+      return;
+    }
+    el("calendar-detail-events").innerHTML = events.map((event) => {
+      const sessionLabel = [
+        event.symbol || event.session_id,
+        String(event.exchange || "").toUpperCase(),
+        event.timeframe || "",
+      ].filter(Boolean).join(" · ");
+      const time = event.time
+        ? `<span class="calendar-event-time">${esc(event.time)}${event.timezone ? ` ${esc(event.timezone)}` : ""}</span>`
+        : "";
+      const details = event.details
+        ? `<div class="calendar-event-details">${esc(event.details)}</div>`
+        : "";
+      const source = event.source_url
+        ? `<a class="calendar-event-source" href="${esc(event.source_url)}" target="_blank" rel="noopener noreferrer">${esc(event.source_name || "Source")}</a>`
+        : "";
+      return `<article class="calendar-event-card" style="--event-color:${calendarSessionColor(event.session_id)}">` +
+        `<div class="calendar-event-session">${esc(sessionLabel)}</div>` +
+        `<div class="calendar-event-title">${esc(event.title || "Schedule")}${time}</div>` +
+        `${details}${source}</article>`;
+    }).join("");
+    section.classList.remove("hidden");
+  }
+
+  function moveCalendarMonth(delta, animate = false) {
+    calendarMonth = new Date(calendarMonth.getFullYear(), calendarMonth.getMonth() + delta, 1);
+    calendarSelectedDate = null;
+    calendarEvents = [];
+    renderCalendar();
+    if (animate) {
+      const grid = el("calendar-grid");
+      const className = delta > 0 ? "calendar-month-next" : "calendar-month-prev";
+      grid.classList.remove("calendar-month-next", "calendar-month-prev");
+      void grid.offsetWidth;
+      grid.classList.add(className);
+      window.setTimeout(() => grid.classList.remove(className), 190);
+    }
+    loadCalendarEvents();
+  }
+
+  function initMobileHubMenuSwipe() {
+    const menu = el("hub-menu");
+    const backdrop = el("hub-menu-backdrop");
+    let drag = null;
+    let suppressClickUntil = 0;
+
+    menu.addEventListener("pointerdown", (event) => {
+      if (!mobileHubQuery.matches || !menu.classList.contains("open") || !event.isPrimary) return;
+      drag = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        dx: 0,
+        axis: null,
+      };
+      try { menu.setPointerCapture(event.pointerId); } catch {}
+    });
+    menu.addEventListener("pointermove", (event) => {
+      if (!drag || event.pointerId !== drag.id) return;
+      const dx = event.clientX - drag.startX;
+      const dy = event.clientY - drag.startY;
+      if (!drag.axis) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) < 8) return;
+        drag.axis = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
+      }
+      if (drag.axis !== "x") return;
+      event.preventDefault();
+      drag.dx = Math.min(0, dx);
+      if (Math.abs(drag.dx) > 8) suppressClickUntil = Date.now() + 400;
+      const width = Math.max(1, menu.getBoundingClientRect().width);
+      menu.classList.add("dragging");
+      backdrop.classList.add("dragging");
+      menu.style.transform = `translateX(${drag.dx}px)`;
+      backdrop.style.opacity = String(Math.max(0, 1 - Math.abs(drag.dx) / width));
+    }, { passive: false });
+    function endMenuDrag(event, cancelled = false) {
+      if (!drag || (event && event.pointerId !== drag.id)) return;
+      const current = drag;
+      drag = null;
+      try { menu.releasePointerCapture(current.id); } catch {}
+      menu.classList.remove("dragging");
+      backdrop.classList.remove("dragging");
+      const shouldClose = !cancelled && current.axis === "x" && current.dx < -64;
+      if (shouldClose) {
+        closeHubMenu();
+        return;
+      }
+      menu.style.transform = current.axis === "x" ? "translateX(0)" : "";
+      backdrop.style.opacity = "";
+      window.setTimeout(() => {
+        if (!menu.classList.contains("open")) return;
+        menu.style.transform = "";
+      }, 190);
+    }
+    menu.addEventListener("pointerup", (event) => endMenuDrag(event));
+    menu.addEventListener("pointercancel", (event) => endMenuDrag(event, true));
+    menu.addEventListener("click", (event) => {
+      if (Date.now() >= suppressClickUntil) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }, true);
+  }
+
+  function initMobileCalendarGestures() {
+    const modal = el("calendar-modal");
+    const box = modal.querySelector(".calendar-modal-box");
+    const header = modal.querySelector(".calendar-modal-header");
+    const grid = el("calendar-grid");
+    let closeDrag = null;
+    let monthDrag = null;
+
+    header.addEventListener("pointerdown", (event) => {
+      if (!mobileHubQuery.matches || !event.isPrimary) return;
+      if (event.target && event.target.closest && event.target.closest("button")) return;
+      closeDrag = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        dy: 0,
+        active: false,
+      };
+      try { header.setPointerCapture(event.pointerId); } catch {}
+    });
+    header.addEventListener("pointermove", (event) => {
+      if (!closeDrag || event.pointerId !== closeDrag.id) return;
+      const dx = event.clientX - closeDrag.startX;
+      const dy = event.clientY - closeDrag.startY;
+      if (!closeDrag.active) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) < 8) return;
+        if (dy <= 0 || Math.abs(dy) <= Math.abs(dx)) {
+          closeDrag = null;
+          return;
+        }
+        closeDrag.active = true;
+        finishCalendarOpening();
+        modal.classList.add("calendar-dragging");
+      }
+      event.preventDefault();
+      closeDrag.dy = Math.max(0, dy);
+      box.style.transform = `translateY(${closeDrag.dy}px)`;
+    }, { passive: false });
+    function endCalendarCloseDrag(event, cancelled = false) {
+      if (!closeDrag || (event && event.pointerId !== closeDrag.id)) return;
+      const current = closeDrag;
+      closeDrag = null;
+      try { header.releasePointerCapture(current.id); } catch {}
+      modal.classList.remove("calendar-dragging");
+      if (!cancelled && current.active && current.dy > 100) {
+        closeCalendar({ fromDrag: true });
+        return;
+      }
+      if (!current.active) return;
+      box.style.transition = "transform 180ms ease";
+      box.style.transform = "translateY(0)";
+      window.setTimeout(() => {
+        if (!isCalendarOpen() || modal.classList.contains("calendar-closing")) return;
+        box.style.transition = "";
+        box.style.transform = "";
+      }, 190);
+    }
+    header.addEventListener("pointerup", (event) => endCalendarCloseDrag(event));
+    header.addEventListener("pointercancel", (event) => endCalendarCloseDrag(event, true));
+
+    grid.addEventListener("pointerdown", (event) => {
+      if (!mobileHubQuery.matches || !event.isPrimary) return;
+      monthDrag = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        dx: 0,
+        axis: null,
+      };
+    });
+    window.addEventListener("pointermove", (event) => {
+      if (!monthDrag || event.pointerId !== monthDrag.id) return;
+      const dx = event.clientX - monthDrag.startX;
+      const dy = event.clientY - monthDrag.startY;
+      if (!monthDrag.axis) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) < 8) return;
+        monthDrag.axis = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
+        if (monthDrag.axis === "x") {
+          try { grid.setPointerCapture(event.pointerId); } catch {}
+        }
+      }
+      if (monthDrag.axis !== "x") return;
+      event.preventDefault();
+      monthDrag.dx = dx;
+      calendarSuppressTapUntil = Date.now() + 500;
+    }, { passive: false });
+    function endMonthDrag(event) {
+      if (!monthDrag || (event && event.pointerId !== monthDrag.id)) return;
+      const current = monthDrag;
+      monthDrag = null;
+      try { grid.releasePointerCapture(current.id); } catch {}
+      if (current.axis !== "x" || Math.abs(current.dx) < 48) return;
+      moveCalendarMonth(current.dx < 0 ? 1 : -1, true);
+    }
+    window.addEventListener("pointerup", endMonthDrag);
+    window.addEventListener("pointercancel", endMonthDrag);
+    grid.addEventListener("click", (event) => {
+      if (Date.now() >= calendarSuppressTapUntil) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }, true);
+  }
+
+  function initHubMenuCalendar() {
+    const calendarModal = el("calendar-modal");
+    calendarModal.addEventListener("touchend", (event) => {
+      if (Date.now() < calendarSuppressTapUntil) {
+        lastCalendarTouchAt = 0;
+        event.preventDefault();
+        return;
+      }
+      const button = event.target && event.target.closest
+        ? event.target.closest("button")
+        : null;
+      if (!button || !calendarModal.contains(button)) return;
+
+      const now = Date.now();
+      const isDoubleTap = now - lastCalendarTouchAt < 360;
+      lastCalendarTouchAt = now;
+      if (!isDoubleTap) return;
+      event.preventDefault();
+      button.click();
+    }, { passive: false });
+
+    el("hub-menu-button").addEventListener("click", openHubMenu);
+    el("hub-menu-close").addEventListener("click", closeHubMenu);
+    el("hub-menu-backdrop").addEventListener("click", closeHubMenu);
+    el("hub-calendar-open").addEventListener("click", openCalendar);
+    el("calendar-close").addEventListener("click", closeCalendar);
+    calendarModal.addEventListener("click", (event) => {
+      if (event.target === calendarModal) closeCalendar();
+    });
+    el("calendar-prev").addEventListener("click", () => moveCalendarMonth(-1));
+    el("calendar-next").addEventListener("click", () => moveCalendarMonth(1));
+    el("calendar-today").addEventListener("click", () => {
+      const now = new Date();
+      calendarMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+      calendarSelectedDate = null;
+      calendarEvents = [];
+      renderCalendar();
+      loadCalendarEvents();
+    });
+    el("calendar-grid").addEventListener("click", (event) => {
+      const day = event.target && event.target.closest
+        ? event.target.closest("[data-calendar-date]")
+        : null;
+      if (!day) return;
+      calendarSelectedDate = day.dataset.calendarDate || null;
+      renderCalendar();
+    });
+    initMobileHubMenuSwipe();
+    initMobileCalendarGestures();
+  }
 
   function updateHubClock() {
     const clock = el("hub-clock");
@@ -2171,6 +2667,8 @@
 
   document.addEventListener("keydown", (e) => {
     if (e.key !== "Escape") return;
+    closeHubMenu();
+    if (isCalendarOpen()) closeCalendar();
     closeScriptDropdown();
     closeDataSinceTooltips();
     if (!el("log-modal").classList.contains("hidden")) closeLogs();
@@ -2498,6 +2996,8 @@
           syncAiChatState({ allowImport: false });
         } else if (msg.type === "ai_prefs_updated") {
           applyAiPrefs(msg.model, msg.effort);
+        } else if (msg.type === "calendar_updated") {
+          if (isCalendarOpen()) loadCalendarEvents();
         }
       } catch {}
     };
@@ -2541,6 +3041,7 @@
   });
   window.addEventListener("online", rebuildHub);
 
+  initHubMenuCalendar();
   initSessionReordering();
   initDesktopCardCarousel();
   initAiChat();

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -23,14 +23,68 @@
   ];
   let calendarMonth = new Date(new Date().getFullYear(), new Date().getMonth(), 1);
   let calendarEvents = [];
+  const calendarForecastStates = new Map();
   let calendarSelectedDate = null;
   let calendarRequestSeq = 0;
   let lastCalendarTouchAt = 0;
   let calendarSuppressTapUntil = 0;
   let calendarOpenTimer = null;
   let calendarCloseTimer = null;
+  let registerAnimatedPepeFace = () => {};
 
   const el = (id) => document.getElementById(id);
+
+  function calendarForecastState(event) {
+    const eventId = String(event && event.id || "");
+    let state = calendarForecastStates.get(eventId);
+    if (!state) {
+      state = {
+        status: "idle",
+        answer: "",
+        html: "",
+        updatedAt: "",
+        error: "",
+        open: false,
+        viewed: false,
+      };
+      calendarForecastStates.set(eventId, state);
+    }
+    return state;
+  }
+
+  function reconcileCalendarForecasts(events) {
+    for (const event of events) {
+      const state = calendarForecastState(event);
+      // Protect only THIS client's in-flight regeneration; a "running" state
+      // set from a peer's broadcast must still be updated once the peer is done.
+      if (state.localStream) continue;
+      if (event && event.forecast_running) {
+        state.status = "running";
+        state.open = false;
+        state.viewed = false;
+        continue;
+      }
+      const forecast = event && event.forecast;
+      if (!forecast || typeof forecast !== "object") {
+        // no server forecast: clear a stale remote "running" back to idle so a
+        // failed peer regeneration doesn't leave Pepe spinning forever
+        if (state.status === "running") {
+          state.status = "idle";
+          state.open = false;
+        }
+        continue;
+      }
+      const updatedAt = String(forecast.updated_at || "");
+      const changed = state.updatedAt !== updatedAt;
+      state.status = "ready";
+      state.answer = String(forecast.answer || "");
+      state.html = String(forecast.html || "");
+      state.updatedAt = updatedAt;
+      state.error = "";
+      state.viewed = Boolean(forecast.viewed_at);
+      if (changed) state.open = false;
+    }
+  }
 
   function calendarDateKey(value) {
     const d = value instanceof Date ? value : new Date(value);
@@ -187,6 +241,7 @@
       const payload = await api(`/api/calendar/events?${query}`);
       if (seq !== calendarRequestSeq) return;
       calendarEvents = Array.isArray(payload.events) ? payload.events : [];
+      reconcileCalendarForecasts(calendarEvents);
       const updated = String(payload.updated_at || "").trim();
       el("calendar-updated").textContent = updated
         ? `Updated ${new Date(updated).toLocaleString([], { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}`
@@ -260,6 +315,7 @@
       return;
     }
     el("calendar-detail-events").innerHTML = events.map((event) => {
+      const forecastState = calendarForecastState(event);
       const sessionLabel = [
         event.symbol || event.session_id,
         String(event.exchange || "").toUpperCase(),
@@ -274,12 +330,204 @@
       const source = event.source_url
         ? `<a class="calendar-event-source" href="${esc(event.source_url)}" target="_blank" rel="noopener noreferrer">${esc(event.source_name || "Source")}</a>`
         : "";
-      return `<article class="calendar-event-card" style="--event-color:${calendarSessionColor(event.session_id)}">` +
+      const forecastClasses = [
+        "calendar-forecast-pepe",
+        forecastState.status === "running" ? "forecast-running" : "",
+        forecastState.status === "ready" && !forecastState.viewed ? "forecast-unread" : "",
+      ].filter(Boolean).join(" ");
+      const forecastLabel = forecastState.status === "running"
+        ? `${event.title} forecast in progress`
+        : forecastState.status === "ready"
+          ? `Open ${event.title} forecast`
+          : `Forecast ${event.title}`;
+      // ready-but-not-open: a tiny "alien speech" bubble signals Pepe has a
+      // forecast to say. It shakes with the button while unread and stays put
+      // (no shake) once viewed; hidden while the full bubble is open.
+      const forecastSay = (forecastState.status === "ready" && !forecastState.open)
+        ? `<span class="pepe-say" aria-hidden="true">&#x2827;&#x2837;&#x282e;</span>`
+        : "";
+      const forecastButton = `<button class="${forecastClasses}" type="button" ` +
+        `data-calendar-forecast-event="${esc(event.id)}" aria-label="${esc(forecastLabel)}" ` +
+        `title="${esc(forecastLabel)}" ` +
+        `${forecastState.status === "running" ? 'aria-busy="true"' : ""} ` +
+        `${aiEnabled ? "" : "disabled"}>${forecastSay}</button>`;
+      let forecastBubble = "";
+      if (forecastState.open && ["ready", "error"].includes(forecastState.status)) {
+        const content = forecastState.status === "error"
+          ? `<div class="calendar-forecast-error">${esc(forecastState.error)}</div>`
+          : `<div class="calendar-forecast-content ai-msg-markdown">` +
+            `${forecastState.html || `<p>${esc(forecastState.answer)}</p>`}</div>`;
+        forecastBubble = `<aside class="calendar-forecast-bubble" role="status">` +
+          `<div class="calendar-forecast-bubble-header"><span>AI Forecast</span>` +
+          `<button class="calendar-forecast-refresh" type="button" ` +
+          `data-calendar-forecast-refresh="${esc(event.id)}" title="Refresh forecast" ` +
+          `aria-label="Refresh ${esc(event.title)} forecast">` +
+          `<svg viewBox="0 0 24 24" aria-hidden="true">` +
+          `<path d="M3 12a9 9 0 0 1 15.7-6L21 8"></path><path d="M21 3v5h-5"></path>` +
+          `<path d="M21 12a9 9 0 0 1-15.7 6L3 16"></path><path d="M3 21v-5h5"></path>` +
+          `</svg></button></div>` +
+          `${content}</aside>`;
+      }
+      return `<article class="calendar-event-card has-forecast" style="--event-color:${calendarSessionColor(event.session_id)}">` +
+        `${forecastButton}` +
         `<div class="calendar-event-session">${esc(sessionLabel)}</div>` +
         `<div class="calendar-event-title">${esc(event.title || "Schedule")}${time}</div>` +
-        `${details}${source}</article>`;
+        `${details}${source}${forecastBubble}</article>`;
     }).join("");
+    hydrateCalendarForecastCards();
     section.classList.remove("hidden");
+  }
+
+  function hydrateCalendarForecastCards() {
+    const template = el("ai-chat-fab").querySelector("svg.pepe");
+    if (!template) return;
+    for (const button of el("calendar-detail-events").querySelectorAll(".calendar-forecast-pepe")) {
+      if (button.querySelector("svg.pepe")) continue;
+      const face = template.cloneNode(true);
+      face.classList.remove("pepe-blink");
+      for (const pupil of face.querySelectorAll(".pepe-pupil")) {
+        pupil.removeAttribute("transform");
+      }
+      button.appendChild(face);
+      registerAnimatedPepeFace(face);
+    }
+    for (const link of el("calendar-detail-events").querySelectorAll(".calendar-forecast-content a")) {
+      link.target = "_blank";
+      link.rel = "noopener noreferrer";
+    }
+    fitCalendarForecastBubbles();
+  }
+
+  function fitCalendarForecastBubbles() {
+    const bubbles = document.querySelectorAll(".calendar-forecast-bubble");
+    for (const bubble of bubbles) {
+      const content = bubble.querySelector(".calendar-forecast-content, .calendar-forecast-error");
+      if (content) content.style.maxHeight = "";
+    }
+    if (!mobileHubQuery.matches || !bubbles.length) return;
+
+    const header = el("calendar-modal").querySelector(".calendar-modal-header");
+    if (!header) return;
+    const safeTop = header.getBoundingClientRect().bottom + 8;
+    const viewportHeight = window.visualViewport
+      ? window.visualViewport.height
+      : window.innerHeight;
+    const cssLimit = Math.min(350, viewportHeight * 0.48);
+
+    for (const bubble of bubbles) {
+      const content = bubble.querySelector(".calendar-forecast-content, .calendar-forecast-error");
+      if (!content) continue;
+      const bubbleRect = bubble.getBoundingClientRect();
+      const contentRect = content.getBoundingClientRect();
+      const bubbleChrome = bubbleRect.height - contentRect.height;
+      const available = Math.floor(bubbleRect.bottom - safeTop - bubbleChrome);
+      content.style.maxHeight = `${Math.max(60, Math.min(cssLimit, available))}px`;
+    }
+  }
+
+  function markCalendarForecastViewed(eventId, state) {
+    state.viewed = true;
+    const updatedAt = state.updatedAt;
+    api(`/api/calendar/events/${encodeURIComponent(eventId)}/forecast/viewed`, {
+      method: "POST",
+    }).catch(() => {
+      if (state.updatedAt !== updatedAt) return;
+      state.viewed = false;
+      if (isCalendarOpen() && calendarSelectedDate) renderCalendarDetails();
+    });
+  }
+
+  async function requestCalendarForecast(event) {
+    const state = calendarForecastState(event);
+    if (!aiEnabled || state.status === "running") return;
+    state.status = "running";
+    state.localStream = true; // this client owns the stream; reconcile must not clobber it
+    state.error = "";
+    state.open = false;
+    state.viewed = false;
+    renderCalendarDetails();
+
+    let completed = false;
+    let streamError = "";
+    try {
+      await streamSse(`/api/calendar/events/${encodeURIComponent(event.id)}/forecast`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "{}",
+      }, (eventName, data) => {
+        if (eventName === "stream_error") {
+          streamError = String(data.error || "Calendar forecast failed");
+          return;
+        }
+        if (eventName !== "done") return;
+        completed = true;
+        state.status = "ready";
+        state.answer = String(data.answer || "");
+        state.html = String(data.html || "");
+        state.updatedAt = String(data.updated_at || "");
+        state.error = "";
+        state.open = false;
+        state.viewed = false;
+        renderCalendarDetails();
+      });
+      if (streamError) throw new Error(streamError);
+      if (!completed) throw new Error("AI forecast ended without a response");
+    } catch (error) {
+      state.status = "error";
+      state.error = error && error.message ? error.message : "Calendar forecast failed";
+      state.open = true;
+      state.viewed = true;
+      renderCalendarDetails();
+    } finally {
+      state.localStream = false;
+      if (isCalendarOpen()) loadCalendarEvents();
+    }
+  }
+
+  // A peer started regenerating this event's forecast: mirror the running
+  // (eye-roll) state so every open dashboard shows it, not the stale answer.
+  function applyCalendarForecastRunning(eventId) {
+    const state = calendarForecastState({ id: eventId });
+    if (state.localStream || state.status === "running") return;
+    state.status = "running";
+    state.open = false;
+    if (isCalendarOpen() && calendarSelectedDate) renderCalendarDetails();
+  }
+
+  function toggleCalendarForecast(event) {
+    const state = calendarForecastState(event);
+    if (state.status === "running") return;
+    if (state.status === "idle") {
+      requestCalendarForecast(event);
+      return;
+    }
+    const shouldOpen = !state.open;
+    for (const other of calendarForecastStates.values()) other.open = false;
+    state.open = shouldOpen;
+    if (shouldOpen && state.status === "ready") {
+      markCalendarForecastViewed(event.id, state);
+    }
+    renderCalendarDetails();
+  }
+
+  function closeCalendarForecastBubbles() {
+    let changed = false;
+    for (const state of calendarForecastStates.values()) {
+      if (!state.open) continue;
+      state.open = false;
+      changed = true;
+    }
+    if (!changed) return;
+    // re-render so the small "say" bubble returns on the now-closed cards; just
+    // removing the big-bubble DOM would leave pepe-say missing until the next
+    // full render (that mismatch is the toggle-vs-outside-click difference)
+    if (isCalendarOpen() && calendarSelectedDate) {
+      renderCalendarDetails();
+    } else {
+      for (const bubble of document.querySelectorAll(".calendar-forecast-bubble")) {
+        bubble.remove();
+      }
+    }
   }
 
   function moveCalendarMonth(delta, animate = false) {
@@ -511,6 +759,34 @@
       calendarSelectedDate = day.dataset.calendarDate || null;
       renderCalendar();
     });
+    el("calendar-detail-events").addEventListener("click", (event) => {
+      const refresh = event.target && event.target.closest
+        ? event.target.closest("[data-calendar-forecast-refresh]")
+        : null;
+      const forecastButton = event.target && event.target.closest
+        ? event.target.closest("[data-calendar-forecast-event]")
+        : null;
+      const eventId = refresh
+        ? refresh.dataset.calendarForecastRefresh
+        : forecastButton && forecastButton.dataset.calendarForecastEvent;
+      if (!eventId) return;
+      const calendarEvent = calendarEvents.find((item) => item.id === eventId);
+      if (!calendarEvent) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (refresh) requestCalendarForecast(calendarEvent);
+      else toggleCalendarForecast(calendarEvent);
+    });
+    document.addEventListener("pointerdown", (event) => {
+      if (!isCalendarOpen()) return;
+      const target = event.target && event.target.closest ? event.target : null;
+      if (target && target.closest(".calendar-forecast-bubble, [data-calendar-forecast-event]")) return;
+      closeCalendarForecastBubbles();
+    }, { passive: true });
+    window.addEventListener("resize", fitCalendarForecastBubbles, { passive: true });
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener("resize", fitCalendarForecastBubbles, { passive: true });
+    }
     initMobileHubMenuSwipe();
     initMobileCalendarGestures();
   }
@@ -1287,6 +1563,7 @@
     if (aiEnabled && reclampAiFab) reclampAiFab();
     if (aiEnabled) loadAiModels();
     if (!aiEnabled && isAiChatOpen()) closeAiChat();
+    if (isCalendarOpen() && calendarSelectedDate) renderCalendarDetails();
   }
 
   function aiEffortLabel(value) {
@@ -2133,36 +2410,51 @@
   // ---- Pepe faces: random blink + pupils that follow the pointer -----------
   function initPepeFaces() {
     if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
-    const faces = Array.from(document.querySelectorAll("svg.pepe")).map((svg) => ({
-      svg,
-      pupils: Array.from(svg.querySelectorAll(".pepe-pupil")).map((node) => ({
-        node,
-        cx: parseFloat(node.getAttribute("cx")),
-        cy: parseFloat(node.getAttribute("cy")),
-      })),
-    }));
-    if (!faces.length) return;
+    const faces = new Map();
 
-    function blinkOnce(svg, done) {
-      svg.classList.add("pepe-blink");
+    function registerFace(svg) {
+      if (!svg || faces.has(svg)) return;
+      const face = {
+        svg,
+        pupils: Array.from(svg.querySelectorAll(".pepe-pupil")).map((node) => ({
+          node,
+          cx: parseFloat(node.getAttribute("cx")),
+          cy: parseFloat(node.getAttribute("cy")),
+        })),
+      };
+      faces.set(svg, face);
+      scheduleBlink(face);
+    }
+    registerAnimatedPepeFace = registerFace;
+
+    function blinkOnce(face, done) {
+      if (!face.svg.isConnected || face.svg.closest(".forecast-running")) {
+        done();
+        return;
+      }
+      face.svg.classList.add("pepe-blink");
       setTimeout(() => {
-        svg.classList.remove("pepe-blink");
+        face.svg.classList.remove("pepe-blink");
         done();
       }, 130);
     }
-    function scheduleBlink(svg) {
+    function scheduleBlink(face) {
       setTimeout(() => {
-        blinkOnce(svg, () => {
+        if (!face.svg.isConnected) {
+          faces.delete(face.svg);
+          return;
+        }
+        blinkOnce(face, () => {
           // occasional quick double blink reads more lifelike than a fixed beat
           if (Math.random() < 0.2) {
-            setTimeout(() => blinkOnce(svg, () => scheduleBlink(svg)), 150);
+            setTimeout(() => blinkOnce(face, () => scheduleBlink(face)), 150);
           } else {
-            scheduleBlink(svg);
+            scheduleBlink(face);
           }
         });
       }, 2200 + Math.random() * 4300);
     }
-    faces.forEach((f) => scheduleBlink(f.svg));
+    document.querySelectorAll("svg.pepe").forEach(registerFace);
 
     const PEPE_VIEWBOX = 64;
     // pupil travel in viewBox units, asymmetric so it stays on the eye white
@@ -2171,7 +2463,12 @@
     const RANGE_Y_UP = 1;
     const RANGE_Y_DOWN = 1.2;
     function lookAt(clientX, clientY) {
-      for (const face of faces) {
+      for (const [svg, face] of faces) {
+        if (!svg.isConnected) {
+          faces.delete(svg);
+          continue;
+        }
+        if (svg.closest(".forecast-running")) continue;
         const rect = face.svg.getBoundingClientRect();
         if (!rect.width) continue; // hidden (chat panel closed)
         const scale = rect.width / PEPE_VIEWBOX;
@@ -2997,6 +3294,10 @@
         } else if (msg.type === "ai_prefs_updated") {
           applyAiPrefs(msg.model, msg.effort);
         } else if (msg.type === "calendar_updated") {
+          if (isCalendarOpen()) loadCalendarEvents();
+        } else if (msg.type === "calendar_forecast_running") {
+          if (isCalendarOpen()) applyCalendarForecastRunning(String(msg.event_id || ""));
+        } else if (msg.type === "calendar_forecast_updated") {
           if (isCalendarOpen()) loadCalendarEvents();
         }
       } catch {}

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -44,6 +44,8 @@ SUPPRESS_EXTERNAL_NOTIFICATIONS: bool = False
 DEFAULT_WEBHOOK_REQUEST_TIMEOUT = (5, 10)
 HYPERLIQUID_WEBHOOK_REQUEST_TIMEOUT = (5, 30)
 TELEGRAM_REQUEST_TIMEOUT = (5, 10)
+TELEGRAM_CONNECT_ATTEMPTS = 3
+TELEGRAM_CONNECT_RETRY_DELAYS = (1, 2)
 
 # Event queue for trade events
 trade_event_queue = deque()
@@ -132,7 +134,34 @@ def send_webhook_message(webhook_url: str, message: str, *, script_title: str | 
     import json
     import re
     import datetime
+    import time
     import requests
+
+    def is_connection_stage_error(error: BaseException) -> bool:
+        pending: list[BaseException] = [error]
+        seen: set[int] = set()
+        while pending:
+            current = pending.pop()
+            if id(current) in seen:
+                continue
+            seen.add(id(current))
+            if isinstance(current, requests.exceptions.ConnectTimeout):
+                return True
+            if type(current).__name__ in {
+                "ConnectTimeoutError",
+                "NameResolutionError",
+                "NewConnectionError",
+            }:
+                return True
+            for related in (
+                current.__cause__,
+                current.__context__,
+                getattr(current, "reason", None),
+            ):
+                if isinstance(related, BaseException):
+                    pending.append(related)
+            pending.extend(arg for arg in current.args if isinstance(arg, BaseException))
+        return False
 
     # Wrap unquoted message fields so JSON parsing succeeds.
     s = re.sub(r'"message"\s*:\s*(?![{["0-9])([A-Za-z][A-Za-z0-9 ]*)',
@@ -183,12 +212,22 @@ def send_webhook_message(webhook_url: str, message: str, *, script_title: str | 
             ),
             # "parse_mode": "Markdown"  # 굵게/이탤릭 등 쓰고 싶으면 선택
         }
-        try:
-            response = requests.get(url, params=payload, timeout=TELEGRAM_REQUEST_TIMEOUT)
-            response.raise_for_status()
-            print("Telegram response:", response.json())
-        except Exception as e:
-            print(f"Telegram notification error: {e}")
+        for attempt in range(1, TELEGRAM_CONNECT_ATTEMPTS + 1):
+            try:
+                response = requests.get(url, params=payload, timeout=TELEGRAM_REQUEST_TIMEOUT)
+                response.raise_for_status()
+                print("Telegram response:", response.json())
+                break
+            except Exception as e:
+                if not is_connection_stage_error(e) or attempt == TELEGRAM_CONNECT_ATTEMPTS:
+                    print(f"Telegram notification error: {e}")
+                    break
+                delay = TELEGRAM_CONNECT_RETRY_DELAYS[attempt - 1]
+                print(
+                    f"Telegram connection error: {e}; "
+                    f"retrying in {delay}s ({attempt}/{TELEGRAM_CONNECT_ATTEMPTS})"
+                )
+                time.sleep(delay)
 
 
 def clear_local_state() -> None:


### PR DESCRIPTION
## 개요

Hub에서 활성 세션의 주요 일정을 관리하고, 일정별 AI 전망을 바로 요청할 수 있는 캘린더 기능을 추가합니다.

## 주요 변경사항

### 세션 일정 캘린더

- PyneReal Hub 제목 왼쪽에 메뉴 버튼과 Calendar 화면을 추가했습니다.
- 활성 세션별 일정을 월간 달력과 일자별 상세 카드로 표시합니다.
- 모바일에서 메뉴·캘린더 스와이프 닫기와 좌우 월 이동을 지원합니다.
- 일정은 `workdir/config/calendar_events.json`에 저장되며 데스크톱과 모바일에서 공유됩니다.

### AI 일정 관리

- `get_calendar_context`, `replace_calendar_events` 전용 도구와 일정 갱신 워크플로를 추가했습니다.
- 사용자가 일정 확인·갱신을 요청하면 활성 세션을 자연어 심볼 및 회사명과 연결해 조사하도록 AI 지침을 보완했습니다.
- 일정 범위 교체는 세션별로 원자적으로 저장하고 삭제된 일정의 관련 전망 데이터도 함께 정리합니다.

### 일정별 AI 전망

- 일정 카드의 페페를 누르면 메인 채팅과 분리된 읽기 전용 AI 전망을 SSE로 실행합니다.
- 완료된 Markdown 응답을 이벤트별로 저장하고 말풍선에서 확인하거나 새로고침할 수 있습니다.
- 분석 중 눈동자 회전, 미확인 응답 흔들림과 작은 말풍선, 평상시 눈 깜빡임과 마우스 추적을 적용했습니다.
- 분석 중·완료·확인 상태를 서버와 Hub WebSocket으로 공유해 여러 브라우저에서 동일하게 표시합니다.
- 긴 응답은 말풍선 내부 스크롤로 표시하고 모바일에서는 캘린더 헤더와 겹치지 않도록 높이를 자동 조정합니다.
- 말풍선 외부 클릭 및 터치로 응답을 닫을 수 있습니다.

### Telegram 안정성

- 일반 전략 알림 전송 중 신규 연결 단계 오류가 발생하면 총 3회까지 재시도합니다.
- HTTP 오류와 read timeout은 재시도하지 않으며 기존 Webhook 전송 로직은 유지합니다.

## 운영 참고

- 캘린더 API와 저장소 초기화가 추가되어 적용 시 data-service 재시작이 필요합니다.
- Telegram 재시도 변경은 새로 시작하거나 재시작한 runner부터 적용됩니다.