### PR TITLE
자산 포트폴리오 조회 및 거래소 계정 간 전송 기능 추가

### DIFF
--- a/ai/scripts/asset.py
+++ b/ai/scripts/asset.py
@@ -683,10 +683,6 @@ def collect_account_type(
     secrets: list[str],
     args: argparse.Namespace,
 ) -> dict[str, Any]:
-    eprint(
-        f"[asset] collecting account={account_name} exchange={exchange_id} "
-        f"account_type={account_type}"
-    )
     try:
         balance, source = fetch_account_type_balance(
             exchange,

--- a/ai/scripts/asset.py
+++ b/ai/scripts/asset.py
@@ -310,6 +310,18 @@ def build_exchange(
     return exchange
 
 
+def apply_cached_markets(
+    exchange: ccxt.Exchange,
+    market_source: ccxt.Exchange,
+) -> None:
+    helpers = market_source.options.get("marketHelperProps", [])
+    if isinstance(helpers, list):
+        for helper in helpers:
+            if isinstance(helper, str):
+                market_source.options.setdefault(helper, None)
+    exchange.set_markets_from_exchange(market_source)
+
+
 def number_or_none(value: Any) -> int | float | None:
     if isinstance(value, bool) or value is None:
         return None
@@ -406,6 +418,12 @@ def retry_read(
         ):
             raise
         except ccxt.BaseError as exc:
+            message = str(exc).lower()
+            if (
+                ("50021" in message and "margin trading account does not exist" in message)
+                or ("40068" in message and "disable subaccount access" in message)
+            ):
+                raise
             if attempt >= attempts:
                 raise
             delay = min(2 ** (attempt - 1), 4)
@@ -720,6 +738,7 @@ def collect_account(
     account: ExchangeAccount,
     account_types: list[str],
     args: argparse.Namespace,
+    market_source: ccxt.Exchange | None = None,
 ) -> list[dict[str, Any]]:
     secrets = secret_values(account.config)
     supported = [
@@ -738,6 +757,14 @@ def collect_account(
                 args.timeout_ms,
                 None,
             )
+            if market_source is not None:
+                try:
+                    apply_cached_markets(exchange, market_source)
+                except Exception as exc:
+                    eprint(
+                        f"[asset] {account.exchange_id} cached markets unavailable: "
+                        f"{type(exc).__name__}; loading markets on demand"
+                    )
         except Exception as exc:
             build_error = exc
 

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -20,6 +20,7 @@ from pynecore.core.csv_file import CSVReader
 import ccxt.pro as ccxtpro
 
 from ai.provider.codex_service import CodexService
+from asset_portfolio import AssetPortfolioError, AssetPortfolioService
 from calendar_store import CalendarEventStore, CalendarStoreError
 from registry import (
     HistoryNotReadyError,
@@ -621,9 +622,18 @@ def build_control_router(
     registry: SessionRegistry,
     codex_service: CodexService,
     calendar_store: CalendarEventStore,
+    asset_portfolio_service: AssetPortfolioService,
 ) -> APIRouter:
     r = APIRouter()
     calendar_forecast_runs: dict[str, int] = {}
+
+    @r.get("/api/assets")
+    async def get_assets(refresh: bool = False) -> JSONResponse:
+        try:
+            result = await asset_portfolio_service.snapshot(force=refresh)
+        except AssetPortfolioError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
 
     @r.get("/api/ai/chat")
     async def get_ai_chat() -> JSONResponse:

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -21,6 +21,7 @@ import ccxt.pro as ccxtpro
 
 from ai.provider.codex_service import CodexService
 from asset_portfolio import AssetPortfolioError, AssetPortfolioService
+from asset_transfer import AssetTransferError, AssetTransferService
 from calendar_store import CalendarEventStore, CalendarStoreError
 from registry import (
     HistoryNotReadyError,
@@ -623,6 +624,7 @@ def build_control_router(
     codex_service: CodexService,
     calendar_store: CalendarEventStore,
     asset_portfolio_service: AssetPortfolioService,
+    asset_transfer_service: AssetTransferService,
 ) -> APIRouter:
     r = APIRouter()
     calendar_forecast_runs: dict[str, int] = {}
@@ -633,6 +635,37 @@ def build_control_router(
             result = await asset_portfolio_service.snapshot(force=refresh)
         except AssetPortfolioError as exc:
             return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
+    @r.get("/api/assets/transfer/options")
+    async def get_asset_transfer_options(
+        exchange: str,
+        account: str,
+        source: str,
+    ) -> JSONResponse:
+        try:
+            result = await asset_transfer_service.options(exchange, account, source)
+        except AssetTransferError as exc:
+            return JSONResponse(
+                {"error": str(exc), **exc.details},
+                status_code=exc.status_code,
+            )
+        return JSONResponse(result)
+
+    @r.post("/api/assets/transfer")
+    async def execute_asset_transfer(
+        payload: dict = Body(default_factory=dict),
+    ) -> JSONResponse:
+        try:
+            result = await asset_transfer_service.execute(payload)
+        except AssetTransferError as exc:
+            if exc.details.get("status") in {"partial", "unknown"}:
+                await asset_portfolio_service.invalidate()
+            return JSONResponse(
+                {"error": str(exc), **exc.details},
+                status_code=exc.status_code,
+            )
+        await asset_portfolio_service.invalidate()
         return JSONResponse(result)
 
     @r.get("/api/ai/chat")

--- a/data_service/asset_portfolio.py
+++ b/data_service/asset_portfolio.py
@@ -1,0 +1,774 @@
+from __future__ import annotations
+
+import argparse
+import asyncio
+import copy
+import math
+import threading
+import time
+from collections import defaultdict
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import ccxt
+
+from ai.scripts.asset import (
+    DEFAULT_ACCOUNT_TYPES,
+    ExchangeAccount,
+    apply_cached_markets,
+    collect_account,
+    configured_accounts,
+    number_or_none,
+    read_provider_config,
+    remove_binance_earn_receipts,
+)
+
+
+_LOCAL_QUOTES = {
+    "bithumb": "KRW",
+    "coinone": "KRW",
+    "korbit": "KRW",
+    "upbit": "KRW",
+}
+_USD_QUOTES = {
+    "BUSD",
+    "DAI",
+    "FDUSD",
+    "PYUSD",
+    "TUSD",
+    "USD",
+    "USDC",
+    "USDP",
+    "USDT",
+}
+_SPOT_ONLY_EXCHANGES = {"bithumb", "coinone", "korbit", "upbit"}
+_UNIFIED_TRADING_EXCHANGES = {"bybit", "okx"}
+_MARKET_REFRESH_INTERVAL_SECONDS = 30 * 60
+
+
+class AssetPortfolioError(RuntimeError):
+    pass
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _finite(value: Any, default: float = 0.0) -> float:
+    parsed = number_or_none(value)
+    return float(parsed) if parsed is not None else default
+
+
+def _quote_currency(exchange_id: str) -> str:
+    if exchange_id == "hyperliquid":
+        return "USDC"
+    return _LOCAL_QUOTES.get(exchange_id, "USDT")
+
+
+def _asset_amount(asset: dict[str, Any]) -> float:
+    total = number_or_none(asset.get("total"))
+    if total is None:
+        total = _finite(asset.get("free")) + _finite(asset.get("used"))
+    return float(total) - _finite(asset.get("debt"))
+
+
+def _aggregate_account_results(
+    results: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    holdings: dict[str, dict[str, Any]] = {}
+    statuses: list[dict[str, Any]] = []
+
+    for result in results:
+        status = str(result.get("status") or "error")
+        account_type = str(result.get("account_type") or "unknown")
+        status_item: dict[str, Any] = {
+            "account_type": account_type,
+            "status": status,
+        }
+        error = result.get("error")
+        if isinstance(error, dict) and error.get("message"):
+            status_item["message"] = str(error["message"])[:300]
+        statuses.append(status_item)
+        if status != "ok":
+            continue
+
+        assets = result.get("assets")
+        if not isinstance(assets, list):
+            continue
+        for asset in assets:
+            if not isinstance(asset, dict):
+                continue
+            currency = str(asset.get("currency") or "").strip().upper()
+            if not currency:
+                continue
+            item = holdings.setdefault(
+                currency,
+                {
+                    "currency": currency,
+                    "amount": 0.0,
+                    "free": 0.0,
+                    "used": 0.0,
+                    "debt": 0.0,
+                    "account_types": set(),
+                },
+            )
+            item["amount"] += _asset_amount(asset)
+            item["free"] += _finite(asset.get("free"))
+            item["used"] += _finite(asset.get("used"))
+            item["debt"] += _finite(asset.get("debt"))
+            item["account_types"].add(account_type)
+
+    normalized: list[dict[str, Any]] = []
+    for item in holdings.values():
+        if item["amount"] <= 0:
+            continue
+        item["account_types"] = sorted(item["account_types"])
+        normalized.append(item)
+    normalized.sort(key=lambda item: (-item["amount"], item["currency"]))
+    return normalized, statuses
+
+
+def _portfolio_account_types(exchange_id: str) -> list[str]:
+    if exchange_id in _SPOT_ONLY_EXCHANGES:
+        return ["spot"]
+    if exchange_id == "okx":
+        return ["spot", "funding"]
+    return list(DEFAULT_ACCOUNT_TYPES)
+
+
+def _deduplicate_unified_trading_results(
+    exchange_id: str,
+    results: list[dict[str, Any]],
+) -> None:
+    if exchange_id not in _UNIFIED_TRADING_EXCHANGES:
+        return
+    primary = next(
+        (
+            result
+            for result in results
+            if result.get("account_type") in {"spot", "swap", "margin"}
+            and result.get("status") == "ok"
+        ),
+        None,
+    )
+    if primary is None:
+        return
+    primary_type = str(primary.get("account_type"))
+    for result in results:
+        if result is primary:
+            continue
+        if (
+            result.get("account_type") in {"spot", "swap", "margin"}
+            and result.get("status") == "ok"
+        ):
+            result["status"] = "duplicate"
+            result["assets"] = []
+            result["asset_count"] = 0
+            result["duplicate_of"] = primary_type
+
+
+def _market_rank(market: dict[str, Any]) -> tuple[int, int, str]:
+    if market.get("spot"):
+        market_type = 0
+    elif market.get("linear"):
+        market_type = 1
+    else:
+        market_type = 2
+    return (
+        1 if market.get("active") is False else 0,
+        market_type,
+        str(market.get("symbol") or ""),
+    )
+
+
+def _find_market(
+    markets: dict[str, dict[str, Any]],
+    base: str,
+    quote: str,
+) -> dict[str, Any] | None:
+    matches = [
+        market
+        for market in markets.values()
+        if str(market.get("base") or "").upper() == base
+        and str(market.get("quote") or "").upper() == quote
+    ]
+    return min(matches, key=_market_rank) if matches else None
+
+
+def _ticker_price(ticker: Any) -> float | None:
+    if not isinstance(ticker, dict):
+        return None
+    for field in ("last", "close"):
+        value = number_or_none(ticker.get(field))
+        if value is not None and value > 0:
+            return float(value)
+    bid = number_or_none(ticker.get("bid"))
+    ask = number_or_none(ticker.get("ask"))
+    if bid is not None and ask is not None and bid > 0 and ask > 0:
+        return (float(bid) + float(ask)) / 2
+    return None
+
+
+def _fetch_symbol_prices(
+    exchange: ccxt.Exchange,
+    symbols: set[str],
+    params: dict[str, Any] | None = None,
+) -> dict[str, float]:
+    if not symbols:
+        return {}
+
+    request_params = params or {}
+    prices: dict[str, float] = {}
+    if exchange.has.get("fetchTickers"):
+        try:
+            tickers = exchange.fetch_tickers(sorted(symbols), request_params)
+            if isinstance(tickers, dict):
+                for symbol, ticker in tickers.items():
+                    price = _ticker_price(ticker)
+                    if price is not None:
+                        prices[str(symbol)] = price
+        except Exception:
+            pass
+
+    missing = symbols - set(prices)
+    if exchange.has.get("fetchTicker"):
+        for symbol in sorted(missing):
+            try:
+                price = _ticker_price(exchange.fetch_ticker(symbol, request_params))
+            except Exception:
+                continue
+            if price is not None:
+                prices[symbol] = price
+    return prices
+
+
+def _market_context_price(market: dict[str, Any]) -> float | None:
+    info = market.get("info")
+    if not isinstance(info, dict):
+        return None
+    for field in ("midPx", "markPx", "last", "close"):
+        value = number_or_none(info.get(field))
+        if value is not None and value > 0:
+            return float(value)
+    return None
+
+
+def _build_public_exchange(exchange_id: str, timeout_ms: int) -> ccxt.Exchange:
+    exchange_class = getattr(ccxt, exchange_id, None)
+    if exchange_class is None:
+        raise ValueError(f"Unsupported CCXT exchange: {exchange_id}")
+
+    client_config: dict[str, Any] = {
+        "enableRateLimit": True,
+        "timeout": timeout_ms,
+    }
+    if exchange_id == "hyperliquid":
+        client_config["options"] = {
+            "fetchMarkets": {
+                "types": ["spot"],
+            },
+        }
+    return exchange_class(client_config)
+
+
+def _fetch_prices(
+    exchange_id: str,
+    currencies: list[str],
+    quote: str,
+    timeout_ms: int,
+    market_source: ccxt.Exchange | None = None,
+) -> tuple[dict[str, float], str | None]:
+    prices: dict[str, float] = {}
+    unresolved = set(currencies)
+    if quote in unresolved:
+        prices[quote] = 1.0
+        unresolved.remove(quote)
+    if quote in _USD_QUOTES:
+        for currency in unresolved & _USD_QUOTES:
+            prices[currency] = 1.0
+        unresolved -= _USD_QUOTES
+    if not unresolved:
+        return prices, None
+
+    try:
+        exchange = _build_public_exchange(exchange_id, timeout_ms)
+    except ValueError as exc:
+        return prices, str(exc)
+    try:
+        if market_source is not None:
+            try:
+                apply_cached_markets(exchange, market_source)
+                markets = exchange.markets
+            except Exception:
+                markets = exchange.load_markets()
+        else:
+            markets = exchange.load_markets()
+        direct_markets: dict[str, dict[str, Any]] = {}
+        bridge_markets: dict[str, dict[str, Any]] = {}
+        quote_bridge = None
+        if quote not in _USD_QUOTES:
+            quote_bridge = _find_market(markets, "USDT", quote)
+
+        for currency in unresolved:
+            direct = _find_market(markets, currency, quote)
+            if direct is not None:
+                direct_markets[currency] = direct
+                continue
+            if quote_bridge is not None:
+                bridge = _find_market(markets, currency, "USDT")
+                if bridge is not None:
+                    bridge_markets[currency] = bridge
+
+        symbols = {
+            str(market["symbol"])
+            for market in (*direct_markets.values(), *bridge_markets.values())
+        }
+        if quote_bridge is not None and bridge_markets:
+            symbols.add(str(quote_bridge["symbol"]))
+        ticker_prices: dict[str, float] = {}
+        if exchange_id == "hyperliquid":
+            for market in direct_markets.values():
+                price = _market_context_price(market)
+                if price is not None:
+                    ticker_prices[str(market["symbol"])] = price
+        missing_symbols = symbols - set(ticker_prices)
+        ticker_prices.update(_fetch_symbol_prices(
+            exchange,
+            missing_symbols,
+            {"type": "spot"} if exchange_id == "hyperliquid" else None,
+        ))
+
+        for currency, market in direct_markets.items():
+            price = ticker_prices.get(str(market["symbol"]))
+            if price is not None:
+                prices[currency] = price
+
+        bridge_quote_price = (
+            ticker_prices.get(str(quote_bridge["symbol"]))
+            if quote_bridge is not None
+            else None
+        )
+        if bridge_quote_price is not None:
+            for currency, market in bridge_markets.items():
+                bridge_price = ticker_prices.get(str(market["symbol"]))
+                if bridge_price is not None:
+                    prices[currency] = bridge_price * bridge_quote_price
+        return prices, None
+    except Exception as exc:
+        message = str(exc).replace("\n", " ").strip()
+        return prices, (message[:300] or type(exc).__name__)
+    finally:
+        try:
+            exchange.close()
+        except Exception:
+            pass
+
+
+def _value_portfolio(
+    account: str,
+    exchange_id: str,
+    results: list[dict[str, Any]],
+    timeout_ms: int,
+    *,
+    prices: dict[str, float] | None = None,
+    price_error: str | None = None,
+) -> dict[str, Any]:
+    holdings, statuses = _aggregate_account_results(results)
+    quote = _quote_currency(exchange_id)
+    if prices is None:
+        prices, price_error = _fetch_prices(
+            exchange_id,
+            [item["currency"] for item in holdings],
+            quote,
+            timeout_ms,
+        )
+
+    assets: list[dict[str, Any]] = []
+    total_value = 0.0
+    for holding in holdings:
+        price = prices.get(holding["currency"])
+        value = holding["amount"] * price if price is not None else None
+        if value is not None and math.isfinite(value):
+            total_value += value
+        assets.append({
+            **holding,
+            "price": price,
+            "value": value,
+            "priced": value is not None,
+        })
+
+    for asset in assets:
+        value = asset["value"]
+        asset["weight"] = (
+            value / total_value * 100
+            if value is not None and total_value > 0
+            else None
+        )
+    assets.sort(
+        key=lambda item: (
+            item["value"] is None,
+            -(item["value"] or 0),
+            item["currency"],
+        )
+    )
+    account_type_breakdown = []
+    for result in results:
+        if result.get("status") != "ok":
+            continue
+        type_holdings, _ = _aggregate_account_results([result])
+        type_total = 0.0
+        unpriced_assets: list[str] = []
+        for holding in type_holdings:
+            price = prices.get(holding["currency"])
+            if price is None:
+                unpriced_assets.append(holding["currency"])
+                continue
+            value = holding["amount"] * price
+            if math.isfinite(value):
+                type_total += value
+        account_type_breakdown.append({
+            "account_type": str(result.get("account_type") or "unknown"),
+            "total_value": type_total,
+            "weight": type_total / total_value * 100 if total_value > 0 else 0.0,
+            "asset_count": len(type_holdings),
+            "unpriced_assets": unpriced_assets,
+        })
+
+    succeeded = sum(item["status"] == "ok" for item in statuses)
+    failed = sum(item["status"] == "error" for item in statuses)
+    warnings = []
+    if price_error:
+        warnings.append(f"Price lookup: {price_error}")
+    if failed:
+        warnings.append(f"{failed} account type request(s) failed")
+    return {
+        "account": account,
+        "exchange": exchange_id,
+        "quote_currency": quote,
+        "total_value": total_value,
+        "priced_asset_count": sum(item["priced"] for item in assets),
+        "unpriced_asset_count": sum(not item["priced"] for item in assets),
+        "assets": assets,
+        "account_type_breakdown": account_type_breakdown,
+        "account_type_statuses": statuses,
+        "warnings": warnings,
+        "status": "ok" if succeeded else ("error" if failed else "empty"),
+    }
+
+
+def _collect_exchange_portfolios(
+    exchange_id: str,
+    accounts: list[ExchangeAccount],
+    args: argparse.Namespace,
+    timeout_ms: int,
+    market_source: ccxt.Exchange | None = None,
+) -> list[dict[str, Any]]:
+    raw_results = [
+        result
+        for account in accounts
+        for result in collect_account(
+            account,
+            _portfolio_account_types(exchange_id),
+            args,
+            market_source,
+        )
+    ]
+    remove_binance_earn_receipts(raw_results)
+    results_by_account: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for result in raw_results:
+        results_by_account[str(result.get("account") or "")].append(result)
+    for account in accounts:
+        _deduplicate_unified_trading_results(
+            exchange_id,
+            results_by_account.get(account.name, []),
+        )
+
+    currencies: set[str] = set()
+    for account in accounts:
+        holdings, _ = _aggregate_account_results(
+            results_by_account.get(account.name, [])
+        )
+        currencies.update(item["currency"] for item in holdings)
+    prices, price_error = _fetch_prices(
+        exchange_id,
+        sorted(currencies),
+        _quote_currency(exchange_id),
+        timeout_ms,
+        market_source,
+    )
+    return [
+        _value_portfolio(
+            account.name,
+            exchange_id,
+            results_by_account.get(account.name, []),
+            timeout_ms,
+            prices=prices,
+            price_error=price_error,
+        )
+        for account in accounts
+    ]
+
+
+class _AssetMarketCache:
+    def __init__(self, timeout_ms: int) -> None:
+        self.timeout_ms = timeout_ms
+        self._lock = threading.RLock()
+        self._sources: dict[str, ccxt.Exchange] = {}
+
+    def get(self, exchange_id: str) -> ccxt.Exchange | None:
+        with self._lock:
+            return self._sources.get(exchange_id)
+
+    def refresh(self, exchange_id: str) -> None:
+        source = _build_public_exchange(exchange_id, self.timeout_ms)
+        try:
+            source.load_markets()
+        except Exception:
+            try:
+                source.close()
+            except Exception:
+                pass
+            raise
+
+        with self._lock:
+            previous = self._sources.get(exchange_id)
+            self._sources[exchange_id] = source
+        if previous is not None:
+            try:
+                previous.close()
+            except Exception:
+                pass
+
+    def retain(self, exchange_ids: set[str]) -> None:
+        with self._lock:
+            removed = [
+                self._sources.pop(exchange_id)
+                for exchange_id in set(self._sources) - exchange_ids
+            ]
+        for source in removed:
+            try:
+                source.close()
+            except Exception:
+                pass
+
+    def close(self) -> None:
+        with self._lock:
+            sources = list(self._sources.values())
+            self._sources.clear()
+        for source in sources:
+            try:
+                source.close()
+            except Exception:
+                pass
+
+
+class AssetPortfolioService:
+    def __init__(
+        self,
+        config_path: Path,
+        *,
+        cache_ttl_seconds: float = 30.0,
+        timeout_ms: int = 30_000,
+        attempts: int = 3,
+        market_refresh_interval_seconds: float = _MARKET_REFRESH_INTERVAL_SECONDS,
+    ) -> None:
+        self.config_path = config_path
+        self.cache_ttl_seconds = cache_ttl_seconds
+        self.timeout_ms = timeout_ms
+        self.attempts = attempts
+        self.market_refresh_interval_seconds = market_refresh_interval_seconds
+        self._lock = asyncio.Lock()
+        self._cached: dict[str, Any] | None = None
+        self._cached_at = 0.0
+        self._market_cache = _AssetMarketCache(timeout_ms)
+        self._market_ready = asyncio.Event()
+        self._market_stop = asyncio.Event()
+        self._market_refresh_task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        if self._market_refresh_task is not None:
+            return
+        self._market_stop.clear()
+        self._market_ready.clear()
+        self._market_refresh_task = asyncio.create_task(
+            self._market_refresh_loop(),
+            name="asset-market-cache",
+        )
+
+    async def close(self) -> None:
+        task = self._market_refresh_task
+        if task is not None:
+            self._market_stop.set()
+            await task
+            self._market_refresh_task = None
+        await asyncio.to_thread(self._market_cache.close)
+
+    def _configured_exchange_ids(self) -> set[str]:
+        data = read_provider_config(self.config_path)
+        return {
+            account.exchange_id
+            for account in configured_accounts(data)
+        }
+
+    async def _refresh_market_cache(self) -> None:
+        exchange_ids = await asyncio.to_thread(self._configured_exchange_ids)
+        self._market_cache.retain(exchange_ids)
+        if not exchange_ids:
+            return
+
+        ordered_ids = sorted(exchange_ids)
+        started_at = time.monotonic()
+        results = await asyncio.gather(*(
+            asyncio.to_thread(self._market_cache.refresh, exchange_id)
+            for exchange_id in ordered_ids
+        ), return_exceptions=True)
+        for exchange_id, result in zip(ordered_ids, results):
+            if isinstance(result, Exception):
+                message = str(result).replace("\n", " ").strip()
+                print(
+                    f"[asset] market cache refresh failed exchange={exchange_id}: "
+                    f"{message[:300] or type(result).__name__}"
+                )
+        elapsed_ms = int((time.monotonic() - started_at) * 1000)
+        succeeded = sum(not isinstance(result, Exception) for result in results)
+        print(
+            f"[asset] market cache refreshed exchanges={succeeded}/{len(results)} "
+            f"in {elapsed_ms}ms"
+        )
+
+    async def _market_refresh_loop(self) -> None:
+        first_refresh = True
+        while not self._market_stop.is_set():
+            try:
+                await self._refresh_market_cache()
+            except Exception as exc:
+                message = str(exc).replace("\n", " ").strip()
+                print(
+                    f"[asset] market cache refresh failed: "
+                    f"{message[:300] or type(exc).__name__}"
+                )
+            finally:
+                if first_refresh:
+                    self._market_ready.set()
+                    first_refresh = False
+            try:
+                await asyncio.wait_for(
+                    self._market_stop.wait(),
+                    timeout=self.market_refresh_interval_seconds,
+                )
+            except TimeoutError:
+                pass
+
+    async def _wait_for_market_cache(self) -> None:
+        if self._market_refresh_task is None:
+            await self.start()
+        await self._market_ready.wait()
+
+    def _cache_valid(self) -> bool:
+        return (
+            self._cached is not None
+            and time.monotonic() - self._cached_at < self.cache_ttl_seconds
+        )
+
+    async def snapshot(self, *, force: bool = False) -> dict[str, Any]:
+        requested_at = time.monotonic()
+        if not force and self._cache_valid():
+            result = copy.deepcopy(self._cached)
+            result["cached"] = True
+            return result
+
+        async with self._lock:
+            if (
+                force
+                and self._cached is not None
+                and self._cached_at >= requested_at
+            ):
+                result = copy.deepcopy(self._cached)
+                result["cached"] = True
+                return result
+            if not force and self._cache_valid():
+                result = copy.deepcopy(self._cached)
+                result["cached"] = True
+                return result
+            await self._wait_for_market_cache()
+            try:
+                result = await asyncio.to_thread(self._collect_snapshot)
+            except Exception as exc:
+                message = str(exc).replace("\n", " ").strip()
+                raise AssetPortfolioError(message[:500] or type(exc).__name__) from exc
+            self._cached = result
+            self._cached_at = time.monotonic()
+            output = copy.deepcopy(result)
+            output["cached"] = False
+            return output
+
+    def _collect_snapshot(self) -> dict[str, Any]:
+        data = read_provider_config(self.config_path)
+        accounts = configured_accounts(data)
+        if not accounts:
+            return {
+                "collected_at": _utc_now(),
+                "read_only": True,
+                "portfolios": [],
+                "totals_by_quote": [],
+                "summary": {
+                    "accounts": 0,
+                    "succeeded": 0,
+                    "failed": 0,
+                    "priced_assets": 0,
+                    "unpriced_assets": 0,
+                },
+            }
+
+        args = argparse.Namespace(
+            timeout_ms=self.timeout_ms,
+            attempts=self.attempts,
+            currencies=set(),
+            include_zero=False,
+        )
+        accounts_by_exchange: dict[str, list[ExchangeAccount]] = defaultdict(list)
+        for account in accounts:
+            accounts_by_exchange[account.exchange_id].append(account)
+        portfolios_by_account: dict[str, dict[str, Any]] = {}
+        worker_count = min(4, len(accounts_by_exchange))
+        with ThreadPoolExecutor(
+            max_workers=worker_count,
+            thread_name_prefix="asset-exchange",
+        ) as executor:
+            futures = {
+                exchange_id: executor.submit(
+                    _collect_exchange_portfolios,
+                    exchange_id,
+                    exchange_accounts,
+                    args,
+                    self.timeout_ms,
+                    self._market_cache.get(exchange_id),
+                )
+                for exchange_id, exchange_accounts in accounts_by_exchange.items()
+            }
+            for future in futures.values():
+                for portfolio in future.result():
+                    portfolios_by_account[portfolio["account"]] = portfolio
+        portfolios = [portfolios_by_account[account.name] for account in accounts]
+        totals: dict[str, float] = defaultdict(float)
+        for portfolio in portfolios:
+            totals[portfolio["quote_currency"]] += portfolio["total_value"]
+        totals_by_quote = [
+            {"currency": currency, "value": value}
+            for currency, value in sorted(totals.items())
+        ]
+        return {
+            "collected_at": _utc_now(),
+            "read_only": True,
+            "portfolios": portfolios,
+            "totals_by_quote": totals_by_quote,
+            "summary": {
+                "accounts": len(portfolios),
+                "succeeded": sum(item["status"] == "ok" for item in portfolios),
+                "failed": sum(item["status"] == "error" for item in portfolios),
+                "priced_assets": sum(item["priced_asset_count"] for item in portfolios),
+                "unpriced_assets": sum(item["unpriced_asset_count"] for item in portfolios),
+            },
+        }

--- a/data_service/asset_portfolio.py
+++ b/data_service/asset_portfolio.py
@@ -619,7 +619,6 @@ class AssetPortfolioService:
             return
 
         ordered_ids = sorted(exchange_ids)
-        started_at = time.monotonic()
         results = await asyncio.gather(*(
             asyncio.to_thread(self._market_cache.refresh, exchange_id)
             for exchange_id in ordered_ids
@@ -631,12 +630,6 @@ class AssetPortfolioService:
                     f"[asset] market cache refresh failed exchange={exchange_id}: "
                     f"{message[:300] or type(result).__name__}"
                 )
-        elapsed_ms = int((time.monotonic() - started_at) * 1000)
-        succeeded = sum(not isinstance(result, Exception) for result in results)
-        print(
-            f"[asset] market cache refreshed exchanges={succeeded}/{len(results)} "
-            f"in {elapsed_ms}ms"
-        )
 
     async def _market_refresh_loop(self) -> None:
         first_refresh = True

--- a/data_service/asset_portfolio.py
+++ b/data_service/asset_portfolio.py
@@ -665,6 +665,11 @@ class AssetPortfolioService:
             and time.monotonic() - self._cached_at < self.cache_ttl_seconds
         )
 
+    async def invalidate(self) -> None:
+        async with self._lock:
+            self._cached = None
+            self._cached_at = 0.0
+
     async def snapshot(self, *, force: bool = False) -> dict[str, Any]:
         requested_at = time.monotonic()
         if not force and self._cache_valid():

--- a/data_service/asset_transfer.py
+++ b/data_service/asset_transfer.py
@@ -1,0 +1,2066 @@
+from __future__ import annotations
+
+import asyncio
+import re
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Callable
+
+import ccxt
+
+from ai.scripts.asset import (
+    ExchangeAccount,
+    build_exchange,
+    configured_accounts,
+    fetch_account_type_balance,
+    fetch_binance_earn_rows,
+    normalize_assets,
+    read_provider_config,
+    redact_error,
+    retry_read,
+    secret_values,
+)
+
+
+_SOURCES = {
+    "binance": {"spot", "swap", "margin", "funding", "earn"},
+    "bitget": {"spot", "swap", "margin", "funding", "earn"},
+    "bybit": {"spot", "swap", "margin", "funding"},
+    "okx": {"spot", "funding"},
+    "hyperliquid": {"spot", "swap"},
+}
+_DESTINATIONS = {
+    "binance": {
+        "spot": ("swap", "margin", "funding"),
+        "swap": ("spot", "margin", "funding"),
+        "margin": ("spot", "swap", "funding"),
+        "funding": ("spot", "swap", "margin"),
+        "earn": ("spot", "swap", "margin"),
+    },
+    "bitget": {
+        "spot": ("swap", "margin", "funding"),
+        "swap": ("spot", "margin", "funding"),
+        "margin": ("spot", "swap", "funding"),
+        "funding": ("spot", "swap", "margin"),
+        "earn": ("spot", "swap", "margin", "funding"),
+    },
+    "bybit": {
+        "spot": ("funding",),
+        "swap": ("funding",),
+        "margin": ("funding",),
+        "funding": ("spot",),
+    },
+    "okx": {
+        "spot": ("funding",),
+        "funding": ("spot",),
+    },
+    "hyperliquid": {
+        "spot": ("swap",),
+        "swap": ("spot",),
+    },
+}
+_BINANCE_TRANSFER_TYPES = {
+    ("spot", "swap"): "MAIN_UMFUTURE",
+    ("spot", "margin"): "MAIN_MARGIN",
+    ("spot", "funding"): "MAIN_FUNDING",
+    ("swap", "spot"): "UMFUTURE_MAIN",
+    ("swap", "margin"): "UMFUTURE_MARGIN",
+    ("swap", "funding"): "UMFUTURE_FUNDING",
+    ("margin", "spot"): "MARGIN_MAIN",
+    ("margin", "swap"): "MARGIN_UMFUTURE",
+    ("margin", "funding"): "MARGIN_FUNDING",
+    ("funding", "spot"): "FUNDING_MAIN",
+    ("funding", "swap"): "FUNDING_UMFUTURE",
+    ("funding", "margin"): "FUNDING_MARGIN",
+}
+_BITGET_ACCOUNT_TYPES = {
+    "spot": "spot",
+    "swap": "usdt_futures",
+    "margin": "crossed_margin",
+    "funding": "p2p",
+}
+_OKX_ACCOUNT_TYPES = {
+    "spot": "18",
+    "funding": "6",
+}
+_BYBIT_ACCOUNT_TYPES = {
+    "spot": "UNIFIED",
+    "swap": "UNIFIED",
+    "margin": "UNIFIED",
+    "funding": "FUND",
+}
+_BINANCE_SUB_ACCOUNT_TYPES = {
+    "spot": "SPOT",
+    "swap": "USDT_FUTURE",
+    "margin": "MARGIN",
+}
+_ASSET_PATTERN = re.compile(r"[A-Z0-9]{1,20}")
+_HYPERLIQUID_ADDRESS_PATTERN = re.compile(r"0x[a-f0-9]{40}")
+_ACCOUNT_HIERARCHY_TTL_SECONDS = 30 * 60
+
+
+@dataclass(frozen=True)
+class TransferAccountIdentity:
+    key: str
+    label: str
+    role: str
+    group_id: str
+    external_id: str | None
+    account: ExchangeAccount | None = field(default=None, repr=False, compare=False)
+
+
+@dataclass
+class TransferAccountHierarchy:
+    exchange_id: str
+    accounts: dict[str, TransferAccountIdentity]
+    masters: dict[str, str]
+
+    def identity(self, account_name: str) -> TransferAccountIdentity | None:
+        return self.accounts.get(str(account_name or "").strip().lower())
+
+    def master(self, identity: TransferAccountIdentity) -> TransferAccountIdentity | None:
+        key = self.masters.get(identity.group_id)
+        return self.accounts.get(key) if key else None
+
+    def related(self, identity: TransferAccountIdentity) -> list[TransferAccountIdentity]:
+        return [
+            item
+            for item in self.accounts.values()
+            if item.group_id == identity.group_id
+        ]
+
+
+class AssetTransferError(RuntimeError):
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: int = 400,
+        details: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.details = details or {}
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _decimal(value: Any, field: str) -> Decimal:
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise AssetTransferError(f"{field} must be a valid number") from exc
+    if not parsed.is_finite():
+        raise AssetTransferError(f"{field} must be a finite number")
+    return parsed
+
+
+def _amount_text(value: Decimal) -> str:
+    text = format(value, "f")
+    if "." in text:
+        text = text.rstrip("0").rstrip(".")
+    return text or "0"
+
+
+def _asset_code(value: Any) -> str:
+    asset = str(value or "").strip().upper()
+    if not _ASSET_PATTERN.fullmatch(asset):
+        raise AssetTransferError("asset must be a valid exchange asset code")
+    return asset
+
+
+def _account_by_name(
+    config_path: Path,
+    account_name: str,
+    exchange_id: str,
+) -> ExchangeAccount:
+    requested = str(account_name or "").strip().lower()
+    accounts = configured_accounts(read_provider_config(config_path))
+    account = next((item for item in accounts if item.name == requested), None)
+    if account is None:
+        raise AssetTransferError("configured exchange account was not found", status_code=404)
+    if account.exchange_id != exchange_id:
+        raise AssetTransferError("account does not belong to the requested exchange")
+    return account
+
+
+def _response_rows(response: Any, *keys: str) -> list[dict[str, Any]]:
+    value = response
+    search_keys = (*keys, "data", "rows", "list", "subAccounts")
+    for _ in range(3):
+        if not isinstance(value, dict):
+            break
+        next_value = None
+        for key in search_keys:
+            candidate = value.get(key)
+            if isinstance(candidate, list):
+                value = candidate
+                next_value = None
+                break
+            if isinstance(candidate, dict) and next_value is None:
+                next_value = candidate
+        else:
+            if next_value is not None:
+                value = next_value
+                continue
+        if isinstance(value, list) or next_value is None:
+            break
+        value = next_value
+    return [item for item in value if isinstance(item, dict)] if isinstance(value, list) else []
+
+
+def _external_id(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _integer_account_id(value: str | None, exchange_label: str) -> int:
+    text = _external_id(value)
+    if not text.isdigit():
+        raise AssetTransferError(f"{exchange_label} account UID discovery is incomplete")
+    return int(text)
+
+
+def _is_main_identifier(parent_id: str, user_id: str) -> bool:
+    return not parent_id or parent_id == "0" or parent_id == user_id
+
+
+def _account_label(account: ExchangeAccount) -> str:
+    return account.name
+
+
+def _wallet_assets(
+    balance: dict[str, Any],
+    *,
+    allowed_assets: set[str] | None = None,
+    unsupported_note: str | None = None,
+) -> list[dict[str, Any]]:
+    assets: list[dict[str, Any]] = []
+    for item in normalize_assets(balance, set(), False):
+        asset = str(item.get("currency") or "").upper()
+        available = _decimal(item.get("free") or 0, "available balance")
+        if available <= 0:
+            continue
+        transferable = allowed_assets is None or asset in allowed_assets
+        assets.append({
+            "key": f"wallet:{asset}",
+            "asset": asset,
+            "available": _amount_text(available),
+            "source_kind": "wallet",
+            "transferable": transferable,
+            "note": None if transferable else unsupported_note,
+        })
+    return sorted(
+        assets,
+        key=lambda item: (not item["transferable"], item["asset"]),
+    )
+
+
+def _wallet_available(balance: dict[str, Any], asset: str) -> Decimal:
+    return next(
+        (
+            _decimal(item.get("free") or 0, "available balance")
+            for item in normalize_assets(balance, {asset}, True)
+            if item.get("currency") == asset
+        ),
+        Decimal(0),
+    )
+
+
+def _binance_earn_positions(
+    exchange: ccxt.Exchange,
+    attempts: int,
+    secrets: list[str],
+) -> list[dict[str, Any]]:
+    flexible = fetch_binance_earn_rows(
+        exchange,
+        "sapiGetSimpleEarnFlexiblePosition",
+        attempts,
+        secrets,
+    )
+    locked = fetch_binance_earn_rows(
+        exchange,
+        "sapiGetSimpleEarnLockedPosition",
+        attempts,
+        secrets,
+    )
+    positions: list[dict[str, Any]] = []
+    for row in flexible:
+        available = _decimal(row.get("totalAmount") or 0, "Earn balance")
+        product_id = str(row.get("productId") or "").strip()
+        asset = str(row.get("asset") or "").strip().upper()
+        if available <= 0 or not product_id or not _ASSET_PATTERN.fullmatch(asset):
+            continue
+        can_redeem = row.get("canRedeem") is not False
+        positions.append({
+            "key": f"flexible:{product_id}",
+            "asset": asset,
+            "available": _amount_text(available),
+            "source_kind": "flexible",
+            "product_id": product_id,
+            "transferable": can_redeem,
+            "note": None if can_redeem else "This Flexible Earn product cannot be redeemed now.",
+        })
+    for row in locked:
+        available = _decimal(row.get("amount") or 0, "Locked Earn balance")
+        position_id = str(row.get("positionId") or "").strip()
+        asset = str(row.get("asset") or "").strip().upper()
+        if available <= 0 or not position_id or not _ASSET_PATTERN.fullmatch(asset):
+            continue
+        positions.append({
+            "key": f"locked:{position_id}",
+            "asset": asset,
+            "available": _amount_text(available),
+            "source_kind": "locked",
+            "position_id": position_id,
+            "transferable": False,
+            "note": "Locked Earn redemption is not supported by this transfer screen.",
+        })
+    return sorted(
+        positions,
+        key=lambda item: (
+            not item["transferable"],
+            item["asset"],
+            item["key"],
+        ),
+    )
+
+
+def _bitget_savings_rows(
+    exchange: ccxt.Exchange,
+    period_type: str,
+    attempts: int,
+    secrets: list[str],
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    end_id = ""
+    while True:
+        params: dict[str, Any] = {"periodType": period_type, "limit": "100"}
+        if end_id:
+            params["idLessThan"] = end_id
+        response = retry_read(
+            exchange,
+            f"fetch_{period_type}_savings_assets",
+            lambda request=dict(params): exchange.privateEarnGetV2EarnSavingsAssets(
+                request
+            ),
+            attempts,
+            secrets,
+        )
+        data = response.get("data", {}) if isinstance(response, dict) else {}
+        page = data.get("resultList", []) if isinstance(data, dict) else []
+        if not isinstance(page, list):
+            raise TypeError("Bitget savings assets returned invalid data")
+        rows.extend(row for row in page if isinstance(row, dict))
+        next_end_id = str(data.get("endId") or "") if isinstance(data, dict) else ""
+        if len(page) < 100 or not next_end_id or next_end_id == end_id:
+            break
+        end_id = next_end_id
+    return rows
+
+
+def _bitget_earn_positions(
+    exchange: ccxt.Exchange,
+    attempts: int,
+    secrets: list[str],
+) -> list[dict[str, Any]]:
+    positions: list[dict[str, Any]] = []
+    for period_type in ("flexible", "fixed"):
+        for row in _bitget_savings_rows(exchange, period_type, attempts, secrets):
+            available = _decimal(row.get("holdAmount") or 0, "Savings balance")
+            product_id = str(row.get("productId") or "").strip()
+            order_id = str(row.get("orderId") or "").strip()
+            asset = str(row.get("productCoin") or "").strip().upper()
+            if available <= 0 or not product_id or not _ASSET_PATTERN.fullmatch(asset):
+                continue
+            status = str(row.get("status") or "").strip().lower()
+            transferable = period_type == "flexible" and status != "in_redemption"
+            note = None
+            if period_type == "fixed":
+                note = "Fixed Savings redemption is not supported by this transfer screen."
+            elif status == "in_redemption":
+                note = "This Savings position is already being redeemed."
+            positions.append({
+                "key": f"{period_type}:{order_id or product_id}",
+                "asset": asset,
+                "available": _amount_text(available),
+                "source_kind": period_type,
+                "period_type": period_type,
+                "product_id": product_id,
+                "order_id": order_id or None,
+                "transferable": transferable,
+                "note": note,
+            })
+    return sorted(
+        positions,
+        key=lambda item: (
+            not item["transferable"],
+            item["asset"],
+            item["key"],
+        ),
+    )
+
+
+def _state_change(
+    callback: Callable[[], Any],
+    *,
+    operation: str,
+    exchange_label: str,
+    secrets: list[str],
+) -> dict[str, Any]:
+    try:
+        result = callback()
+    except ccxt.NetworkError as exc:
+        raise AssetTransferError(
+            f"{operation} response was not received. Execution status is unknown; "
+            f"check {exchange_label} balances or transfer history before trying again.",
+            status_code=502,
+            details={"status": "unknown"},
+        ) from exc
+    except ccxt.BaseError as exc:
+        raise AssetTransferError(
+            f"{operation} failed: {redact_error(exc, secrets)}",
+            status_code=502,
+            details={"status": "failed"},
+        ) from exc
+    except Exception as exc:
+        raise AssetTransferError(
+            f"{operation} response was not received. Execution status is unknown; "
+            f"check {exchange_label} balances or transfer history before trying again.",
+            status_code=502,
+            details={"status": "unknown"},
+        ) from exc
+    if not isinstance(result, dict):
+        raise AssetTransferError(
+            f"{operation} returned an invalid response. "
+            f"Check {exchange_label} before trying again.",
+            status_code=502,
+            details={"status": "unknown"},
+        )
+    return result
+
+
+def _client_id() -> str:
+    return f"pynereal{uuid.uuid4().hex[:24]}"
+
+
+def _success_result(
+    account: ExchangeAccount,
+    source: str,
+    destination: str,
+    asset: str,
+    amount: Decimal,
+    steps: list[dict[str, Any]],
+    *,
+    target_account: str | None = None,
+    target_account_label: str | None = None,
+    status: str = "success",
+) -> dict[str, Any]:
+    return {
+        "status": status,
+        "account": account.name,
+        "target_account": target_account or account.name,
+        "target_account_label": target_account_label or target_account or account.name,
+        "exchange": account.exchange_id,
+        "source": source,
+        "destination": destination,
+        "asset": asset,
+        "amount": _amount_text(amount),
+        "steps": steps,
+        "completed_at": _utc_now(),
+    }
+
+
+class AssetTransferService:
+    def __init__(
+        self,
+        config_path: Path,
+        *,
+        timeout_ms: int = 30_000,
+        read_attempts: int = 3,
+    ) -> None:
+        self.config_path = config_path
+        self.timeout_ms = timeout_ms
+        self.read_attempts = read_attempts
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._hierarchy_cache: dict[
+            str,
+            tuple[int, float, TransferAccountHierarchy],
+        ] = {}
+        self._hierarchy_cache_lock = threading.Lock()
+
+    @staticmethod
+    def _validate_route(
+        exchange_id: str,
+        source: str,
+        destination: str | None = None,
+        *,
+        allowed_destinations: tuple[str, ...] | None = None,
+    ) -> None:
+        if exchange_id not in _SOURCES:
+            raise AssetTransferError("internal transfer is not supported for this exchange")
+        if source not in _SOURCES[exchange_id]:
+            raise AssetTransferError("unsupported source account type")
+        destinations = (
+            allowed_destinations
+            if allowed_destinations is not None
+            else _DESTINATIONS[exchange_id][source]
+        )
+        if destination is not None and destination not in destinations:
+            raise AssetTransferError("unsupported transfer destination")
+
+    def _config_revision(self) -> int:
+        try:
+            return self.config_path.stat().st_mtime_ns
+        except OSError:
+            return 0
+
+    @staticmethod
+    def _standalone_hierarchy(
+        exchange_id: str,
+        accounts: list[ExchangeAccount],
+    ) -> TransferAccountHierarchy:
+        identities = {
+            account.name: TransferAccountIdentity(
+                key=account.name,
+                label=_account_label(account),
+                role="standalone",
+                group_id=account.name,
+                external_id=None,
+                account=account,
+            )
+            for account in accounts
+        }
+        return TransferAccountHierarchy(
+            exchange_id=exchange_id,
+            accounts=identities,
+            masters={account.name: account.name for account in accounts},
+        )
+
+    def _read_identity(
+        self,
+        exchange: ccxt.Exchange,
+        operation: str,
+        callback: Callable[[], Any],
+        secrets: list[str],
+    ) -> Any:
+        return retry_read(
+            exchange,
+            operation,
+            callback,
+            self.read_attempts,
+            secrets,
+        )
+
+    def _account_hierarchy(
+        self,
+        exchange_id: str,
+        fallback_account: ExchangeAccount | None = None,
+    ) -> TransferAccountHierarchy:
+        revision = self._config_revision()
+        now = time.monotonic()
+        with self._hierarchy_cache_lock:
+            cached = self._hierarchy_cache.get(exchange_id)
+            if (
+                cached is not None
+                and cached[0] == revision
+                and now - cached[1] < _ACCOUNT_HIERARCHY_TTL_SECONDS
+            ):
+                return cached[2]
+
+        try:
+            accounts = [
+                account
+                for account in configured_accounts(read_provider_config(self.config_path))
+                if account.exchange_id == exchange_id
+            ]
+        except Exception:
+            accounts = [fallback_account] if fallback_account is not None else []
+        if fallback_account is not None and not any(
+            account.name == fallback_account.name for account in accounts
+        ):
+            accounts.append(fallback_account)
+        if not accounts:
+            raise AssetTransferError("configured exchange account was not found", status_code=404)
+
+        hierarchy = self._standalone_hierarchy(exchange_id, accounts)
+        discover = getattr(self, f"_discover_{exchange_id}_hierarchy", None)
+        if callable(discover):
+            try:
+                hierarchy = discover(accounts, hierarchy)
+            except Exception:
+                # Account discovery is optional for existing same-account transfers.
+                hierarchy = self._standalone_hierarchy(exchange_id, accounts)
+        with self._hierarchy_cache_lock:
+            self._hierarchy_cache[exchange_id] = (revision, now, hierarchy)
+        return hierarchy
+
+    def _discover_bitget_hierarchy(
+        self,
+        accounts: list[ExchangeAccount],
+        hierarchy: TransferAccountHierarchy,
+    ) -> TransferAccountHierarchy:
+        identities = dict(hierarchy.accounts)
+        masters: dict[str, str] = {}
+        for account in accounts:
+            exchange = build_exchange("bitget", account.config, self.timeout_ms, None)
+            secrets = secret_values(account.config)
+            try:
+                response = self._read_identity(
+                    exchange,
+                    "Bitget account info",
+                    lambda: exchange.privateSpotGetV2SpotAccountInfo({}),
+                    secrets,
+                )
+                data = response.get("data", {}) if isinstance(response, dict) else {}
+                user_id = _external_id(
+                    data.get("userId") if isinstance(data, dict) else None
+                )
+                parent_id = _external_id(
+                    data.get("parentId") if isinstance(data, dict) else None
+                )
+                if not user_id:
+                    continue
+                is_main = _is_main_identifier(parent_id, user_id)
+                group_id = user_id if is_main else parent_id
+                identities[account.name] = TransferAccountIdentity(
+                    key=account.name,
+                    label=_account_label(account),
+                    role="main" if is_main else "sub",
+                    group_id=group_id,
+                    external_id=user_id,
+                    account=account,
+                )
+                if is_main:
+                    masters[group_id] = account.name
+            except Exception:
+                continue
+            finally:
+                try:
+                    exchange.close()
+                except Exception:
+                    pass
+        return TransferAccountHierarchy("bitget", identities, masters)
+
+    def _discover_bybit_hierarchy(
+        self,
+        accounts: list[ExchangeAccount],
+        hierarchy: TransferAccountHierarchy,
+    ) -> TransferAccountHierarchy:
+        identities = dict(hierarchy.accounts)
+        masters: dict[str, str] = {}
+        for account in accounts:
+            exchange = build_exchange("bybit", account.config, self.timeout_ms, None)
+            secrets = secret_values(account.config)
+            try:
+                response = self._read_identity(
+                    exchange,
+                    "Bybit API key info",
+                    lambda: exchange.privateGetV5UserQueryApi({}),
+                    secrets,
+                )
+                data = response.get("result", {}) if isinstance(response, dict) else {}
+                user_id = _external_id(
+                    data.get("userID", data.get("userId"))
+                    if isinstance(data, dict)
+                    else None
+                )
+                parent_id = _external_id(
+                    data.get("parentUid", data.get("parentUID"))
+                    if isinstance(data, dict)
+                    else None
+                )
+                is_master_value = data.get("isMaster") if isinstance(data, dict) else None
+                is_main = (
+                    is_master_value is True
+                    or str(is_master_value).lower() in {"1", "true"}
+                    or _is_main_identifier(parent_id, user_id)
+                )
+                if not user_id:
+                    continue
+                group_id = user_id if is_main else parent_id
+                identities[account.name] = TransferAccountIdentity(
+                    key=account.name,
+                    label=_account_label(account),
+                    role="main" if is_main else "sub",
+                    group_id=group_id,
+                    external_id=user_id,
+                    account=account,
+                )
+                if is_main:
+                    masters[group_id] = account.name
+            except Exception:
+                continue
+            finally:
+                try:
+                    exchange.close()
+                except Exception:
+                    pass
+        return TransferAccountHierarchy("bybit", identities, masters)
+
+    def _discover_okx_hierarchy(
+        self,
+        accounts: list[ExchangeAccount],
+        hierarchy: TransferAccountHierarchy,
+    ) -> TransferAccountHierarchy:
+        identities = dict(hierarchy.accounts)
+        masters: dict[str, str] = {}
+        uid_by_account: dict[str, str] = {}
+        for account in accounts:
+            exchange = build_exchange("okx", account.config, self.timeout_ms, None)
+            secrets = secret_values(account.config)
+            try:
+                response = self._read_identity(
+                    exchange,
+                    "OKX account config",
+                    lambda: exchange.privateGetAccountConfig({}),
+                    secrets,
+                )
+                rows = _response_rows(response, "data")
+                data = rows[0] if rows else {}
+                user_id = _external_id(data.get("uid"))
+                main_id = _external_id(data.get("mainUid")) or user_id
+                if not user_id:
+                    continue
+                is_main = user_id == main_id
+                uid_by_account[account.name] = user_id
+                identities[account.name] = TransferAccountIdentity(
+                    key=account.name,
+                    label=_account_label(account),
+                    role="main" if is_main else "sub",
+                    group_id=main_id,
+                    external_id=None if is_main else user_id,
+                    account=account,
+                )
+                if is_main:
+                    masters[main_id] = account.name
+            except Exception:
+                continue
+            finally:
+                try:
+                    exchange.close()
+                except Exception:
+                    pass
+
+        for group_id, master_key in masters.items():
+            master = identities.get(master_key)
+            if master is None or master.account is None:
+                continue
+            exchange = build_exchange("okx", master.account.config, self.timeout_ms, None)
+            secrets = secret_values(master.account.config)
+            try:
+                response = self._read_identity(
+                    exchange,
+                    "OKX sub-account list",
+                    lambda: exchange.privateGetUsersSubaccountList({}),
+                    secrets,
+                )
+                names_by_uid = {
+                    _external_id(row.get("uid")): _external_id(row.get("subAcct"))
+                    for row in _response_rows(response, "data")
+                }
+                for account_name, user_id in uid_by_account.items():
+                    identity = identities.get(account_name)
+                    if (
+                        identity is None
+                        or identity.group_id != group_id
+                        or identity.role != "sub"
+                    ):
+                        continue
+                    sub_name = names_by_uid.get(user_id)
+                    if sub_name:
+                        identities[account_name] = TransferAccountIdentity(
+                            key=identity.key,
+                            label=identity.label,
+                            role=identity.role,
+                            group_id=identity.group_id,
+                            external_id=sub_name,
+                            account=identity.account,
+                        )
+            except Exception:
+                continue
+            finally:
+                try:
+                    exchange.close()
+                except Exception:
+                    pass
+        return TransferAccountHierarchy("okx", identities, masters)
+
+    def _discover_binance_hierarchy(
+        self,
+        accounts: list[ExchangeAccount],
+        hierarchy: TransferAccountHierarchy,
+    ) -> TransferAccountHierarchy:
+        candidates = sorted(
+            accounts,
+            key=lambda account: (
+                0 if account.name in {"binance", "binance_main"} else 1,
+                account.name,
+            ),
+        )
+        master_account: ExchangeAccount | None = None
+        sub_rows: list[dict[str, Any]] = []
+        master_exchange: ccxt.Exchange | None = None
+        master_secrets: list[str] = []
+        for account in candidates:
+            exchange = build_exchange("binance", account.config, self.timeout_ms, None)
+            secrets = secret_values(account.config)
+            try:
+                response = self._read_identity(
+                    exchange,
+                    "Binance sub-account list",
+                    lambda: exchange.sapiGetSubAccountList({}),
+                    secrets,
+                )
+                sub_rows = _response_rows(response, "subAccounts")
+                master_account = account
+                master_exchange = exchange
+                master_secrets = secrets
+                break
+            except Exception:
+                try:
+                    exchange.close()
+                except Exception:
+                    pass
+        if master_account is None or master_exchange is None:
+            return hierarchy
+
+        group_id = master_account.name
+        identities = dict(hierarchy.accounts)
+        identities[master_account.name] = TransferAccountIdentity(
+            key=master_account.name,
+            label=_account_label(master_account),
+            role="main",
+            group_id=group_id,
+            external_id=None,
+            account=master_account,
+        )
+        row_by_hint: dict[str, dict[str, Any]] = {}
+        for row in sub_rows:
+            for value in (row.get("email"), row.get("subUserId")):
+                hint = _external_id(value).lower()
+                if hint:
+                    row_by_hint[hint] = row
+
+        try:
+            rows_by_account: dict[str, dict[str, Any]] = {}
+            unresolved_by_api_key: dict[str, ExchangeAccount] = {}
+            for account in accounts:
+                if account.name == master_account.name:
+                    continue
+                row = None
+                for key in ("email", "uid"):
+                    hint = _external_id(account.config.get(key)).lower()
+                    if hint and hint in row_by_hint:
+                        row = row_by_hint[hint]
+                        break
+                if row is not None:
+                    rows_by_account[account.name] = row
+                    continue
+                api_key = _external_id(account.config.get("apiKey"))
+                if api_key:
+                    unresolved_by_api_key[api_key] = account
+
+            for candidate in sub_rows:
+                if not unresolved_by_api_key:
+                    break
+                email = _external_id(candidate.get("email"))
+                if not email:
+                    continue
+                try:
+                    response = self._read_identity(
+                        master_exchange,
+                        "Binance sub-account API key list",
+                        lambda email=email: master_exchange.request(
+                            "sub-account/subAccountApi",
+                            "sapi",
+                            "GET",
+                            {"email": email, "size": 100},
+                        ),
+                        master_secrets,
+                    )
+                except Exception:
+                    continue
+                for item in _response_rows(
+                    response,
+                    "subAccountApiKeyList",
+                    "data",
+                ):
+                    api_key = _external_id(item.get("apiKey", item.get("apikey")))
+                    account = unresolved_by_api_key.pop(api_key, None)
+                    if account is not None:
+                        rows_by_account[account.name] = candidate
+
+            for account_name, row in rows_by_account.items():
+                email = _external_id(row.get("email"))
+                if not email:
+                    continue
+                account = next(
+                    item for item in accounts if item.name == account_name
+                )
+                identities[account_name] = TransferAccountIdentity(
+                    key=account_name,
+                    label=_account_label(account),
+                    role="sub",
+                    group_id=group_id,
+                    external_id=email,
+                    account=account,
+                )
+        finally:
+            try:
+                master_exchange.close()
+            except Exception:
+                pass
+        return TransferAccountHierarchy(
+            "binance",
+            identities,
+            {group_id: master_account.name},
+        )
+
+    def _discover_hyperliquid_hierarchy(
+        self,
+        accounts: list[ExchangeAccount],
+        hierarchy: TransferAccountHierarchy,
+    ) -> TransferAccountHierarchy:
+        identities = dict(hierarchy.accounts)
+        masters: dict[str, str] = {}
+        main_clients: dict[str, tuple[ccxt.Exchange, list[str]]] = {}
+        try:
+            for account in accounts:
+                exchange = build_exchange(
+                    "hyperliquid",
+                    account.config,
+                    self.timeout_ms,
+                    None,
+                )
+                secrets = secret_values(account.config)
+                keep_client = False
+                try:
+                    address = _external_id(
+                        account.config.get("walletAddress")
+                        or getattr(exchange, "walletAddress", None)
+                    ).lower()
+                    if not _HYPERLIQUID_ADDRESS_PATTERN.fullmatch(address):
+                        continue
+                    response = self._read_identity(
+                        exchange,
+                        "Hyperliquid user role",
+                        lambda address=address: exchange.publicPostInfo({
+                            "type": "userRole",
+                            "user": address,
+                        }),
+                        secrets,
+                    )
+                    role = (
+                        _external_id(response.get("role")).lower()
+                        if isinstance(response, dict)
+                        else ""
+                    )
+                    data = response.get("data", {}) if isinstance(response, dict) else {}
+                    master_address = (
+                        _external_id(data.get("master")).lower()
+                        if isinstance(data, dict)
+                        else ""
+                    )
+                    is_main = role != "subaccount" or not master_address
+                    group_id = address if is_main else master_address
+                    identities[account.name] = TransferAccountIdentity(
+                        key=account.name,
+                        label=_account_label(account),
+                        role="main" if is_main else "sub",
+                        group_id=group_id,
+                        external_id=address,
+                        account=account,
+                    )
+                    if is_main:
+                        masters[group_id] = account.name
+                        main_clients[group_id] = (exchange, secrets)
+                        keep_client = True
+                except Exception:
+                    continue
+                finally:
+                    if not keep_client:
+                        try:
+                            exchange.close()
+                        except Exception:
+                            pass
+
+            configured_addresses = {
+                identity.external_id
+                for identity in identities.values()
+                if identity.external_id
+            }
+            for group_id, (exchange, secrets) in main_clients.items():
+                try:
+                    response = self._read_identity(
+                        exchange,
+                        "Hyperliquid sub-account list",
+                        lambda group_id=group_id: exchange.publicPostInfo({
+                            "type": "subAccounts",
+                            "user": group_id,
+                        }),
+                        secrets,
+                    )
+                except Exception:
+                    continue
+                for index, row in enumerate(_response_rows(response)):
+                    address = _external_id(
+                        row.get("subAccountUser", row.get("user"))
+                    ).lower()
+                    if (
+                        not _HYPERLIQUID_ADDRESS_PATTERN.fullmatch(address)
+                        or address in configured_addresses
+                    ):
+                        continue
+                    name = _external_id(row.get("name")) or f"Sub-account {index + 1}"
+                    key = f"hyperliquid_sub_{address}"
+                    identities[key] = TransferAccountIdentity(
+                        key=key,
+                        label=name,
+                        role="sub",
+                        group_id=group_id,
+                        external_id=address,
+                    )
+        finally:
+            for exchange, _ in main_clients.values():
+                try:
+                    exchange.close()
+                except Exception:
+                    pass
+        return TransferAccountHierarchy("hyperliquid", identities, masters)
+
+    @staticmethod
+    def _cross_destinations(
+        exchange_id: str,
+        source: str,
+        source_account: TransferAccountIdentity,
+        target_account: TransferAccountIdentity,
+    ) -> tuple[str, ...]:
+        if (
+            source_account.key == target_account.key
+            or source_account.group_id != target_account.group_id
+            or source_account.role not in {"main", "sub"}
+            or target_account.role not in {"main", "sub"}
+        ):
+            return ()
+
+        effective_source = "spot" if source == "earn" else source
+        if exchange_id == "binance":
+            if effective_source == "spot":
+                if source_account.role == "main":
+                    return ("spot", "swap", "margin")
+                if target_account.role == "main":
+                    return ("spot",)
+                return ("spot",)
+            if effective_source == "swap":
+                return ("spot",)
+            if effective_source == "margin":
+                if target_account.role == "main":
+                    return ("spot",)
+                if source_account.role == "sub":
+                    return ("margin",)
+            return ()
+        if exchange_id == "bitget":
+            return (
+                ("spot", "swap", "margin")
+                if target_account.role == "sub"
+                else ("spot", "swap", "margin", "funding")
+            )
+        if exchange_id == "bybit":
+            return ("spot", "funding")
+        if exchange_id == "okx":
+            return ("spot", "funding")
+        if exchange_id == "hyperliquid" and effective_source == "swap":
+            # Hyperliquid's sub-account USDC transfer moves Perps collateral.
+            if source_account.role == "main" or target_account.role == "main":
+                return ("swap",)
+        return ()
+
+    def _target_account_options(
+        self,
+        hierarchy: TransferAccountHierarchy,
+        source_account: TransferAccountIdentity,
+        source: str,
+    ) -> list[dict[str, Any]]:
+        options: list[dict[str, Any]] = []
+        for target in hierarchy.related(source_account):
+            if target.key == source_account.key:
+                destinations = _DESTINATIONS[hierarchy.exchange_id][source]
+            else:
+                master = hierarchy.master(source_account)
+                destinations = self._cross_destinations(
+                    hierarchy.exchange_id,
+                    source,
+                    source_account,
+                    target,
+                )
+                if master is None or master.account is None:
+                    destinations = ()
+            if not destinations:
+                continue
+            options.append({
+                "key": target.key,
+                "label": target.label,
+                "role": target.role,
+                "destinations": list(destinations),
+            })
+        return sorted(
+            options,
+            key=lambda item: (
+                item["key"] != source_account.key,
+                item["role"] != "main",
+                item["label"].lower(),
+            ),
+        )
+
+    def _resolve_account_route(
+        self,
+        exchange_id: str,
+        source_account: ExchangeAccount,
+        target_name: str,
+        source: str,
+        destination: str,
+    ) -> tuple[
+        TransferAccountHierarchy,
+        TransferAccountIdentity,
+        TransferAccountIdentity,
+    ]:
+        hierarchy = self._account_hierarchy(exchange_id, source_account)
+        source_identity = hierarchy.identity(source_account.name)
+        target_identity = hierarchy.identity(target_name)
+        if source_identity is None or target_identity is None:
+            raise AssetTransferError(
+                "target account was not found in the configured account hierarchy",
+                status_code=404,
+            )
+        if source_identity.key == target_identity.key:
+            self._validate_route(exchange_id, source, destination)
+            return hierarchy, source_identity, target_identity
+        destinations = self._cross_destinations(
+            exchange_id,
+            source,
+            source_identity,
+            target_identity,
+        )
+        self._validate_route(
+            exchange_id,
+            source,
+            destination,
+            allowed_destinations=destinations,
+        )
+        master = hierarchy.master(source_identity)
+        if (
+            source_identity.group_id != target_identity.group_id
+            or master is None
+            or master.account is None
+        ):
+            raise AssetTransferError(
+                "the selected accounts are not managed by the same configured main account"
+            )
+        return hierarchy, source_identity, target_identity
+
+    async def options(
+        self,
+        exchange: str,
+        account: str,
+        source: str,
+    ) -> dict[str, Any]:
+        exchange_id = str(exchange or "").strip().lower()
+        source_type = str(source or "").strip().lower()
+        self._validate_route(exchange_id, source_type)
+        try:
+            return await asyncio.to_thread(
+                self._options_sync,
+                exchange_id,
+                account,
+                source_type,
+            )
+        except AssetTransferError:
+            raise
+        except Exception as exc:
+            raise AssetTransferError(
+                "could not load transfer options",
+                status_code=502,
+            ) from exc
+
+    def _options_sync(
+        self,
+        exchange_id: str,
+        account_name: str,
+        source: str,
+    ) -> dict[str, Any]:
+        account = _account_by_name(self.config_path, account_name, exchange_id)
+        exchange = build_exchange(exchange_id, account.config, self.timeout_ms, None)
+        secrets = secret_values(account.config)
+        try:
+            if exchange_id == "binance" and source == "earn":
+                assets = _binance_earn_positions(
+                    exchange,
+                    self.read_attempts,
+                    secrets,
+                )
+            elif exchange_id == "bitget" and source == "earn":
+                assets = _bitget_earn_positions(
+                    exchange,
+                    self.read_attempts,
+                    secrets,
+                )
+            else:
+                balance, _ = fetch_account_type_balance(
+                    exchange,
+                    exchange_id,
+                    source,
+                    self.read_attempts,
+                    secrets,
+                )
+                if exchange_id == "hyperliquid":
+                    assets = _wallet_assets(
+                        balance,
+                        allowed_assets={"USDC"},
+                        unsupported_note=(
+                            "Hyperliquid Spot/Perp internal transfer supports USDC only."
+                        ),
+                    )
+                else:
+                    assets = _wallet_assets(balance)
+            hierarchy = self._account_hierarchy(exchange_id, account)
+            source_identity = hierarchy.identity(account.name)
+            target_accounts = (
+                self._target_account_options(hierarchy, source_identity, source)
+                if source_identity is not None
+                else []
+            )
+            if not target_accounts:
+                target_accounts = [{
+                    "key": account.name,
+                    "label": account.name,
+                    "role": "standalone",
+                    "destinations": list(_DESTINATIONS[exchange_id][source]),
+                }]
+            return {
+                "account": account.name,
+                "exchange": exchange_id,
+                "source": source,
+                "destinations": list(_DESTINATIONS[exchange_id][source]),
+                "target_accounts": target_accounts,
+                "assets": assets,
+                "collected_at": _utc_now(),
+            }
+        except AssetTransferError:
+            raise
+        except Exception as exc:
+            raise AssetTransferError(
+                f"could not load transfer options: {redact_error(exc, secrets)}",
+                status_code=502,
+            ) from exc
+        finally:
+            try:
+                exchange.close()
+            except Exception:
+                pass
+
+    async def execute(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if payload.get("confirm") != "TRANSFER":
+            raise AssetTransferError("explicit transfer confirmation is required")
+        exchange_id = str(payload.get("exchange") or "").strip().lower()
+        account_name = str(payload.get("account") or "").strip().lower()
+        if not account_name:
+            raise AssetTransferError("account is required")
+        if exchange_id not in _SOURCES:
+            raise AssetTransferError("internal transfer is not supported for this exchange")
+        lock_key = exchange_id
+        lock = self._locks.setdefault(lock_key, asyncio.Lock())
+        if lock.locked():
+            raise AssetTransferError(
+                "another transfer is already running for this exchange",
+                status_code=409,
+            )
+        async with lock:
+            try:
+                return await asyncio.to_thread(self._execute_sync, payload)
+            except AssetTransferError:
+                raise
+            except Exception as exc:
+                raise AssetTransferError(
+                    "internal transfer failed before submission",
+                    status_code=502,
+                ) from exc
+
+    def _execute_sync(self, payload: dict[str, Any]) -> dict[str, Any]:
+        exchange_id = str(payload.get("exchange") or "").strip().lower()
+        source = str(payload.get("source") or "").strip().lower()
+        destination = str(payload.get("destination") or "").strip().lower()
+        self._validate_route(exchange_id, source)
+        asset = _asset_code(payload.get("asset"))
+        amount = _decimal(payload.get("amount"), "amount")
+        if amount <= 0:
+            raise AssetTransferError("amount must be greater than zero")
+        if exchange_id == "hyperliquid" and asset != "USDC":
+            raise AssetTransferError("Hyperliquid transfer supports USDC only")
+
+        account = _account_by_name(
+            self.config_path,
+            payload.get("account"),
+            exchange_id,
+        )
+        target_name = str(
+            payload.get("target_account") or account.name
+        ).strip().lower()
+        hierarchy, source_identity, target_identity = self._resolve_account_route(
+            exchange_id,
+            account,
+            target_name,
+            source,
+            destination,
+        )
+        secrets = secret_values(account.config)
+        exchange: ccxt.Exchange | None = None
+        try:
+            exchange = build_exchange(exchange_id, account.config, self.timeout_ms, None)
+            if source_identity.key != target_identity.key:
+                return self._transfer_between_accounts(
+                    exchange,
+                    hierarchy,
+                    source_identity,
+                    target_identity,
+                    source,
+                    destination,
+                    asset,
+                    amount,
+                    payload,
+                    secrets,
+                )
+            if source == "earn":
+                if exchange_id == "binance":
+                    return self._redeem_binance_earn(
+                        exchange,
+                        account,
+                        destination,
+                        asset,
+                        amount,
+                        str(payload.get("product_id") or "").strip(),
+                        secrets,
+                    )
+                return self._redeem_bitget_earn(
+                    exchange,
+                    account,
+                    destination,
+                    asset,
+                    amount,
+                    str(payload.get("product_id") or "").strip(),
+                    str(payload.get("period_type") or "").strip().lower(),
+                    secrets,
+                )
+            return self._transfer_wallet(
+                exchange,
+                account,
+                source,
+                destination,
+                asset,
+                amount,
+                secrets,
+            )
+        except AssetTransferError:
+            raise
+        except Exception as exc:
+            raise AssetTransferError(
+                f"transfer preflight failed: {redact_error(exc, secrets)}",
+                status_code=502,
+                details={"status": "failed"},
+            ) from exc
+        finally:
+            if exchange is not None:
+                try:
+                    exchange.close()
+                except Exception:
+                    pass
+
+    def _transfer_between_accounts(
+        self,
+        source_exchange: ccxt.Exchange,
+        hierarchy: TransferAccountHierarchy,
+        source_identity: TransferAccountIdentity,
+        target_identity: TransferAccountIdentity,
+        source: str,
+        destination: str,
+        asset: str,
+        amount: Decimal,
+        payload: dict[str, Any],
+        source_secrets: list[str],
+    ) -> dict[str, Any]:
+        source_account = source_identity.account
+        if source_account is None:
+            raise AssetTransferError("source account is not configured")
+        steps: list[dict[str, Any]] = []
+        effective_source = source
+        if source == "earn":
+            if hierarchy.exchange_id == "binance":
+                redeemed = self._redeem_binance_earn(
+                    source_exchange,
+                    source_account,
+                    "spot",
+                    asset,
+                    amount,
+                    str(payload.get("product_id") or "").strip(),
+                    source_secrets,
+                )
+            elif hierarchy.exchange_id == "bitget":
+                redeemed = self._redeem_bitget_earn(
+                    source_exchange,
+                    source_account,
+                    "spot",
+                    asset,
+                    amount,
+                    str(payload.get("product_id") or "").strip(),
+                    str(payload.get("period_type") or "").strip().lower(),
+                    source_secrets,
+                )
+            else:
+                raise AssetTransferError("Earn transfer is not supported for this exchange")
+            steps.extend(redeemed.get("steps", []))
+            effective_source = "spot"
+        else:
+            balance, _ = fetch_account_type_balance(
+                source_exchange,
+                hierarchy.exchange_id,
+                source,
+                self.read_attempts,
+                source_secrets,
+            )
+            available = _wallet_available(balance, asset)
+            if amount > available:
+                raise AssetTransferError(
+                    f"insufficient {asset} balance in {source}: "
+                    f"available {_amount_text(available)}"
+                )
+
+        master = hierarchy.master(source_identity)
+        if master is None or master.account is None:
+            raise AssetTransferError("configured main account is required for this transfer")
+        signer_exchange = source_exchange
+        signer_secrets = source_secrets
+        close_signer = False
+        if master.account.name != source_account.name:
+            signer_exchange = build_exchange(
+                hierarchy.exchange_id,
+                master.account.config,
+                self.timeout_ms,
+                None,
+            )
+            signer_secrets = secret_values(master.account.config)
+            close_signer = True
+        route_secrets = [
+            *signer_secrets,
+            *(
+                value
+                for value in (
+                    source_identity.external_id,
+                    target_identity.external_id,
+                )
+                if value
+            ),
+        ]
+        try:
+            transaction_id, transfer_status = self._submit_account_transfer(
+                signer_exchange,
+                hierarchy.exchange_id,
+                source_identity,
+                target_identity,
+                effective_source,
+                destination,
+                asset,
+                amount,
+                route_secrets,
+            )
+        except AssetTransferError as exc:
+            if steps:
+                raise AssetTransferError(
+                    f"Earn redemption completed, but account transfer failed. "
+                    f"Redeemed funds remain in {source_identity.label} Spot.",
+                    status_code=exc.status_code,
+                    details={
+                        "status": "partial",
+                        "completed_steps": steps,
+                    },
+                ) from exc
+            raise
+        finally:
+            if close_signer:
+                try:
+                    signer_exchange.close()
+                except Exception:
+                    pass
+
+        step: dict[str, Any] = {
+            "action": "account_transfer",
+            "source": effective_source,
+            "destination": destination,
+            "source_account": source_identity.label,
+            "target_account": target_identity.label,
+            "status": transfer_status,
+        }
+        if transaction_id:
+            step["transaction_id"] = transaction_id
+        steps.append(step)
+        return _success_result(
+            source_account,
+            source,
+            destination,
+            asset,
+            amount,
+            steps,
+            target_account=target_identity.key,
+            target_account_label=target_identity.label,
+            status="pending" if transfer_status == "pending" else "success",
+        )
+
+    def _transfer_wallet(
+        self,
+        exchange: ccxt.Exchange,
+        account: ExchangeAccount,
+        source: str,
+        destination: str,
+        asset: str,
+        amount: Decimal,
+        secrets: list[str],
+    ) -> dict[str, Any]:
+        balance, _ = fetch_account_type_balance(
+            exchange,
+            account.exchange_id,
+            source,
+            self.read_attempts,
+            secrets,
+        )
+        available = _wallet_available(balance, asset)
+        if amount > available:
+            raise AssetTransferError(
+                f"insufficient {asset} balance in {source}: "
+                f"available {_amount_text(available)}"
+            )
+
+        transaction_id = self._submit_wallet_transfer(
+            exchange,
+            account.exchange_id,
+            source,
+            destination,
+            asset,
+            amount,
+            secrets,
+        )
+        step: dict[str, Any] = {
+            "action": "transfer",
+            "source": source,
+            "destination": destination,
+        }
+        if transaction_id:
+            step["transaction_id"] = transaction_id
+        return _success_result(
+            account,
+            source,
+            destination,
+            asset,
+            amount,
+            [step],
+        )
+
+    def _submit_wallet_transfer(
+        self,
+        exchange: ccxt.Exchange,
+        exchange_id: str,
+        source: str,
+        destination: str,
+        asset: str,
+        amount: Decimal,
+        secrets: list[str],
+    ) -> str | None:
+        if exchange_id == "binance":
+            response = _state_change(
+                lambda: exchange.sapiPostAssetTransfer({
+                    "type": _BINANCE_TRANSFER_TYPES[(source, destination)],
+                    "asset": asset,
+                    "amount": _amount_text(amount),
+                }),
+                operation="Binance internal transfer",
+                exchange_label="Binance",
+                secrets=secrets,
+            )
+            transaction_id = response.get("tranId")
+        elif exchange_id == "bitget":
+            response = _state_change(
+                lambda: exchange.privateSpotPostV2SpotWalletTransfer({
+                    "fromType": _BITGET_ACCOUNT_TYPES[source],
+                    "toType": _BITGET_ACCOUNT_TYPES[destination],
+                    "amount": _amount_text(amount),
+                    "coin": asset,
+                    "clientOid": _client_id(),
+                }),
+                operation="Bitget internal transfer",
+                exchange_label="Bitget",
+                secrets=secrets,
+            )
+            data = response.get("data", {})
+            transaction_id = data.get("transferId") if isinstance(data, dict) else None
+        elif exchange_id == "bybit":
+            response = _state_change(
+                lambda: exchange.privatePostV5AssetTransferInterTransfer({
+                    "transferId": str(uuid.uuid4()),
+                    "coin": asset,
+                    "amount": _amount_text(amount),
+                    "fromAccountType": _BYBIT_ACCOUNT_TYPES[source],
+                    "toAccountType": _BYBIT_ACCOUNT_TYPES[destination],
+                }),
+                operation="Bybit internal transfer",
+                exchange_label="Bybit",
+                secrets=secrets,
+            )
+            data = response.get("result", {})
+            transaction_id = data.get("transferId") if isinstance(data, dict) else None
+        elif exchange_id == "okx":
+            response = _state_change(
+                lambda: exchange.privatePostAssetTransfer({
+                    "ccy": asset,
+                    "amt": _amount_text(amount),
+                    "type": "0",
+                    "from": _OKX_ACCOUNT_TYPES[source],
+                    "to": _OKX_ACCOUNT_TYPES[destination],
+                    "clientId": _client_id(),
+                }),
+                operation="OKX internal transfer",
+                exchange_label="OKX",
+                secrets=secrets,
+            )
+            rows = response.get("data", [])
+            first = rows[0] if isinstance(rows, list) and rows else {}
+            transaction_id = first.get("transId") if isinstance(first, dict) else None
+        else:
+            response = _state_change(
+                lambda: exchange.transfer(
+                    asset,
+                    _amount_text(amount),
+                    source,
+                    destination,
+                ),
+                operation="Hyperliquid Spot/Perp transfer",
+                exchange_label="Hyperliquid",
+                secrets=secrets,
+            )
+            if response.get("status") != "ok":
+                raise AssetTransferError(
+                    "Hyperliquid rejected the Spot/Perp transfer",
+                    status_code=502,
+                    details={"status": "failed"},
+                )
+            transaction_id = response.get("id")
+            return str(transaction_id) if transaction_id else None
+
+        if transaction_id is None:
+            raise AssetTransferError(
+                f"{exchange_id} transfer response did not include a transaction ID. "
+                "Check exchange balances before trying again.",
+                status_code=502,
+                details={"status": "unknown"},
+            )
+        return str(transaction_id)
+
+    def _submit_account_transfer(
+        self,
+        exchange: ccxt.Exchange,
+        exchange_id: str,
+        source_account: TransferAccountIdentity,
+        target_account: TransferAccountIdentity,
+        source: str,
+        destination: str,
+        asset: str,
+        amount: Decimal,
+        secrets: list[str],
+    ) -> tuple[str | None, str]:
+        amount_value = _amount_text(amount)
+        if exchange_id == "binance":
+            params: dict[str, Any] = {
+                "fromAccountType": _BINANCE_SUB_ACCOUNT_TYPES[source],
+                "toAccountType": _BINANCE_SUB_ACCOUNT_TYPES[destination],
+                "asset": asset,
+                "amount": amount_value,
+                "clientTranId": _client_id(),
+            }
+            if source_account.role == "sub":
+                params["fromEmail"] = source_account.external_id
+            if target_account.role == "sub":
+                params["toEmail"] = target_account.external_id
+            response = _state_change(
+                lambda: exchange.sapiPostSubAccountUniversalTransfer(params),
+                operation="Binance account transfer",
+                exchange_label="Binance",
+                secrets=secrets,
+            )
+            transaction_id = response.get("tranId")
+        elif exchange_id == "bitget":
+            if not source_account.external_id or not target_account.external_id:
+                raise AssetTransferError("Bitget account UID discovery is incomplete")
+            response = _state_change(
+                lambda: exchange.privateSpotPostV2SpotWalletSubaccountTransfer({
+                    "fromType": _BITGET_ACCOUNT_TYPES[source],
+                    "toType": _BITGET_ACCOUNT_TYPES[destination],
+                    "amount": amount_value,
+                    "coin": asset,
+                    "fromUserId": source_account.external_id,
+                    "toUserId": target_account.external_id,
+                    "clientOid": _client_id(),
+                }),
+                operation="Bitget account transfer",
+                exchange_label="Bitget",
+                secrets=secrets,
+            )
+            data = response.get("data", {})
+            transaction_id = data.get("transferId") if isinstance(data, dict) else None
+        elif exchange_id == "bybit":
+            from_member_id = _integer_account_id(
+                source_account.external_id,
+                "Bybit",
+            )
+            to_member_id = _integer_account_id(
+                target_account.external_id,
+                "Bybit",
+            )
+            response = _state_change(
+                lambda: exchange.privatePostV5AssetTransferUniversalTransfer({
+                    "transferId": str(uuid.uuid4()),
+                    "coin": asset,
+                    "amount": amount_value,
+                    "fromMemberId": from_member_id,
+                    "toMemberId": to_member_id,
+                    "fromAccountType": _BYBIT_ACCOUNT_TYPES[source],
+                    "toAccountType": _BYBIT_ACCOUNT_TYPES[destination],
+                }),
+                operation="Bybit account transfer",
+                exchange_label="Bybit",
+                secrets=secrets,
+            )
+            data = response.get("result", {})
+            status = _external_id(
+                data.get("status") if isinstance(data, dict) else None
+            ).upper()
+            if status in {"FAILED", "STATUS_UNKNOWN"}:
+                raise AssetTransferError(
+                    f"Bybit account transfer returned {status or 'an unknown status'}. "
+                    "Check Bybit transfer history before trying again.",
+                    status_code=502,
+                    details={"status": "unknown" if status == "STATUS_UNKNOWN" else "failed"},
+                )
+            transaction_id = (
+                data.get("transferId") if isinstance(data, dict) else None
+            )
+            transfer_status = "pending" if status == "PENDING" else "success"
+            if transaction_id is None:
+                raise AssetTransferError(
+                    "Bybit account transfer response did not include a transfer ID. "
+                    "Check Bybit before trying again.",
+                    status_code=502,
+                    details={"status": "unknown"},
+                )
+            return str(transaction_id), transfer_status
+        elif exchange_id == "okx":
+            common = {
+                "ccy": asset,
+                "amt": amount_value,
+                "from": _OKX_ACCOUNT_TYPES[source],
+                "to": _OKX_ACCOUNT_TYPES[destination],
+            }
+            if source_account.role == "sub" and target_account.role == "sub":
+                if not source_account.external_id or not target_account.external_id:
+                    raise AssetTransferError("OKX sub-account name discovery is incomplete")
+                response = _state_change(
+                    lambda: exchange.privatePostAssetSubaccountTransfer({
+                        **common,
+                        "fromSubAccount": source_account.external_id,
+                        "toSubAccount": target_account.external_id,
+                    }),
+                    operation="OKX sub-account transfer",
+                    exchange_label="OKX",
+                    secrets=secrets,
+                )
+            else:
+                sub_account = (
+                    target_account.external_id
+                    if target_account.role == "sub"
+                    else source_account.external_id
+                )
+                if not sub_account:
+                    raise AssetTransferError("OKX sub-account name discovery is incomplete")
+                response = _state_change(
+                    lambda: exchange.privatePostAssetTransfer({
+                        **common,
+                        "type": "1" if source_account.role == "main" else "2",
+                        "subAcct": sub_account,
+                        "clientId": _client_id(),
+                    }),
+                    operation="OKX account transfer",
+                    exchange_label="OKX",
+                    secrets=secrets,
+                )
+            rows = _response_rows(response, "data")
+            transaction_id = rows[0].get("transId") if rows else None
+        else:
+            if (
+                source_account.role == "main"
+                and target_account.role == "sub"
+                and target_account.external_id
+            ):
+                from_account = "main"
+                to_account = target_account.external_id
+            elif (
+                source_account.role == "sub"
+                and target_account.role == "main"
+                and source_account.external_id
+            ):
+                from_account = source_account.external_id
+                to_account = "main"
+            else:
+                raise AssetTransferError(
+                    "Hyperliquid supports account transfer only between main and sub accounts"
+                )
+            response = _state_change(
+                lambda: exchange.transfer(
+                    asset,
+                    amount_value,
+                    from_account,
+                    to_account,
+                ),
+                operation="Hyperliquid account transfer",
+                exchange_label="Hyperliquid",
+                secrets=secrets,
+            )
+            status = _external_id(response.get("status")).lower()
+            if status and status not in {"ok", "success"}:
+                raise AssetTransferError(
+                    "Hyperliquid rejected the account transfer",
+                    status_code=502,
+                    details={"status": "failed"},
+                )
+            transaction_id = response.get("id")
+            return (
+                str(transaction_id) if transaction_id else None,
+                "success",
+            )
+
+        if transaction_id is None:
+            raise AssetTransferError(
+                f"{exchange_id} account transfer response did not include a transaction ID. "
+                "Check exchange balances before trying again.",
+                status_code=502,
+                details={"status": "unknown"},
+            )
+        return str(transaction_id), "success"
+
+    def _redeem_binance_earn(
+        self,
+        exchange: ccxt.Exchange,
+        account: ExchangeAccount,
+        destination: str,
+        asset: str,
+        amount: Decimal,
+        product_id: str,
+        secrets: list[str],
+    ) -> dict[str, Any]:
+        if not product_id:
+            raise AssetTransferError("Flexible Earn product is required")
+        positions = fetch_binance_earn_rows(
+            exchange,
+            "sapiGetSimpleEarnFlexiblePosition",
+            self.read_attempts,
+            secrets,
+        )
+        position = next(
+            (
+                row
+                for row in positions
+                if str(row.get("productId") or "") == product_id
+                and str(row.get("asset") or "").upper() == asset
+            ),
+            None,
+        )
+        if position is None:
+            raise AssetTransferError("Flexible Earn position was not found")
+        available = _decimal(position.get("totalAmount") or 0, "Earn balance")
+        if position.get("canRedeem") is False:
+            raise AssetTransferError("this Flexible Earn product cannot be redeemed now")
+        if amount > available:
+            raise AssetTransferError(
+                f"insufficient {asset} Flexible Earn balance: "
+                f"available {_amount_text(available)}"
+            )
+
+        response = _state_change(
+            lambda: exchange.sapiPostSimpleEarnFlexibleRedeem({
+                "productId": product_id,
+                "redeemAll": False,
+                "amount": _amount_text(amount),
+                "destAccount": "SPOT",
+            }),
+            operation="Binance Flexible Earn redemption",
+            exchange_label="Binance",
+            secrets=secrets,
+        )
+        if response.get("success") is not True:
+            raise AssetTransferError(
+                "Binance Earn redemption response was inconclusive. "
+                "Check Binance before trying again.",
+                status_code=502,
+                details={"status": "unknown"},
+            )
+        steps = [{
+            "action": "redeem",
+            "source": "earn",
+            "destination": "spot",
+            "redeem_id": str(response.get("redeemId") or ""),
+        }]
+        self._transfer_redeemed_funds(
+            exchange,
+            account,
+            destination,
+            asset,
+            amount,
+            secrets,
+            steps,
+        )
+        return _success_result(
+            account,
+            "earn",
+            destination,
+            asset,
+            amount,
+            steps,
+        )
+
+    def _redeem_bitget_earn(
+        self,
+        exchange: ccxt.Exchange,
+        account: ExchangeAccount,
+        destination: str,
+        asset: str,
+        amount: Decimal,
+        product_id: str,
+        period_type: str,
+        secrets: list[str],
+    ) -> dict[str, Any]:
+        if not product_id or period_type != "flexible":
+            raise AssetTransferError("Flexible Savings product is required")
+        positions = _bitget_savings_rows(
+            exchange,
+            "flexible",
+            self.read_attempts,
+            secrets,
+        )
+        position = next(
+            (
+                row
+                for row in positions
+                if str(row.get("productId") or "") == product_id
+                and str(row.get("productCoin") or "").upper() == asset
+            ),
+            None,
+        )
+        if position is None:
+            raise AssetTransferError("Bitget Flexible Savings position was not found")
+        available = _decimal(position.get("holdAmount") or 0, "Savings balance")
+        if str(position.get("status") or "").lower() == "in_redemption":
+            raise AssetTransferError("this Savings position is already being redeemed")
+        if amount > available:
+            raise AssetTransferError(
+                f"insufficient {asset} Flexible Savings balance: "
+                f"available {_amount_text(available)}"
+            )
+
+        response = _state_change(
+            lambda: exchange.privateEarnPostV2EarnSavingsRedeem({
+                "periodType": "flexible",
+                "productId": product_id,
+                "amount": _amount_text(amount),
+            }),
+            operation="Bitget Flexible Savings redemption",
+            exchange_label="Bitget",
+            secrets=secrets,
+        )
+        data = response.get("data", {})
+        redeem_id = data.get("orderId") if isinstance(data, dict) else None
+        if redeem_id is None:
+            raise AssetTransferError(
+                "Bitget Savings redemption response did not include an order ID. "
+                "Check Bitget before trying again.",
+                status_code=502,
+                details={"status": "unknown"},
+            )
+        steps = [{
+            "action": "redeem",
+            "source": "earn",
+            "destination": "spot",
+            "redeem_id": str(redeem_id),
+        }]
+        self._transfer_redeemed_funds(
+            exchange,
+            account,
+            destination,
+            asset,
+            amount,
+            secrets,
+            steps,
+        )
+        return _success_result(
+            account,
+            "earn",
+            destination,
+            asset,
+            amount,
+            steps,
+        )
+
+    def _transfer_redeemed_funds(
+        self,
+        exchange: ccxt.Exchange,
+        account: ExchangeAccount,
+        destination: str,
+        asset: str,
+        amount: Decimal,
+        secrets: list[str],
+        steps: list[dict[str, Any]],
+    ) -> None:
+        if destination == "spot":
+            return
+        try:
+            transaction_id = self._submit_wallet_transfer(
+                exchange,
+                account.exchange_id,
+                "spot",
+                destination,
+                asset,
+                amount,
+                secrets,
+            )
+        except AssetTransferError as exc:
+            raise AssetTransferError(
+                f"Earn redemption was accepted, but transfer to {destination} did not "
+                f"complete. The redeemed funds should remain in Spot. {exc}",
+                status_code=502,
+                details={
+                    "status": "partial",
+                    "account": account.name,
+                    "exchange": account.exchange_id,
+                    "asset": asset,
+                    "amount": _amount_text(amount),
+                    "completed_steps": steps,
+                },
+            ) from exc
+        step: dict[str, Any] = {
+            "action": "transfer",
+            "source": "spot",
+            "destination": destination,
+        }
+        if transaction_id:
+            step["transaction_id"] = transaction_id
+        steps.append(step)

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -12,6 +12,7 @@ import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from ai.provider.codex_service import CodexService
+from asset_portfolio import AssetPortfolioService
 from calendar_store import CalendarEventStore
 from config import ensure_provider_config, load_hub_config, load_initial_sessions
 from registry import SessionRegistry
@@ -32,10 +33,18 @@ def build_app(
     registry: SessionRegistry,
     codex_service: CodexService,
     calendar_store: CalendarEventStore,
+    asset_portfolio_service: AssetPortfolioService,
 ) -> FastAPI:
     app = FastAPI()
     app.include_router(build_ui_router())
-    app.include_router(build_control_router(registry, codex_service, calendar_store))
+    app.include_router(
+        build_control_router(
+            registry,
+            codex_service,
+            calendar_store,
+            asset_portfolio_service,
+        )
+    )
     app.include_router(build_validation_router())
     app.include_router(build_session_api_router(registry))
 
@@ -128,6 +137,9 @@ async def main() -> None:
     calendar_store = CalendarEventStore(
         _PROJECT_ROOT / "workdir" / "config" / "calendar_events.json"
     )
+    asset_portfolio_service = AssetPortfolioService(
+        _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
+    )
     codex_service = CodexService(
         project_root=_PROJECT_ROOT,
         session_registry=registry,
@@ -138,9 +150,15 @@ async def main() -> None:
         await codex_service.start()
     except Exception as e:
         print(f"[ai] Codex app-server startup failed: {e}")
-    app = build_app(registry, codex_service, calendar_store)
+    app = build_app(
+        registry,
+        codex_service,
+        calendar_store,
+        asset_portfolio_service,
+    )
 
     await registry.start_all(specs)
+    await asset_portfolio_service.start()
     heartbeat = asyncio.create_task(_hub_status_heartbeat(registry))
 
     server = uvicorn.Server(
@@ -154,7 +172,10 @@ async def main() -> None:
         try:
             await registry.shutdown()
         finally:
-            await codex_service.close()
+            try:
+                await asset_portfolio_service.close()
+            finally:
+                await codex_service.close()
 
 
 if __name__ == "__main__":

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -13,6 +13,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from ai.provider.codex_service import CodexService
 from asset_portfolio import AssetPortfolioService
+from asset_transfer import AssetTransferService
 from calendar_store import CalendarEventStore
 from config import ensure_provider_config, load_hub_config, load_initial_sessions
 from registry import SessionRegistry
@@ -34,6 +35,7 @@ def build_app(
     codex_service: CodexService,
     calendar_store: CalendarEventStore,
     asset_portfolio_service: AssetPortfolioService,
+    asset_transfer_service: AssetTransferService,
 ) -> FastAPI:
     app = FastAPI()
     app.include_router(build_ui_router())
@@ -43,6 +45,7 @@ def build_app(
             codex_service,
             calendar_store,
             asset_portfolio_service,
+            asset_transfer_service,
         )
     )
     app.include_router(build_validation_router())
@@ -140,6 +143,9 @@ async def main() -> None:
     asset_portfolio_service = AssetPortfolioService(
         _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
     )
+    asset_transfer_service = AssetTransferService(
+        _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
+    )
     codex_service = CodexService(
         project_root=_PROJECT_ROOT,
         session_registry=registry,
@@ -155,6 +161,7 @@ async def main() -> None:
         codex_service,
         calendar_store,
         asset_portfolio_service,
+        asset_transfer_service,
     )
 
     await registry.start_all(specs)

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -24,6 +24,7 @@ body {
   .log-content,
   .calendar-body,
   .assets-body,
+  .asset-transfer-body,
   .calendar-forecast-content,
   .calendar-forecast-error {
     scrollbar-color: #3a4350 #0b0e13;
@@ -34,6 +35,7 @@ body {
   .log-content::-webkit-scrollbar,
   .calendar-body::-webkit-scrollbar,
   .assets-body::-webkit-scrollbar,
+  .asset-transfer-body::-webkit-scrollbar,
   .calendar-forecast-content::-webkit-scrollbar,
   .calendar-forecast-error::-webkit-scrollbar {
     width: 10px;
@@ -44,6 +46,7 @@ body {
   .log-content::-webkit-scrollbar-track,
   .calendar-body::-webkit-scrollbar-track,
   .assets-body::-webkit-scrollbar-track,
+  .asset-transfer-body::-webkit-scrollbar-track,
   .calendar-forecast-content::-webkit-scrollbar-track,
   .calendar-forecast-error::-webkit-scrollbar-track {
     background: #0b0e13;
@@ -53,6 +56,7 @@ body {
   .log-content::-webkit-scrollbar-thumb,
   .calendar-body::-webkit-scrollbar-thumb,
   .assets-body::-webkit-scrollbar-thumb,
+  .asset-transfer-body::-webkit-scrollbar-thumb,
   .calendar-forecast-content::-webkit-scrollbar-thumb,
   .calendar-forecast-error::-webkit-scrollbar-thumb {
     background: #3a4350;
@@ -64,6 +68,7 @@ body {
   .log-content::-webkit-scrollbar-thumb:hover,
   .calendar-body::-webkit-scrollbar-thumb:hover,
   .assets-body::-webkit-scrollbar-thumb:hover,
+  .asset-transfer-body::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-content::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-error::-webkit-scrollbar-thumb:hover {
     background: #4a5565;
@@ -72,7 +77,8 @@ body {
   body::-webkit-scrollbar-corner,
   .log-content::-webkit-scrollbar-corner,
   .calendar-body::-webkit-scrollbar-corner,
-  .assets-body::-webkit-scrollbar-corner {
+  .assets-body::-webkit-scrollbar-corner,
+  .asset-transfer-body::-webkit-scrollbar-corner {
     background: #0b0e13;
   }
 }
@@ -1360,6 +1366,317 @@ tr:last-child td { border-bottom: none; }
   animation: assets-spin 700ms linear infinite;
 }
 @keyframes assets-spin { to { transform: rotate(360deg); } }
+
+.asset-transfer-modal {
+  z-index: 90;
+}
+.asset-transfer-box {
+  width: min(460px, 100%);
+  max-height: calc(100vh - 32px);
+}
+.asset-transfer-header {
+  align-items: flex-start;
+}
+.asset-transfer-header > div {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+.asset-transfer-header span {
+  color: #f2f5f8;
+  font-size: 14px;
+  font-weight: 600;
+}
+.asset-transfer-header small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.asset-transfer-body {
+  min-height: 248px;
+  overflow: auto;
+  padding: 16px;
+}
+.asset-transfer-state {
+  min-height: 216px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  color: var(--muted);
+  font-size: 12px;
+}
+.asset-transfer-form {
+  display: grid;
+  gap: 14px;
+}
+.asset-transfer-field {
+  display: grid;
+  gap: 6px;
+}
+.asset-transfer-field > span {
+  color: #aeb7c2;
+  font-size: 11px;
+  font-weight: 600;
+}
+.asset-transfer-field input {
+  width: 100%;
+  min-width: 0;
+  height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #0d1117;
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+}
+.asset-transfer-field input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.asset-transfer-field input:disabled {
+  opacity: 0.58;
+  cursor: not-allowed;
+}
+.asset-transfer-field small {
+  color: var(--muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.asset-transfer-select {
+  position: relative;
+  min-width: 0;
+}
+.asset-transfer-native-select {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+.asset-transfer-select-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: 100%;
+  height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #0d1117;
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+}
+.asset-transfer-select.open .asset-transfer-select-button,
+.asset-transfer-select-button:focus-visible {
+  outline: none;
+  border-color: var(--accent);
+}
+.asset-transfer-select-button:disabled {
+  opacity: 0.58;
+  cursor: not-allowed;
+}
+.asset-transfer-select-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.asset-transfer-select-chevron {
+  flex: none;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1;
+  transition: transform 120ms ease;
+}
+.asset-transfer-select.open .asset-transfer-select-chevron {
+  transform: rotate(180deg);
+}
+.asset-transfer-select-options {
+  position: fixed;
+  z-index: 100;
+  max-height: min(220px, 34vh);
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid #303946;
+  border-radius: 6px;
+  background: #0b0e13;
+  box-shadow: 0 12px 28px rgba(0, 0, 0, 0.44);
+  scrollbar-color: #3a4350 #0b0e13;
+  scrollbar-width: thin;
+}
+.asset-transfer-select-options.hidden {
+  display: none;
+}
+.asset-transfer-select-options::-webkit-scrollbar {
+  width: 9px;
+}
+.asset-transfer-select-options::-webkit-scrollbar-track {
+  background: #0b0e13;
+  border-radius: 999px;
+}
+.asset-transfer-select-options::-webkit-scrollbar-thumb {
+  border: 2px solid #0b0e13;
+  border-radius: 999px;
+  background: #3a4350;
+}
+.asset-transfer-select-options::-webkit-scrollbar-thumb:hover {
+  background: #4a5565;
+}
+.asset-transfer-select-option {
+  display: block;
+  width: 100%;
+  min-height: 34px;
+  padding: 7px 9px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+.asset-transfer-select-option:hover,
+.asset-transfer-select-option:focus-visible {
+  outline: none;
+  background: rgba(41, 98, 255, 0.18);
+}
+.asset-transfer-select-option.selected {
+  color: #ffffff;
+  background: rgba(41, 98, 255, 0.34);
+}
+.asset-transfer-select-option:disabled {
+  color: #5e6875;
+  cursor: not-allowed;
+}
+.asset-transfer-amount-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 7px;
+}
+.asset-transfer-amount-row .btn {
+  min-width: 54px;
+}
+.asset-transfer-note {
+  margin: 0;
+  padding: 9px 10px;
+  border-left: 2px solid #d29922;
+  background: rgba(210, 153, 34, 0.08);
+  color: #c5a75a;
+  font-size: 10px;
+  line-height: 1.5;
+}
+.asset-transfer-review {
+  display: grid;
+  gap: 10px;
+}
+.asset-transfer-review-row {
+  display: grid;
+  grid-template-columns: 94px minmax(0, 1fr);
+  gap: 12px;
+  padding-bottom: 9px;
+  border-bottom: 1px solid #222a34;
+  font-size: 12px;
+}
+.asset-transfer-review-row:last-of-type {
+  padding-bottom: 0;
+  border-bottom: 0;
+}
+.asset-transfer-review-label {
+  color: var(--muted);
+}
+.asset-transfer-review-value {
+  color: #f2f5f8;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  overflow-wrap: anywhere;
+}
+.asset-transfer-warning {
+  margin: 6px 0 0;
+  color: #d29922;
+  font-size: 10px;
+  line-height: 1.5;
+}
+.asset-transfer-result {
+  color: #cbd2db;
+  font-size: 12px;
+  line-height: 1.55;
+}
+.asset-transfer-result strong {
+  display: block;
+  margin-bottom: 7px;
+  color: #7ee787;
+  font-size: 13px;
+}
+.asset-transfer-result-step {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted);
+}
+.asset-transfer-error {
+  margin-top: 12px;
+  color: #ff7b72;
+  font-size: 11px;
+  line-height: 1.5;
+  white-space: pre-wrap;
+}
+.asset-transfer-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--border);
+}
+.asset-transfer-modal button {
+  touch-action: manipulation;
+}
+.assets-legend-row.assets-legend-account-row {
+  appearance: none;
+  grid-template-columns: 9px minmax(46px, 1fr) auto 10px;
+  width: 100%;
+  padding: 4px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #cbd2db;
+  font-family: inherit;
+  text-align: left;
+  -webkit-tap-highlight-color: transparent;
+}
+.assets-legend-account-row .assets-legend-value {
+  grid-column: 2 / 5;
+}
+.assets-legend-chevron {
+  grid-column: 4;
+  align-self: center;
+  color: #697483;
+  font-size: 15px;
+  line-height: 1;
+}
+.assets-legend-chevron-placeholder {
+  visibility: hidden;
+}
+.assets-legend-row.assets-legend-action {
+  cursor: pointer;
+}
+.assets-legend-row.assets-legend-action:hover {
+  background: #171e27;
+}
+.assets-legend-row.assets-legend-action:focus-visible {
+  outline: 1px solid var(--accent);
+  outline-offset: 1px;
+}
+
 .log-content {
   margin: 0;
   padding: 12px 14px;
@@ -2067,7 +2384,29 @@ tr:last-child td { border-bottom: none; }
     gap: 6px;
     font-size: 10px;
   }
+  .assets-legend-row.assets-legend-account-row {
+    grid-template-columns: 8px minmax(38px, 1fr) auto 9px;
+  }
   .assets-legend-value { font-size: 9px; }
+  .asset-transfer-modal {
+    align-items: flex-end;
+    padding: 0;
+  }
+  .asset-transfer-box {
+    width: 100%;
+    max-height: min(78dvh, 620px);
+    border-right: 0;
+    border-bottom: 0;
+    border-left: 0;
+    border-radius: 8px 8px 0 0;
+  }
+  .asset-transfer-body {
+    padding: 14px;
+    padding-bottom: 16px;
+  }
+  .asset-transfer-footer {
+    padding: 11px 14px calc(11px + env(safe-area-inset-bottom, 0px));
+  }
   .clock-hour { height: 8px; }
   .clock-minute { height: 11px; }
   .clock-second { height: 13px; }

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -23,6 +23,7 @@ body {
   body,
   .log-content,
   .calendar-body,
+  .assets-body,
   .calendar-forecast-content,
   .calendar-forecast-error {
     scrollbar-color: #3a4350 #0b0e13;
@@ -32,6 +33,7 @@ body {
   body::-webkit-scrollbar,
   .log-content::-webkit-scrollbar,
   .calendar-body::-webkit-scrollbar,
+  .assets-body::-webkit-scrollbar,
   .calendar-forecast-content::-webkit-scrollbar,
   .calendar-forecast-error::-webkit-scrollbar {
     width: 10px;
@@ -41,6 +43,7 @@ body {
   body::-webkit-scrollbar-track,
   .log-content::-webkit-scrollbar-track,
   .calendar-body::-webkit-scrollbar-track,
+  .assets-body::-webkit-scrollbar-track,
   .calendar-forecast-content::-webkit-scrollbar-track,
   .calendar-forecast-error::-webkit-scrollbar-track {
     background: #0b0e13;
@@ -49,6 +52,7 @@ body {
   body::-webkit-scrollbar-thumb,
   .log-content::-webkit-scrollbar-thumb,
   .calendar-body::-webkit-scrollbar-thumb,
+  .assets-body::-webkit-scrollbar-thumb,
   .calendar-forecast-content::-webkit-scrollbar-thumb,
   .calendar-forecast-error::-webkit-scrollbar-thumb {
     background: #3a4350;
@@ -59,6 +63,7 @@ body {
   body::-webkit-scrollbar-thumb:hover,
   .log-content::-webkit-scrollbar-thumb:hover,
   .calendar-body::-webkit-scrollbar-thumb:hover,
+  .assets-body::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-content::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-error::-webkit-scrollbar-thumb:hover {
     background: #4a5565;
@@ -66,7 +71,8 @@ body {
   html::-webkit-scrollbar-corner,
   body::-webkit-scrollbar-corner,
   .log-content::-webkit-scrollbar-corner,
-  .calendar-body::-webkit-scrollbar-corner {
+  .calendar-body::-webkit-scrollbar-corner,
+  .assets-body::-webkit-scrollbar-corner {
     background: #0b0e13;
   }
 }
@@ -177,6 +183,9 @@ body {
   line-height: 1;
   text-align: center;
 }
+/* the money-bag glyph fills its em square more than the calendar's, so it reads
+   wider at the same font-size — nudge it down to match Calendar's footprint */
+#hub-assets-open .hub-menu-emoji { font-size: 16px; }
 
 .conn {
   font-size: 12px;
@@ -1015,6 +1024,342 @@ tr:last-child td { border-bottom: none; }
 }
 .calendar-event-source:hover { text-decoration: underline; }
 .calendar-empty-day { color: var(--muted); font-size: 12px; }
+
+/* ---- account assets ---- */
+.assets-modal { z-index: 80; }
+.assets-modal-box {
+  width: min(1000px, 100%);
+  max-height: calc(100vh - 32px);
+}
+.assets-modal-header { min-height: 50px; }
+.assets-title-group {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.assets-title-group > span {
+  overflow: hidden;
+  color: #f2f5f8;
+  font-size: 14px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+#assets-back { flex: none; }
+.assets-modal button { touch-action: manipulation; }
+.assets-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 18px;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
+}
+.assets-summary {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 18px;
+  padding: 0 2px 16px;
+  border-bottom: 1px solid var(--border);
+}
+.assets-summary-label {
+  display: block;
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 11px;
+}
+.assets-summary-totals {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 8px 18px;
+  color: #f2f5f8;
+  font-variant-numeric: tabular-nums;
+}
+.assets-summary-total-value {
+  font-size: 24px;
+  font-weight: 650;
+}
+.assets-summary-total-currency {
+  margin-left: 6px;
+  color: #aeb7c2;
+  font-size: 12px;
+  font-weight: 500;
+}
+.assets-summary-meta {
+  flex: none;
+  display: grid;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.35;
+  text-align: right;
+}
+.assets-summary-meta > span { white-space: nowrap; }
+.assets-portfolios {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+.assets-portfolios.assets-overview {
+  display: block;
+}
+.assets-exchange-list {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #11161d;
+}
+.assets-exchange-row {
+  appearance: none;
+  width: 100%;
+  min-height: 68px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 18px;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border: 0;
+  border-bottom: 1px solid #222a34;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 120ms ease;
+}
+.assets-exchange-row:last-child { border-bottom: 0; }
+.assets-exchange-row:hover { background: #171e27; }
+.assets-exchange-row:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid #58a6ff;
+  outline-offset: -2px;
+}
+.assets-exchange-identity { min-width: 0; }
+.assets-exchange-title {
+  display: block;
+  overflow: hidden;
+  color: #f2f5f8;
+  font-size: 14px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.assets-exchange-accounts {
+  display: block;
+  overflow: hidden;
+  margin-top: 4px;
+  color: var(--muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.assets-exchange-total {
+  color: #f2f5f8;
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  text-align: right;
+  white-space: nowrap;
+}
+.assets-exchange-total span {
+  margin-left: 4px;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 500;
+}
+.assets-exchange-chevron {
+  width: 17px;
+  height: 17px;
+  fill: none;
+  stroke: #697483;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.assets-portfolio {
+  min-width: 0;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #11161d;
+}
+.assets-portfolio-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+.assets-account-name {
+  min-width: 0;
+  color: #f2f5f8;
+  font-size: 14px;
+  font-weight: 600;
+  overflow-wrap: anywhere;
+}
+.assets-exchange-name {
+  display: block;
+  margin-top: 3px;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+.assets-account-total {
+  flex: none;
+  color: #f2f5f8;
+  font-size: 14px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+  text-align: right;
+}
+.assets-account-total span {
+  margin-left: 4px;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 500;
+}
+.assets-portfolio-content {
+  display: grid;
+  grid-template-columns: 164px minmax(0, 1fr);
+  align-items: center;
+  gap: 16px;
+}
+.assets-donut {
+  appearance: none;
+  position: relative;
+  display: block;
+  width: 164px;
+  padding: 0;
+  border: 0;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: #29313c;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+  -webkit-tap-highlight-color: transparent;
+  transition: filter 120ms ease, box-shadow 120ms ease;
+}
+.assets-donut:hover { filter: brightness(1.08); }
+.assets-donut:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 3px;
+}
+.assets-donut.showing-account-types {
+  box-shadow:
+    inset 0 0 0 1px rgba(255, 255, 255, 0.08),
+    0 0 0 1px rgba(88, 166, 255, 0.22);
+}
+.assets-donut::after {
+  content: "";
+  position: absolute;
+  inset: 28%;
+  border-radius: 50%;
+  background: #11161d;
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+.assets-donut-center {
+  position: absolute;
+  inset: 31%;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.3;
+  text-align: center;
+}
+.assets-legend {
+  min-width: 0;
+  display: grid;
+  gap: 7px;
+}
+.assets-legend-row {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: 9px minmax(46px, 1fr) auto;
+  align-items: center;
+  gap: 7px;
+  color: #cbd2db;
+  font-size: 11px;
+}
+.assets-legend-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--asset-color);
+}
+.assets-legend-currency {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.assets-legend-weight {
+  color: #f2f5f8;
+  font-variant-numeric: tabular-nums;
+}
+.assets-legend-value {
+  grid-column: 2 / 4;
+  margin-top: -5px;
+  color: #707a87;
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+}
+.assets-portfolio-footer {
+  display: grid;
+  gap: 4px;
+  margin-top: 13px;
+  padding-top: 10px;
+  border-top: 1px solid #222a34;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.4;
+}
+.assets-account-list {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.assets-warning { color: #ff9b95; overflow-wrap: anywhere; }
+.assets-state {
+  min-height: 220px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+.assets-state-error {
+  flex-direction: column;
+  color: #ff7b72;
+  white-space: pre-wrap;
+}
+.assets-spinner {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  border: 2px solid #313a46;
+  border-top-color: #58a6ff;
+  border-radius: 50%;
+  animation: assets-spin 700ms linear infinite;
+}
+#assets-refresh.assets-refreshing .icon {
+  animation: assets-spin 700ms linear infinite;
+}
+@keyframes assets-spin { to { transform: rotate(360deg); } }
 .log-content {
   margin: 0;
   padding: 12px 14px;
@@ -1640,6 +1985,89 @@ tr:last-child td { border-bottom: none; }
     right: 44px;
     width: calc(100% - 62px);
   }
+  .assets-modal { padding: 0; }
+  .assets-modal-box {
+    position: relative;
+    width: 100%;
+    height: 100dvh;
+    max-height: none;
+    border: 0;
+    border-radius: 0;
+  }
+  .assets-modal.assets-opening {
+    animation: calendar-backdrop-in 220ms ease-out;
+  }
+  .assets-modal.assets-opening .assets-modal-box {
+    animation: calendar-sheet-in 220ms cubic-bezier(0.22, 0.75, 0.25, 1);
+  }
+  .assets-modal.assets-dragging .assets-modal-box {
+    animation: none;
+    transition: none;
+  }
+  .assets-modal.assets-closing {
+    animation: calendar-backdrop-out 220ms ease-in forwards;
+  }
+  .assets-modal.assets-closing .assets-modal-box {
+    animation: calendar-sheet-out 220ms cubic-bezier(0.55, 0, 1, 0.45) forwards;
+  }
+  .assets-modal.assets-closing.assets-swipe-closing .assets-modal-box {
+    animation: none;
+  }
+  .assets-modal-header {
+    position: relative;
+    padding-top: calc(18px + env(safe-area-inset-top));
+    touch-action: none;
+  }
+  .assets-modal-header::before {
+    content: "";
+    position: absolute;
+    top: calc(7px + env(safe-area-inset-top));
+    left: 50%;
+    width: 40px;
+    height: 4px;
+    margin-left: -20px;
+    border-radius: 999px;
+    background: var(--border);
+  }
+  .assets-body {
+    padding: 12px;
+    padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px));
+  }
+  .assets-summary {
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+    padding: 2px 2px 13px;
+  }
+  .assets-summary-total-value { font-size: 20px; }
+  .assets-summary-meta {
+    padding-top: 0;
+    font-size: 10px;
+  }
+  .assets-portfolios { grid-template-columns: minmax(0, 1fr); }
+  .assets-exchange-row {
+    min-height: 64px;
+    grid-template-columns: minmax(0, 1fr) auto 16px;
+    gap: 10px;
+    padding: 11px 12px;
+  }
+  .assets-exchange-total { font-size: 13px; }
+  .assets-portfolio { padding: 12px; }
+  .assets-portfolio-content {
+    grid-template-columns: minmax(122px, 42%) minmax(0, 1fr);
+    gap: 12px;
+  }
+  .assets-donut {
+    width: min(100%, 150px);
+    justify-self: center;
+  }
+  .assets-legend { gap: 6px; }
+  .assets-legend-row {
+    grid-template-columns: 8px minmax(38px, 1fr) auto;
+    gap: 6px;
+    font-size: 10px;
+  }
+  .assets-legend-value { font-size: 9px; }
   .clock-hour { height: 8px; }
   .clock-minute { height: 11px; }
   .clock-second { height: 13px; }

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=48" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=50" />
 </head>
 <body>
   <header class="topbar">
@@ -192,6 +192,99 @@
     </div>
   </div>
 
+  <div id="asset-transfer-modal" class="modal asset-transfer-modal hidden" aria-hidden="true">
+    <div class="modal-box asset-transfer-box" role="dialog" aria-modal="true"
+         aria-labelledby="asset-transfer-title">
+      <div class="modal-header asset-transfer-header">
+        <div>
+          <span id="asset-transfer-title">Internal transfer</span>
+          <small id="asset-transfer-subtitle"></small>
+        </div>
+        <button id="asset-transfer-close" class="btn" type="button"
+                title="Close" aria-label="Close">&times;</button>
+      </div>
+      <div id="asset-transfer-body" class="asset-transfer-body">
+        <div id="asset-transfer-loading" class="asset-transfer-state">
+          <span class="assets-spinner" aria-hidden="true"></span>
+          <span>Loading transferable balance...</span>
+        </div>
+        <form id="asset-transfer-form" class="asset-transfer-form hidden">
+          <div class="asset-transfer-field">
+            <span id="asset-transfer-asset-caption">Asset</span>
+            <div id="asset-transfer-asset-control" class="asset-transfer-select">
+              <select id="asset-transfer-asset" class="asset-transfer-native-select"
+                      tabindex="-1" aria-hidden="true"></select>
+              <button id="asset-transfer-asset-button" class="asset-transfer-select-button"
+                      type="button" aria-haspopup="listbox" aria-expanded="false"
+                      aria-controls="asset-transfer-asset-options"
+                      aria-labelledby="asset-transfer-asset-caption asset-transfer-asset-label">
+                <span id="asset-transfer-asset-label" class="asset-transfer-select-label">
+                  Select asset
+                </span>
+                <span class="asset-transfer-select-chevron" aria-hidden="true">&#9662;</span>
+              </button>
+              <div id="asset-transfer-asset-options"
+                   class="asset-transfer-select-options hidden" role="listbox"></div>
+            </div>
+          </div>
+          <label class="asset-transfer-field">
+            <span>Amount</span>
+            <div class="asset-transfer-amount-row">
+              <input id="asset-transfer-amount" type="text" inputmode="decimal"
+                     autocomplete="off" enterkeyhint="done" />
+              <button id="asset-transfer-max" class="btn" type="button">Max</button>
+            </div>
+            <small id="asset-transfer-available"></small>
+          </label>
+          <div class="asset-transfer-field">
+            <span id="asset-transfer-account-caption">Account</span>
+            <div id="asset-transfer-account-control" class="asset-transfer-select">
+              <select id="asset-transfer-account" class="asset-transfer-native-select"
+                      tabindex="-1" aria-hidden="true"></select>
+              <button id="asset-transfer-account-button"
+                      class="asset-transfer-select-button" type="button"
+                      aria-haspopup="listbox" aria-expanded="false"
+                      aria-controls="asset-transfer-account-options"
+                      aria-labelledby="asset-transfer-account-caption asset-transfer-account-label">
+                <span id="asset-transfer-account-label"
+                      class="asset-transfer-select-label">Select account</span>
+                <span class="asset-transfer-select-chevron" aria-hidden="true">&#9662;</span>
+              </button>
+              <div id="asset-transfer-account-options"
+                   class="asset-transfer-select-options hidden" role="listbox"></div>
+            </div>
+          </div>
+          <div class="asset-transfer-field">
+            <span id="asset-transfer-destination-caption">To</span>
+            <div id="asset-transfer-destination-control" class="asset-transfer-select">
+              <select id="asset-transfer-destination" class="asset-transfer-native-select"
+                      tabindex="-1" aria-hidden="true"></select>
+              <button id="asset-transfer-destination-button"
+                      class="asset-transfer-select-button" type="button"
+                      aria-haspopup="listbox" aria-expanded="false"
+                      aria-controls="asset-transfer-destination-options"
+                      aria-labelledby="asset-transfer-destination-caption asset-transfer-destination-label">
+                <span id="asset-transfer-destination-label"
+                      class="asset-transfer-select-label">Select destination</span>
+                <span class="asset-transfer-select-chevron" aria-hidden="true">&#9662;</span>
+              </button>
+              <div id="asset-transfer-destination-options"
+                   class="asset-transfer-select-options hidden" role="listbox"></div>
+            </div>
+          </div>
+          <p id="asset-transfer-note" class="asset-transfer-note hidden"></p>
+        </form>
+        <div id="asset-transfer-review" class="asset-transfer-review hidden"></div>
+        <div id="asset-transfer-result" class="asset-transfer-result hidden"></div>
+        <div id="asset-transfer-error" class="asset-transfer-error hidden" role="alert"></div>
+      </div>
+      <div class="asset-transfer-footer">
+        <button id="asset-transfer-back" class="btn" type="button">Cancel</button>
+        <button id="asset-transfer-submit" class="btn btn-primary" type="button" disabled>Review</button>
+      </div>
+    </div>
+  </div>
+
   <div id="log-modal" class="modal hidden" aria-hidden="true">
     <div class="modal-box">
       <div class="modal-header">
@@ -311,6 +404,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=47"></script>
+  <script src="/static/dashboard.js?v=51"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=38" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=48" />
 </head>
 <body>
   <header class="topbar">
@@ -31,6 +31,10 @@
       <button id="hub-menu-close" class="hub-menu-close" type="button" aria-label="Close menu">&times;</button>
     </div>
     <nav class="hub-menu-nav" aria-label="Hub menu">
+      <button id="hub-assets-open" class="hub-menu-item" type="button">
+        <span class="hub-menu-emoji" aria-hidden="true">&#x1f4b0;</span>
+        <span>Assets</span>
+      </button>
       <button id="hub-calendar-open" class="hub-menu-item" type="button">
         <span class="hub-menu-emoji" aria-hidden="true">&#x1f4c5;</span>
         <span>Calendar</span>
@@ -134,6 +138,56 @@
           <h3 id="calendar-detail-date"></h3>
           <div id="calendar-detail-events" class="calendar-detail-events"></div>
         </section>
+      </div>
+    </div>
+  </div>
+
+  <div id="assets-modal" class="modal assets-modal hidden" aria-hidden="true">
+    <div class="modal-box assets-modal-box" role="dialog" aria-modal="true" aria-labelledby="assets-title">
+      <div class="modal-header assets-modal-header">
+        <div class="assets-title-group">
+          <button id="assets-back" class="btn btn-icon hidden" type="button"
+                  title="Back to exchanges" aria-label="Back to exchanges">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M19 12H5" />
+              <path d="m12 19-7-7 7-7" />
+            </svg>
+          </button>
+          <span id="assets-title">Assets</span>
+        </div>
+        <div class="modal-actions">
+          <button id="assets-refresh" class="btn btn-icon" type="button"
+                  title="Refresh assets" aria-label="Refresh assets">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M3 12a9 9 0 0 1 15.7-6L21 8" />
+              <path d="M21 3v5h-5" />
+              <path d="M21 12a9 9 0 0 1-15.7 6L3 16" />
+              <path d="M3 21v-5h5" />
+            </svg>
+          </button>
+          <button id="assets-close" class="btn" type="button" title="Close" aria-label="Close">&times;</button>
+        </div>
+      </div>
+      <div class="assets-body">
+        <section id="assets-summary" class="assets-summary hidden" aria-label="Asset summary">
+          <div>
+            <span class="assets-summary-label">Total assets</span>
+            <div id="assets-summary-totals" class="assets-summary-totals"></div>
+          </div>
+          <div class="assets-summary-meta">
+            <span id="assets-summary-counts"></span>
+            <span id="assets-updated"></span>
+          </div>
+        </section>
+        <div id="assets-loading" class="assets-state">
+          <span class="assets-spinner" aria-hidden="true"></span>
+          <span>Loading account assets...</span>
+        </div>
+        <div id="assets-error" class="assets-state assets-state-error hidden" role="alert"></div>
+        <div id="assets-empty" class="assets-state hidden">
+          No exchange accounts are configured in providers.toml.
+        </div>
+        <div id="assets-portfolios" class="assets-portfolios"></div>
       </div>
     </div>
   </div>
@@ -257,6 +311,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=41"></script>
+  <script src="/static/dashboard.js?v=47"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -35,12 +35,24 @@
     "#3b82f6", "#f59e0b", "#10b981", "#ef4444",
     "#a78bfa", "#22d3ee", "#f472b6", "#94a3b8",
   ];
+  const assetTransferSources = {
+    binance: new Set(["spot", "swap", "margin", "funding", "earn"]),
+    bitget: new Set(["spot", "swap", "margin", "funding", "earn"]),
+    bybit: new Set(["spot", "swap", "margin", "funding"]),
+    okx: new Set(["spot", "funding"]),
+    hyperliquid: new Set(["spot", "swap"]),
+  };
   let assetsRequestSeq = 0;
   let assetsOpenTimer = null;
   let assetsCloseTimer = null;
   let assetsHaveData = false;
   let assetsPayload = null;
   let selectedAssetExchange = null;
+  let assetTransferRequestSeq = 0;
+  let assetTransferContext = null;
+  let assetTransferReview = null;
+  let assetTransferMode = "options";
+  let assetTransferSubmitting = false;
 
   const el = (id) => document.getElementById(id);
 
@@ -306,6 +318,7 @@
 
   function closeAssets(options = {}) {
     if (!isAssetsOpen()) return;
+    closeAssetTransfer();
     const modal = el("assets-modal");
     if (modal.classList.contains("assets-closing")) return;
     const fromDrag = options && options.fromDrag === true;
@@ -351,6 +364,607 @@
       minimumFractionDigits: 0,
       maximumFractionDigits: 8,
     });
+  }
+
+  function assetAccountTypeLabel(accountType, exchange = "") {
+    const account = String(accountType || "").toLowerCase();
+    const exchangeId = String(exchange || "").toLowerCase();
+    if (exchangeId === "okx" && account === "spot") return "Trading";
+    if (
+      exchangeId === "bybit"
+      && ["spot", "swap", "margin"].includes(account)
+    ) return "Unified";
+    if (exchangeId === "hyperliquid" && account === "swap") return "Perps";
+    if (exchangeId === "bitget" && account === "swap") return "USDT-M Futures";
+    const labels = {
+      spot: "Spot",
+      swap: "USD\u24c8-M Futures",
+      margin: "Cross Margin",
+      funding: "Funding",
+      earn: "Earn",
+    };
+    return labels[account]
+      || String(accountType || "Unknown");
+  }
+
+  function supportsAssetTransfer(exchange, accountType) {
+    const sources = assetTransferSources[String(exchange || "").toLowerCase()];
+    return Boolean(sources && sources.has(String(accountType || "").toLowerCase()));
+  }
+
+  function isAssetTransferOpen() {
+    return !el("asset-transfer-modal").classList.contains("hidden");
+  }
+
+  function assetTransferSelectNodes(name) {
+    const prefix = `asset-transfer-${name}`;
+    return {
+      control: el(`${prefix}-control`),
+      select: el(prefix),
+      button: el(`${prefix}-button`),
+      label: el(`${prefix}-label`),
+      options: el(`${prefix}-options`),
+    };
+  }
+
+  function closeAssetTransferDropdown(name = null) {
+    ["asset", "account", "destination"].forEach((key) => {
+      if (name && key === name) return;
+      const nodes = assetTransferSelectNodes(key);
+      if (!nodes.control) return;
+      nodes.control.classList.remove("open");
+      nodes.button.setAttribute("aria-expanded", "false");
+      nodes.options.classList.add("hidden");
+    });
+  }
+
+  function syncAssetTransferDropdown(name) {
+    const nodes = assetTransferSelectNodes(name);
+    if (!nodes.select || !nodes.options) return;
+    const options = Array.from(nodes.select.options);
+    const selected = options.find((option) => option.value === nodes.select.value)
+      || options.find((option) => option.selected)
+      || null;
+    nodes.label.textContent = selected
+      ? selected.textContent
+      : name === "asset"
+        ? "Select asset"
+        : name === "account" ? "Select account" : "Select destination";
+    nodes.button.title = selected ? selected.textContent : "";
+    nodes.button.disabled = !options.some((option) => !option.disabled);
+    nodes.options.replaceChildren();
+    options.forEach((option) => {
+      const item = document.createElement("button");
+      item.type = "button";
+      item.className = "asset-transfer-select-option";
+      item.dataset.value = option.value;
+      item.textContent = option.textContent;
+      item.disabled = option.disabled;
+      item.setAttribute("role", "option");
+      item.setAttribute(
+        "aria-selected",
+        String(option.value === nodes.select.value),
+      );
+      item.classList.toggle("selected", option.value === nodes.select.value);
+      nodes.options.appendChild(item);
+    });
+  }
+
+  function positionAssetTransferDropdown(name) {
+    const nodes = assetTransferSelectNodes(name);
+    if (!nodes.button || !nodes.options || nodes.options.classList.contains("hidden")) {
+      return;
+    }
+    const rect = nodes.button.getBoundingClientRect();
+    const viewport = window.visualViewport;
+    const viewportTop = viewport ? viewport.offsetTop : 0;
+    const viewportLeft = viewport ? viewport.offsetLeft : 0;
+    const viewportHeight = viewport ? viewport.height : window.innerHeight;
+    const viewportWidth = viewport ? viewport.width : window.innerWidth;
+    const viewportBottom = viewportTop + viewportHeight;
+    const viewportRight = viewportLeft + viewportWidth;
+    const gap = 5;
+    const edge = 8;
+    const width = Math.min(rect.width, viewportWidth - edge * 2);
+    const left = Math.min(
+      Math.max(rect.left, viewportLeft + edge),
+      viewportRight - width - edge,
+    );
+    const spaceBelow = Math.max(0, viewportBottom - rect.bottom - gap - edge);
+    const spaceAbove = Math.max(0, rect.top - viewportTop - gap - edge);
+    const desiredHeight = Math.min(nodes.options.scrollHeight, 220);
+    const openBelow = spaceBelow >= Math.min(desiredHeight, 120)
+      || spaceBelow >= spaceAbove;
+    const availableHeight = Math.max(72, openBelow ? spaceBelow : spaceAbove);
+    const menuHeight = Math.min(desiredHeight, availableHeight);
+    const top = openBelow
+      ? rect.bottom + gap
+      : rect.top - gap - menuHeight;
+
+    nodes.options.style.left = `${Math.round(left)}px`;
+    nodes.options.style.top = `${Math.round(Math.max(viewportTop + edge, top))}px`;
+    nodes.options.style.width = `${Math.round(width)}px`;
+    nodes.options.style.maxHeight = `${Math.round(availableHeight)}px`;
+  }
+
+  function openAssetTransferDropdown(name, focusOption = false) {
+    const nodes = assetTransferSelectNodes(name);
+    if (!nodes.control || nodes.button.disabled) return;
+    closeAssetTransferDropdown(name);
+    syncAssetTransferDropdown(name);
+    nodes.control.classList.add("open");
+    nodes.button.setAttribute("aria-expanded", "true");
+    nodes.options.classList.remove("hidden");
+    positionAssetTransferDropdown(name);
+    if (focusOption) {
+      const target = nodes.options.querySelector(
+        ".asset-transfer-select-option.selected:not(:disabled), "
+          + ".asset-transfer-select-option:not(:disabled)",
+      );
+      if (target) target.focus();
+    }
+  }
+
+  function toggleAssetTransferDropdown(name) {
+    const nodes = assetTransferSelectNodes(name);
+    if (!nodes.options) return;
+    if (nodes.options.classList.contains("hidden")) {
+      openAssetTransferDropdown(name);
+    } else {
+      closeAssetTransferDropdown();
+    }
+  }
+
+  function selectAssetTransferDropdownValue(name, value) {
+    const nodes = assetTransferSelectNodes(name);
+    if (!nodes.select) return;
+    nodes.select.value = String(value || "");
+    nodes.select.dispatchEvent(new Event("change", { bubbles: true }));
+    syncAssetTransferDropdown(name);
+  }
+
+  function initAssetTransferDropdown(name) {
+    const nodes = assetTransferSelectNodes(name);
+    nodes.button.addEventListener("click", (event) => {
+      event.preventDefault();
+      toggleAssetTransferDropdown(name);
+    });
+    nodes.button.addEventListener("keydown", (event) => {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        openAssetTransferDropdown(name, true);
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        closeAssetTransferDropdown();
+      }
+    });
+    nodes.options.addEventListener("click", (event) => {
+      const option = event.target && event.target.closest
+        ? event.target.closest(".asset-transfer-select-option")
+        : null;
+      if (!option || option.disabled) return;
+      selectAssetTransferDropdownValue(name, option.dataset.value);
+      closeAssetTransferDropdown();
+      nodes.button.focus();
+    });
+    nodes.options.addEventListener("keydown", (event) => {
+      const options = Array.from(
+        nodes.options.querySelectorAll(".asset-transfer-select-option:not(:disabled)"),
+      );
+      const index = options.indexOf(document.activeElement);
+      let next = null;
+      if (event.key === "ArrowDown") next = Math.min(index + 1, options.length - 1);
+      else if (event.key === "ArrowUp") next = Math.max(index - 1, 0);
+      else if (event.key === "Home") next = 0;
+      else if (event.key === "End") next = options.length - 1;
+      else if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        closeAssetTransferDropdown();
+        nodes.button.focus();
+        return;
+      }
+      if (next !== null && options[next]) {
+        event.preventDefault();
+        options[next].focus();
+      }
+    });
+  }
+
+  function closeAssetTransfer() {
+    if (!isAssetTransferOpen() || assetTransferSubmitting) return;
+    assetTransferRequestSeq += 1;
+    assetTransferContext = null;
+    assetTransferReview = null;
+    assetTransferMode = "options";
+    assetTransferSubmitting = false;
+    closeAssetTransferDropdown();
+    const modal = el("asset-transfer-modal");
+    modal.classList.add("hidden");
+    modal.setAttribute("aria-hidden", "true");
+  }
+
+  function setAssetTransferError(message) {
+    const error = el("asset-transfer-error");
+    error.textContent = String(message || "");
+    error.classList.toggle("hidden", !message);
+  }
+
+  function setAssetTransferMode(mode) {
+    assetTransferMode = mode;
+    const loading = mode === "loading";
+    const options = mode === "options";
+    const review = mode === "review";
+    const result = mode === "result";
+    el("asset-transfer-loading").classList.toggle("hidden", !loading);
+    el("asset-transfer-form").classList.toggle("hidden", !options);
+    el("asset-transfer-review").classList.toggle("hidden", !review);
+    el("asset-transfer-result").classList.toggle("hidden", !result);
+    el("asset-transfer-back").textContent = review ? "Edit" : "Cancel";
+    el("asset-transfer-back").classList.toggle("hidden", result);
+    el("asset-transfer-submit").textContent = review
+      ? "Confirm transfer"
+      : result ? "Done" : "Review";
+    if (!options) closeAssetTransferDropdown();
+  }
+
+  function selectedAssetTransferItem() {
+    if (!assetTransferContext) return null;
+    const key = el("asset-transfer-asset").value;
+    return (Array.isArray(assetTransferContext.assets)
+      ? assetTransferContext.assets
+      : []).find((item) => item.key === key) || null;
+  }
+
+  function selectedAssetTransferAccount() {
+    if (!assetTransferContext) return null;
+    const key = el("asset-transfer-account").value;
+    return (Array.isArray(assetTransferContext.target_accounts)
+      ? assetTransferContext.target_accounts
+      : []).find((account) => account.key === key) || null;
+  }
+
+  function renderAssetTransferDestinations() {
+    const account = selectedAssetTransferAccount();
+    const destinations = account && Array.isArray(account.destinations)
+      ? account.destinations
+      : [];
+    const destinationSelect = el("asset-transfer-destination");
+    destinationSelect.replaceChildren();
+    destinations.forEach((destination) => {
+      const option = document.createElement("option");
+      option.value = destination;
+      option.textContent = assetAccountTypeLabel(
+        destination,
+        assetTransferContext && assetTransferContext.exchange,
+      );
+      destinationSelect.appendChild(option);
+    });
+    if (!destinations.length) {
+      const empty = document.createElement("option");
+      empty.value = "";
+      empty.textContent = "No supported destination";
+      empty.disabled = true;
+      empty.selected = true;
+      destinationSelect.appendChild(empty);
+    }
+    syncAssetTransferDropdown("destination");
+  }
+
+  function updateAssetTransferForm() {
+    if (!assetTransferContext || assetTransferMode !== "options") return;
+    const item = selectedAssetTransferItem();
+    const targetAccount = selectedAssetTransferAccount();
+    const destination = el("asset-transfer-destination").value;
+    const amount = Number(el("asset-transfer-amount").value);
+    const available = item ? Number(item.available) : 0;
+    const valid = Boolean(
+      item
+      && item.transferable
+      && targetAccount
+      && destination
+      && Number.isFinite(amount)
+      && amount > 0
+      && amount <= available,
+    );
+    el("asset-transfer-submit").disabled = !valid;
+    el("asset-transfer-max").disabled = !item || !item.transferable;
+    el("asset-transfer-amount").disabled = !item || !item.transferable;
+    el("asset-transfer-available").textContent = item
+      ? `Available ${formatAssetAmount(item.available)} ${item.asset}`
+      : "No transferable balance";
+
+    const notes = [];
+    if (item && item.note) notes.push(String(item.note));
+    if (
+      assetTransferContext.source === "earn"
+      && item
+      && item.source_kind === "flexible"
+      && destination !== "spot"
+    ) {
+      notes.push(
+        `This runs in two steps: redeem to Spot, then transfer to ${
+          assetAccountTypeLabel(destination, assetTransferContext.exchange)
+        }.`,
+      );
+    }
+    const note = el("asset-transfer-note");
+    note.textContent = notes.join(" ");
+    note.classList.toggle("hidden", notes.length === 0);
+  }
+
+  function renderAssetTransferOptions(context) {
+    assetTransferContext = context;
+    const assetSelect = el("asset-transfer-asset");
+    assetSelect.replaceChildren();
+    const items = Array.isArray(context.assets) ? context.assets : [];
+    items.forEach((item) => {
+      const option = document.createElement("option");
+      option.value = item.key;
+      const kind = item.source_kind === "flexible"
+        ? "Flexible"
+        : item.source_kind === "locked"
+          ? "Locked"
+          : item.source_kind === "fixed" ? "Fixed" : "";
+      option.textContent = [
+        item.asset,
+        kind,
+        formatAssetAmount(item.available),
+      ].filter(Boolean).join(" \u00b7 ");
+      option.disabled = !item.transferable;
+      assetSelect.appendChild(option);
+    });
+    const firstTransferable = items.find((item) => item.transferable);
+    if (firstTransferable) {
+      assetSelect.value = firstTransferable.key;
+    } else {
+      const empty = document.createElement("option");
+      empty.value = "";
+      empty.textContent = items.length
+        ? "No transferable balance"
+        : "No assets available";
+      empty.disabled = true;
+      empty.selected = true;
+      assetSelect.prepend(empty);
+    }
+
+    const accountSelect = el("asset-transfer-account");
+    accountSelect.replaceChildren();
+    const targetAccounts = Array.isArray(context.target_accounts)
+      ? context.target_accounts
+      : [{
+        key: context.account,
+        label: context.account,
+        role: "standalone",
+        destinations: context.destinations || [],
+      }];
+    targetAccounts.forEach((account) => {
+      const option = document.createElement("option");
+      option.value = account.key;
+      option.textContent = account.role === "main"
+        ? `${account.label} \u00b7 Main`
+        : account.role === "sub"
+          ? `${account.label} \u00b7 Sub`
+          : account.label;
+      accountSelect.appendChild(option);
+    });
+    syncAssetTransferDropdown("asset");
+    syncAssetTransferDropdown("account");
+    renderAssetTransferDestinations();
+    el("asset-transfer-amount").value = "";
+    el("asset-transfer-amount").placeholder = "0";
+    setAssetTransferMode("options");
+    setAssetTransferError("");
+    updateAssetTransferForm();
+  }
+
+  async function openAssetTransfer(portfolio, source) {
+    const exchangeId = String(portfolio.exchange || "").toLowerCase();
+    if (!supportsAssetTransfer(exchangeId, source)) return;
+    const requestId = ++assetTransferRequestSeq;
+    assetTransferContext = null;
+    assetTransferReview = null;
+    assetTransferSubmitting = false;
+    setAssetTransferError("");
+    el("asset-transfer-review").replaceChildren();
+    el("asset-transfer-result").replaceChildren();
+    el("asset-transfer-title").textContent =
+      `${assetExchangeLabel(exchangeId)} transfer`;
+    el("asset-transfer-subtitle").textContent =
+      `${portfolio.account} \u00b7 ${assetAccountTypeLabel(source, exchangeId)}`;
+    el("asset-transfer-submit").disabled = true;
+    setAssetTransferMode("loading");
+    const modal = el("asset-transfer-modal");
+    modal.classList.remove("hidden");
+    modal.setAttribute("aria-hidden", "false");
+    try {
+      const query = new URLSearchParams({
+        exchange: exchangeId,
+        account: String(portfolio.account || ""),
+        source: String(source || ""),
+      });
+      const context = await api(`/api/assets/transfer/options?${query}`);
+      if (requestId !== assetTransferRequestSeq || !isAssetTransferOpen()) return;
+      renderAssetTransferOptions(context);
+    } catch (error) {
+      if (requestId !== assetTransferRequestSeq || !isAssetTransferOpen()) return;
+      setAssetTransferMode("options");
+      el("asset-transfer-form").classList.add("hidden");
+      setAssetTransferError(error.message || String(error));
+    }
+  }
+
+  function appendAssetTransferReviewRow(container, label, value) {
+    const row = document.createElement("div");
+    row.className = "asset-transfer-review-row";
+    const name = document.createElement("span");
+    name.className = "asset-transfer-review-label";
+    name.textContent = label;
+    const detail = document.createElement("span");
+    detail.className = "asset-transfer-review-value";
+    detail.textContent = value;
+    row.append(name, detail);
+    container.appendChild(row);
+  }
+
+  function reviewAssetTransfer() {
+    const item = selectedAssetTransferItem();
+    const targetAccount = selectedAssetTransferAccount();
+    const amount = el("asset-transfer-amount").value.trim();
+    const amountNumber = Number(amount);
+    const available = item ? Number(item.available) : 0;
+    const destination = el("asset-transfer-destination").value;
+    if (
+      !assetTransferContext
+      || !item
+      || !item.transferable
+      || !targetAccount
+      || !destination
+      || !Number.isFinite(amountNumber)
+      || amountNumber <= 0
+      || amountNumber > available
+    ) {
+      setAssetTransferError("Enter an amount within the available balance.");
+      return;
+    }
+    assetTransferReview = {
+      exchange: assetTransferContext.exchange,
+      account: assetTransferContext.account,
+      target_account: targetAccount.key,
+      target_account_label: targetAccount.label,
+      source: assetTransferContext.source,
+      destination,
+      asset: item.asset,
+      amount,
+      product_id: item.product_id || null,
+      period_type: item.period_type || null,
+      order_id: item.order_id || null,
+    };
+    const review = el("asset-transfer-review");
+    review.replaceChildren();
+    appendAssetTransferReviewRow(
+      review,
+      "From",
+      `${assetTransferReview.account} \u00b7 ${assetAccountTypeLabel(
+        assetTransferReview.source,
+        assetTransferReview.exchange,
+      )}`,
+    );
+    appendAssetTransferReviewRow(
+      review,
+      "To",
+      `${assetTransferReview.target_account_label} \u00b7 ${assetAccountTypeLabel(
+        assetTransferReview.destination,
+        assetTransferReview.exchange,
+      )}`,
+    );
+    appendAssetTransferReviewRow(
+      review,
+      "Amount",
+      `${assetTransferReview.amount} ${assetTransferReview.asset}`,
+    );
+    const warning = document.createElement("p");
+    warning.className = "asset-transfer-warning";
+    warning.textContent = assetTransferReview.source === "earn"
+      && assetTransferReview.destination !== "spot"
+      ? "Earn redemption and the following wallet transfer are separate operations. "
+        + "If the second step fails, redeemed funds remain in Spot."
+      : `This moves real funds between the selected ${
+        assetExchangeLabel(assetTransferReview.exchange)
+      } wallets or accounts and cannot be undone here.`;
+    review.appendChild(warning);
+    setAssetTransferError("");
+    setAssetTransferMode("review");
+    el("asset-transfer-submit").disabled = false;
+  }
+
+  function renderAssetTransferResult(data) {
+    const result = el("asset-transfer-result");
+    result.replaceChildren();
+    const title = document.createElement("strong");
+    title.textContent = data.status === "pending"
+      ? "Transfer submitted"
+      : "Transfer completed";
+    const summary = document.createElement("span");
+    summary.textContent =
+      `${data.amount} ${data.asset} \u00b7 `
+      + `${data.account} ${assetAccountTypeLabel(data.source, data.exchange)} \u2192 `
+      + `${data.target_account_label || data.target_account || data.account} ${
+        assetAccountTypeLabel(data.destination, data.exchange)
+      }`;
+    result.append(title, summary);
+    (Array.isArray(data.steps) ? data.steps : []).forEach((step) => {
+      const line = document.createElement("span");
+      line.className = "asset-transfer-result-step";
+      line.textContent = step.action === "redeem"
+        ? `Earn redeemed to Spot${step.redeem_id ? ` \u00b7 ID ${step.redeem_id}` : ""}`
+        : `${step.source_account ? `${step.source_account} \u00b7 ` : ""}`
+          + `${assetAccountTypeLabel(step.source, data.exchange)} \u2192 `
+          + `${step.target_account ? `${step.target_account} \u00b7 ` : ""}`
+          + `${assetAccountTypeLabel(step.destination, data.exchange)}`
+          + (step.status === "pending" ? " \u00b7 Pending" : "")
+          + (step.transaction_id ? ` \u00b7 ID ${step.transaction_id}` : "");
+      result.appendChild(line);
+    });
+    setAssetTransferMode("result");
+    el("asset-transfer-submit").disabled = false;
+  }
+
+  async function executeAssetTransfer() {
+    if (!assetTransferReview || assetTransferSubmitting) return;
+    assetTransferSubmitting = true;
+    el("asset-transfer-submit").disabled = true;
+    el("asset-transfer-back").disabled = true;
+    el("asset-transfer-close").disabled = true;
+    el("asset-transfer-submit").textContent = "Transferring\u2026";
+    setAssetTransferError("");
+    let response;
+    let data;
+    try {
+      response = await fetch("/api/assets/transfer", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ...assetTransferReview,
+          confirm: "TRANSFER",
+        }),
+      });
+      data = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const error = new Error(data.error || `HTTP ${response.status}`);
+        error.payload = data;
+        throw error;
+      }
+      renderAssetTransferResult(data);
+      loadAssets(true).catch(() => {});
+    } catch (error) {
+      const payload = error && error.payload ? error.payload : {};
+      setAssetTransferError(error.message || String(error));
+      if (payload.status === "partial" || payload.status === "unknown") {
+        setAssetTransferMode("result");
+        const result = el("asset-transfer-result");
+        result.replaceChildren();
+        const title = document.createElement("strong");
+        title.textContent = payload.status === "partial"
+          ? "Transfer partially completed"
+          : "Transfer status unknown";
+        result.appendChild(title);
+        loadAssets(true).catch(() => {});
+      } else {
+        setAssetTransferMode("review");
+      }
+      el("asset-transfer-submit").disabled = false;
+    } finally {
+      assetTransferSubmitting = false;
+      el("asset-transfer-back").disabled = false;
+      el("asset-transfer-close").disabled = false;
+      if (assetTransferMode === "review") {
+        el("asset-transfer-submit").textContent = "Confirm transfer";
+      } else if (assetTransferMode === "result") {
+        el("asset-transfer-submit").textContent = "Done";
+      }
+    }
   }
 
   function assetExchangeLabel(exchange) {
@@ -433,9 +1047,9 @@
     return breakdown.map((item) => {
       const accountType = String(item.account_type || "unknown");
       return {
-        currency: accountType.charAt(0).toUpperCase() + accountType.slice(1),
+        currency: assetAccountTypeLabel(accountType, portfolio.exchange),
         value: Number(item.total_value || 0),
-        accountType: true,
+        accountType,
       };
     });
   }
@@ -491,8 +1105,31 @@
       slices.forEach((slice, index) => {
         const color = assetColors[index % assetColors.length];
         const ratio = total > 0 ? Number(slice.value || 0) / total * 100 : 0;
-        const row = document.createElement("div");
+        const canTransfer = Boolean(
+          showAccountTypes
+          && slice.accountType
+          && Number(slice.value) > 0
+          && supportsAssetTransfer(portfolio.exchange, slice.accountType),
+        );
+        const row = document.createElement(canTransfer ? "button" : "div");
         row.className = "assets-legend-row";
+        if (showAccountTypes) {
+          row.classList.add("assets-legend-account-row");
+        }
+        if (canTransfer) {
+          row.type = "button";
+          row.classList.add("assets-legend-action");
+          row.setAttribute(
+            "aria-label",
+            `Transfer from ${
+              assetAccountTypeLabel(slice.accountType, portfolio.exchange)
+            } in ${portfolio.account}`,
+          );
+          row.addEventListener("click", (event) => {
+            event.stopPropagation();
+            openAssetTransfer(portfolio, slice.accountType);
+          });
+        }
         const dot = document.createElement("span");
         dot.className = "assets-legend-dot";
         dot.style.setProperty("--asset-color", color);
@@ -502,6 +1139,11 @@
         const weight = document.createElement("span");
         weight.className = "assets-legend-weight";
         weight.textContent = `${ratio.toFixed(ratio < 0.1 ? 2 : 1)}%`;
+        const chevron = document.createElement("span");
+        chevron.className = "assets-legend-chevron";
+        chevron.classList.toggle("assets-legend-chevron-placeholder", !canTransfer);
+        chevron.textContent = "\u203a";
+        chevron.setAttribute("aria-hidden", "true");
         const detail = document.createElement("span");
         detail.className = "assets-legend-value";
         if (slice.accountType) {
@@ -516,7 +1158,11 @@
                 true,
               )}`;
         }
-        row.append(dot, currency, weight, detail);
+        if (showAccountTypes) {
+          row.append(dot, currency, weight, chevron, detail);
+        } else {
+          row.append(dot, currency, weight, detail);
+        }
         legend.appendChild(row);
       });
     }
@@ -1390,6 +2036,90 @@
     assetsModal.addEventListener("click", (event) => {
       if (event.target === assetsModal) closeAssets();
     });
+    el("asset-transfer-close").addEventListener("click", closeAssetTransfer);
+    el("asset-transfer-back").addEventListener("click", () => {
+      if (assetTransferMode === "review") {
+        assetTransferReview = null;
+        setAssetTransferMode("options");
+        updateAssetTransferForm();
+        return;
+      }
+      closeAssetTransfer();
+    });
+    el("asset-transfer-submit").addEventListener("click", () => {
+      if (assetTransferMode === "options") reviewAssetTransfer();
+      else if (assetTransferMode === "review") executeAssetTransfer();
+      else if (assetTransferMode === "result") closeAssetTransfer();
+    });
+    el("asset-transfer-form").addEventListener("submit", (event) => {
+      event.preventDefault();
+      if (assetTransferMode === "options" && !el("asset-transfer-submit").disabled) {
+        reviewAssetTransfer();
+      }
+    });
+    el("asset-transfer-asset").addEventListener("change", () => {
+      el("asset-transfer-amount").value = "";
+      setAssetTransferError("");
+      syncAssetTransferDropdown("asset");
+      updateAssetTransferForm();
+    });
+    el("asset-transfer-destination").addEventListener("change", () => {
+      setAssetTransferError("");
+      syncAssetTransferDropdown("destination");
+      updateAssetTransferForm();
+    });
+    el("asset-transfer-account").addEventListener("change", () => {
+      setAssetTransferError("");
+      syncAssetTransferDropdown("account");
+      renderAssetTransferDestinations();
+      updateAssetTransferForm();
+    });
+    initAssetTransferDropdown("asset");
+    initAssetTransferDropdown("account");
+    initAssetTransferDropdown("destination");
+    el("asset-transfer-amount").addEventListener("input", () => {
+      setAssetTransferError("");
+      updateAssetTransferForm();
+    });
+    el("asset-transfer-max").addEventListener("click", () => {
+      const item = selectedAssetTransferItem();
+      if (!item || !item.transferable) return;
+      el("asset-transfer-amount").value = item.available;
+      setAssetTransferError("");
+      updateAssetTransferForm();
+    });
+    const transferModal = el("asset-transfer-modal");
+    transferModal.addEventListener("click", (event) => {
+      if (event.target === transferModal && assetTransferMode !== "review") {
+        closeAssetTransfer();
+      }
+    });
+    document.addEventListener("pointerdown", (event) => {
+      const target = event.target && event.target.closest ? event.target : null;
+      if (target && target.closest(".asset-transfer-select")) return;
+      closeAssetTransferDropdown();
+    }, { passive: true });
+    const positionOpenTransferDropdown = () => {
+      ["asset", "account", "destination"].forEach((name) => {
+        positionAssetTransferDropdown(name);
+      });
+    };
+    window.addEventListener("resize", positionOpenTransferDropdown, { passive: true });
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener(
+        "resize",
+        positionOpenTransferDropdown,
+        { passive: true },
+      );
+    }
+    const transferBody = el("asset-transfer-body");
+    if (transferBody) {
+      transferBody.addEventListener(
+        "scroll",
+        () => closeAssetTransferDropdown(),
+        { passive: true },
+      );
+    }
     initMobileAssetsGestures();
   }
 
@@ -3568,7 +4298,8 @@
     if (e.key !== "Escape") return;
     closeHubMenu();
     if (isCalendarOpen()) closeCalendar();
-    if (isAssetsOpen()) closeAssets();
+    if (isAssetTransferOpen()) closeAssetTransfer();
+    else if (isAssetsOpen()) closeAssets();
     closeScriptDropdown();
     closeDataSinceTooltips();
     if (!el("log-modal").classList.contains("hidden")) closeLogs();

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -31,6 +31,16 @@
   let calendarOpenTimer = null;
   let calendarCloseTimer = null;
   let registerAnimatedPepeFace = () => {};
+  const assetColors = [
+    "#3b82f6", "#f59e0b", "#10b981", "#ef4444",
+    "#a78bfa", "#22d3ee", "#f472b6", "#94a3b8",
+  ];
+  let assetsRequestSeq = 0;
+  let assetsOpenTimer = null;
+  let assetsCloseTimer = null;
+  let assetsHaveData = false;
+  let assetsPayload = null;
+  let selectedAssetExchange = null;
 
   const el = (id) => document.getElementById(id);
 
@@ -228,6 +238,526 @@
     }
     modal.classList.add("calendar-closing");
     calendarCloseTimer = window.setTimeout(finishCalendarClose, 220);
+  }
+
+  function isAssetsOpen() {
+    return !el("assets-modal").classList.contains("hidden");
+  }
+
+  function finishAssetsOpening() {
+    if (assetsOpenTimer !== null) {
+      clearTimeout(assetsOpenTimer);
+      assetsOpenTimer = null;
+    }
+    el("assets-modal").classList.remove("assets-opening");
+  }
+
+  function finishAssetsClose() {
+    const modal = el("assets-modal");
+    const box = modal.querySelector(".assets-modal-box");
+    modal.classList.remove(
+      "assets-closing",
+      "assets-dragging",
+      "assets-swipe-closing",
+      "assets-opening",
+    );
+    modal.classList.add("hidden");
+    modal.style.background = "";
+    box.style.transform = "";
+    box.style.transition = "";
+    modal.setAttribute("aria-hidden", "true");
+    assetsCloseTimer = null;
+    assetsOpenTimer = null;
+    unlockBodyScroll();
+  }
+
+  async function openAssets() {
+    closeHubMenu();
+    closeAiChat();
+    selectedAssetExchange = null;
+    el("assets-title").textContent = "Assets";
+    el("assets-back").classList.add("hidden");
+    if (assetsCloseTimer !== null) {
+      clearTimeout(assetsCloseTimer);
+      assetsCloseTimer = null;
+    }
+    if (assetsOpenTimer !== null) {
+      clearTimeout(assetsOpenTimer);
+      assetsOpenTimer = null;
+    }
+    const modal = el("assets-modal");
+    const box = modal.querySelector(".assets-modal-box");
+    modal.classList.remove(
+      "assets-closing",
+      "assets-dragging",
+      "assets-swipe-closing",
+      "assets-opening",
+      "hidden",
+    );
+    modal.classList.add("assets-opening");
+    assetsOpenTimer = window.setTimeout(finishAssetsOpening, 230);
+    modal.style.background = "";
+    box.style.transform = "";
+    box.style.transition = "";
+    modal.setAttribute("aria-hidden", "false");
+    lockBodyScroll();
+    await loadAssets(false);
+  }
+
+  function closeAssets(options = {}) {
+    if (!isAssetsOpen()) return;
+    const modal = el("assets-modal");
+    if (modal.classList.contains("assets-closing")) return;
+    const fromDrag = options && options.fromDrag === true;
+    finishAssetsOpening();
+    assetsRequestSeq += 1;
+    if (!mobileHubQuery.matches) {
+      finishAssetsClose();
+      return;
+    }
+    const box = modal.querySelector(".assets-modal-box");
+    modal.classList.remove("assets-dragging");
+    if (fromDrag) {
+      modal.classList.add("assets-swipe-closing");
+      box.style.transition = "transform 220ms cubic-bezier(0.55, 0, 1, 0.45)";
+      window.requestAnimationFrame(() => {
+        box.style.transform = "translateY(100dvh)";
+      });
+    } else {
+      box.style.transform = "";
+      box.style.transition = "";
+    }
+    modal.classList.add("assets-closing");
+    assetsCloseTimer = window.setTimeout(finishAssetsClose, 220);
+  }
+
+  function formatAssetValue(value, currency, compact = false) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "—";
+    let maximumFractionDigits = currency === "KRW" ? 0 : 2;
+    if (!compact && Math.abs(number) > 0 && Math.abs(number) < 1) {
+      maximumFractionDigits = 6;
+    }
+    return `${number.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits,
+    })} ${currency}`;
+  }
+
+  function formatAssetAmount(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "—";
+    return number.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 8,
+    });
+  }
+
+  function assetExchangeLabel(exchange) {
+    const value = String(exchange || "Exchange");
+    const labels = {
+      binance: "Binance",
+      bitget: "Bitget",
+      bybit: "Bybit",
+      hyperliquid: "Hyperliquid",
+      okx: "OKX",
+      upbit: "Upbit",
+    };
+    return labels[value.toLowerCase()]
+      || `${value.charAt(0).toUpperCase()}${value.slice(1)}`;
+  }
+
+  function assetExchangeKey(exchange, quoteCurrency) {
+    return `${String(exchange || "")}:${String(quoteCurrency || "")}`;
+  }
+
+  function groupAssetPortfolios(portfolios) {
+    const groups = new Map();
+    portfolios.forEach((portfolio) => {
+      const exchange = String(portfolio.exchange || "exchange");
+      const quoteCurrency = String(portfolio.quote_currency || "");
+      const key = assetExchangeKey(exchange, quoteCurrency);
+      let group = groups.get(key);
+      if (!group) {
+        group = {
+          key,
+          account: assetExchangeLabel(exchange),
+          exchange,
+          quote_currency: quoteCurrency,
+          total_value: 0,
+          account_names: [],
+        };
+        groups.set(key, group);
+      }
+
+      const accountName = String(portfolio.account || exchange);
+      group.account_names.push(accountName);
+      group.total_value += Number(portfolio.total_value || 0);
+    });
+
+    return Array.from(groups.values()).map((group) => ({
+      ...group,
+      account_count: group.account_names.length,
+    }));
+  }
+
+  function assetSlices(portfolio) {
+    const priced = (Array.isArray(portfolio.assets) ? portfolio.assets : [])
+      .filter((asset) => Number(asset.value) > 0)
+      .sort((left, right) => Number(right.value) - Number(left.value));
+    const isBinance = String(portfolio.exchange || "").toLowerCase() === "binance";
+    const visible = isBinance
+      ? priced.filter((asset) => Number(asset.value) >= 1)
+      : priced.slice();
+    const remaining = isBinance
+      ? priced.filter((asset) => Number(asset.value) < 1)
+      : [];
+    if (!isBinance && visible.length > 7) {
+      remaining.push(...visible.splice(7));
+    }
+    if (remaining.length) {
+      visible.push({
+        currency: "Other",
+        value: remaining.reduce((sum, asset) => sum + Number(asset.value || 0), 0),
+        weight: remaining.reduce((sum, asset) => sum + Number(asset.weight || 0), 0),
+        grouped: true,
+      });
+    }
+    return visible;
+  }
+
+  function accountTypeSlices(portfolio) {
+    const breakdown = Array.isArray(portfolio.account_type_breakdown)
+      ? portfolio.account_type_breakdown
+      : [];
+    return breakdown.map((item) => {
+      const accountType = String(item.account_type || "unknown");
+      return {
+        currency: accountType.charAt(0).toUpperCase() + accountType.slice(1),
+        value: Number(item.total_value || 0),
+        accountType: true,
+      };
+    });
+  }
+
+  function renderAssetDonut(portfolio) {
+    const wrap = document.createElement("div");
+    wrap.className = "assets-portfolio-content";
+    const donut = document.createElement("button");
+    donut.type = "button";
+    donut.className = "assets-donut";
+    const center = document.createElement("span");
+    center.className = "assets-donut-center";
+    donut.appendChild(center);
+
+    const legend = document.createElement("div");
+    legend.className = "assets-legend";
+    let showAccountTypes = false;
+
+    function renderDonutMode() {
+      const slices = showAccountTypes
+        ? accountTypeSlices(portfolio)
+        : assetSlices(portfolio);
+      const total = slices.reduce((sum, slice) => sum + Number(slice.value || 0), 0);
+      const positiveSlices = slices
+        .map((slice, index) => ({ slice, index }))
+        .filter(({ slice }) => Number(slice.value) > 0);
+      let cursor = 0;
+      const stops = [];
+      positiveSlices.forEach(({ slice, index }, positiveIndex) => {
+        const color = assetColors[index % assetColors.length];
+        const ratio = total > 0 ? Number(slice.value || 0) / total * 100 : 0;
+        const end = positiveIndex === positiveSlices.length - 1 ? 100 : cursor + ratio;
+        stops.push(`${color} ${cursor.toFixed(3)}% ${end.toFixed(3)}%`);
+        cursor = end;
+      });
+      donut.style.background = stops.length
+        ? `conic-gradient(${stops.join(", ")})`
+        : "#29313c";
+      donut.classList.toggle("showing-account-types", showAccountTypes);
+      donut.setAttribute("aria-pressed", String(showAccountTypes));
+      donut.setAttribute(
+        "aria-label",
+        showAccountTypes
+          ? `Show asset allocation for ${portfolio.account}`
+          : `Show account type allocation for ${portfolio.account}`,
+      );
+      donut.title = showAccountTypes
+        ? "Show asset allocation"
+        : "Show account type allocation";
+      center.textContent = showAccountTypes ? "Account types (%)" : "Assets (%)";
+
+      legend.replaceChildren();
+      slices.forEach((slice, index) => {
+        const color = assetColors[index % assetColors.length];
+        const ratio = total > 0 ? Number(slice.value || 0) / total * 100 : 0;
+        const row = document.createElement("div");
+        row.className = "assets-legend-row";
+        const dot = document.createElement("span");
+        dot.className = "assets-legend-dot";
+        dot.style.setProperty("--asset-color", color);
+        const currency = document.createElement("span");
+        currency.className = "assets-legend-currency";
+        currency.textContent = slice.currency;
+        const weight = document.createElement("span");
+        weight.className = "assets-legend-weight";
+        weight.textContent = `${ratio.toFixed(ratio < 0.1 ? 2 : 1)}%`;
+        const detail = document.createElement("span");
+        detail.className = "assets-legend-value";
+        if (slice.accountType) {
+          detail.textContent =
+            formatAssetValue(slice.value, portfolio.quote_currency, true);
+        } else {
+          detail.textContent = slice.grouped
+            ? formatAssetValue(slice.value, portfolio.quote_currency, true)
+            : `${formatAssetAmount(slice.amount)} · ${formatAssetValue(
+                slice.value,
+                portfolio.quote_currency,
+                true,
+              )}`;
+        }
+        row.append(dot, currency, weight, detail);
+        legend.appendChild(row);
+      });
+    }
+    donut.addEventListener("click", () => {
+      showAccountTypes = !showAccountTypes;
+      renderDonutMode();
+    });
+    renderDonutMode();
+    wrap.append(donut, legend);
+    return wrap;
+  }
+
+  function renderAssetPortfolio(portfolio) {
+    const section = document.createElement("section");
+    section.className = "assets-portfolio";
+    const header = document.createElement("div");
+    header.className = "assets-portfolio-header";
+    const identity = document.createElement("div");
+    identity.className = "assets-account-name";
+    identity.textContent = portfolio.account || portfolio.exchange || "Account";
+    const exchange = document.createElement("span");
+    exchange.className = "assets-exchange-name";
+    const accountCount = Number(portfolio.account_count || 0);
+    exchange.textContent = accountCount
+      ? `${accountCount} account${accountCount === 1 ? "" : "s"}`
+      : portfolio.exchange || "";
+    identity.appendChild(exchange);
+    const total = document.createElement("div");
+    total.className = "assets-account-total";
+    total.textContent = Number(portfolio.total_value || 0).toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: portfolio.quote_currency === "KRW" ? 0 : 2,
+    });
+    const quote = document.createElement("span");
+    quote.textContent = portfolio.quote_currency || "";
+    total.appendChild(quote);
+    header.append(identity, total);
+    section.append(header, renderAssetDonut(portfolio));
+
+    const footer = document.createElement("div");
+    footer.className = "assets-portfolio-footer";
+    const statuses = Array.isArray(portfolio.account_type_statuses)
+      ? portfolio.account_type_statuses
+      : [];
+    const availableTypes = Array.from(new Set(statuses
+      .filter((item) => item.status === "ok")
+      .map((item) => item.account_type)));
+    const statusText = document.createElement("span");
+    statusText.textContent = availableTypes.length
+      ? `Included: ${availableTypes.join(", ")}`
+      : "No account balance type was available.";
+    footer.appendChild(statusText);
+
+    const accountNames = Array.isArray(portfolio.account_names)
+      ? portfolio.account_names
+      : [];
+    if (accountNames.length) {
+      const accountsText = document.createElement("span");
+      accountsText.className = "assets-account-list";
+      accountsText.textContent = `Accounts: ${accountNames.join(", ")}`;
+      accountsText.title = accountNames.join(", ");
+      footer.appendChild(accountsText);
+    }
+
+    const warnings = Array.isArray(portfolio.warnings) ? portfolio.warnings : [];
+    warnings.forEach((warning) => {
+      const warningText = document.createElement("span");
+      warningText.className = "assets-warning";
+      warningText.textContent = String(warning);
+      footer.appendChild(warningText);
+    });
+    section.appendChild(footer);
+    return section;
+  }
+
+  function renderAssetExchangeRow(portfolio) {
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "assets-exchange-row";
+    row.setAttribute("aria-label", `Show ${portfolio.account} asset details`);
+
+    const identity = document.createElement("span");
+    identity.className = "assets-exchange-identity";
+    const title = document.createElement("span");
+    title.className = "assets-exchange-title";
+    title.textContent = portfolio.account;
+    const accounts = document.createElement("span");
+    accounts.className = "assets-exchange-accounts";
+    const accountNames = Array.isArray(portfolio.account_names)
+      ? portfolio.account_names
+      : [];
+    accounts.textContent =
+      `${Number(portfolio.account_count || 0)} account${portfolio.account_count === 1 ? "" : "s"}`
+      + (accountNames.length ? ` · ${accountNames.join(", ")}` : "");
+    accounts.title = accountNames.join(", ");
+    identity.append(title, accounts);
+
+    const total = document.createElement("span");
+    total.className = "assets-exchange-total";
+    total.textContent = Number(portfolio.total_value || 0).toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: portfolio.quote_currency === "KRW" ? 0 : 2,
+    });
+    const quote = document.createElement("span");
+    quote.textContent = portfolio.quote_currency || "";
+    total.appendChild(quote);
+
+    const chevron = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    chevron.classList.add("assets-exchange-chevron");
+    chevron.setAttribute("viewBox", "0 0 24 24");
+    chevron.setAttribute("aria-hidden", "true");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "m9 18 6-6-6-6");
+    chevron.appendChild(path);
+
+    row.append(identity, total, chevron);
+    row.addEventListener("click", () => {
+      selectedAssetExchange = portfolio.key;
+      renderAssetsView();
+      el("assets-body").scrollTop = 0;
+    });
+    return row;
+  }
+
+  function renderAssetsView() {
+    if (!assetsPayload) return;
+    const portfolios = Array.isArray(assetsPayload.exchangePortfolios)
+      ? assetsPayload.exchangePortfolios
+      : [];
+    let selected = selectedAssetExchange
+      ? portfolios.find((portfolio) => portfolio.key === selectedAssetExchange)
+      : null;
+    if (selectedAssetExchange && !selected) {
+      selectedAssetExchange = null;
+      selected = null;
+    }
+
+    const container = el("assets-portfolios");
+    container.replaceChildren();
+    container.className = selected
+      ? "assets-portfolios assets-detail"
+      : "assets-portfolios assets-overview";
+    el("assets-back").classList.toggle("hidden", !selected);
+    el("assets-title").textContent = selected
+      ? `${selected.account} Assets`
+      : "Assets";
+    el("assets-summary").classList.toggle(
+      "hidden",
+      Boolean(selected) || portfolios.length === 0,
+    );
+    el("assets-empty").classList.toggle("hidden", portfolios.length !== 0);
+
+    if (selected) {
+      const accountPortfolios = (Array.isArray(assetsPayload.portfolios)
+        ? assetsPayload.portfolios
+        : []).filter((portfolio) => (
+        assetExchangeKey(portfolio.exchange, portfolio.quote_currency) === selected.key
+      ));
+      accountPortfolios.forEach((portfolio) => {
+        container.appendChild(renderAssetPortfolio(portfolio));
+      });
+      return;
+    }
+    const list = document.createElement("div");
+    list.className = "assets-exchange-list";
+    portfolios.forEach((portfolio) => {
+      list.appendChild(renderAssetExchangeRow(portfolio));
+    });
+    container.appendChild(list);
+  }
+
+  function renderAssets(payload) {
+    const portfolios = Array.isArray(payload.portfolios) ? payload.portfolios : [];
+    const exchangePortfolios = groupAssetPortfolios(portfolios);
+    assetsPayload = { ...payload, exchangePortfolios };
+    const summary = payload.summary || {};
+    const totals = Array.isArray(payload.totals_by_quote) ? payload.totals_by_quote : [];
+
+    const totalsElement = el("assets-summary-totals");
+    totalsElement.replaceChildren();
+    totals.forEach((total) => {
+      const item = document.createElement("span");
+      item.className = "assets-summary-total-value";
+      item.textContent = Number(total.value || 0).toLocaleString(undefined, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: total.currency === "KRW" ? 0 : 2,
+      });
+      const currency = document.createElement("span");
+      currency.className = "assets-summary-total-currency";
+      currency.textContent = total.currency || "";
+      item.appendChild(currency);
+      totalsElement.appendChild(item);
+    });
+    el("assets-summary-counts").textContent =
+      `${exchangePortfolios.length} exchanges · ${Number(summary.accounts || 0)} accounts`;
+    const collectedAt = Date.parse(payload.collected_at || "");
+    el("assets-updated").textContent = Number.isFinite(collectedAt)
+      ? `Updated ${new Date(collectedAt).toLocaleString("en-US", {
+          month: "short",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        })}${payload.cached ? " · cached" : ""}`
+      : "";
+    renderAssetsView();
+    assetsHaveData = true;
+  }
+
+  function setAssetsLoading(loading, preserveContent = false) {
+    el("assets-refresh").disabled = loading;
+    el("assets-refresh").classList.toggle("assets-refreshing", loading);
+    el("assets-loading").classList.toggle("hidden", !loading || preserveContent);
+    if (loading) el("assets-error").classList.add("hidden");
+    if (loading && !preserveContent) {
+      assetsPayload = null;
+      el("assets-summary").classList.add("hidden");
+      el("assets-empty").classList.add("hidden");
+      el("assets-portfolios").replaceChildren();
+    }
+  }
+
+  async function loadAssets(force) {
+    const seq = ++assetsRequestSeq;
+    const preserveContent = Boolean(force && assetsHaveData);
+    setAssetsLoading(true, preserveContent);
+    try {
+      const payload = await api(`/api/assets${force ? "?refresh=true" : ""}`);
+      if (seq !== assetsRequestSeq || !isAssetsOpen()) return;
+      renderAssets(payload);
+    } catch (error) {
+      if (seq !== assetsRequestSeq || !isAssetsOpen()) return;
+      const errorElement = el("assets-error");
+      errorElement.textContent = `${error.message}\nUse refresh to try again.`;
+      errorElement.classList.remove("hidden");
+      if (!preserveContent) {
+        el("assets-summary").classList.add("hidden");
+        el("assets-portfolios").replaceChildren();
+      }
+    } finally {
+      if (seq === assetsRequestSeq) setAssetsLoading(false);
+    }
   }
 
   async function loadCalendarEvents() {
@@ -712,6 +1242,65 @@
     }, true);
   }
 
+  function initMobileAssetsGestures() {
+    const modal = el("assets-modal");
+    const box = modal.querySelector(".assets-modal-box");
+    const header = modal.querySelector(".assets-modal-header");
+    let closeDrag = null;
+
+    header.addEventListener("pointerdown", (event) => {
+      if (!mobileHubQuery.matches || !event.isPrimary) return;
+      if (event.target && event.target.closest && event.target.closest("button")) return;
+      closeDrag = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        dy: 0,
+        active: false,
+      };
+      try { header.setPointerCapture(event.pointerId); } catch {}
+    });
+    header.addEventListener("pointermove", (event) => {
+      if (!closeDrag || event.pointerId !== closeDrag.id) return;
+      const dx = event.clientX - closeDrag.startX;
+      const dy = event.clientY - closeDrag.startY;
+      if (!closeDrag.active) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) < 8) return;
+        if (dy <= 0 || Math.abs(dy) <= Math.abs(dx)) {
+          closeDrag = null;
+          return;
+        }
+        closeDrag.active = true;
+        finishAssetsOpening();
+        modal.classList.add("assets-dragging");
+      }
+      event.preventDefault();
+      closeDrag.dy = Math.max(0, dy);
+      box.style.transform = `translateY(${closeDrag.dy}px)`;
+    }, { passive: false });
+    function endAssetsCloseDrag(event, cancelled = false) {
+      if (!closeDrag || (event && event.pointerId !== closeDrag.id)) return;
+      const current = closeDrag;
+      closeDrag = null;
+      try { header.releasePointerCapture(current.id); } catch {}
+      modal.classList.remove("assets-dragging");
+      if (!cancelled && current.active && current.dy > 100) {
+        closeAssets({ fromDrag: true });
+        return;
+      }
+      if (!current.active) return;
+      box.style.transition = "transform 180ms ease";
+      box.style.transform = "translateY(0)";
+      window.setTimeout(() => {
+        if (!isAssetsOpen() || modal.classList.contains("assets-closing")) return;
+        box.style.transition = "";
+        box.style.transform = "";
+      }, 190);
+    }
+    header.addEventListener("pointerup", (event) => endAssetsCloseDrag(event));
+    header.addEventListener("pointercancel", (event) => endAssetsCloseDrag(event, true));
+  }
+
   function initHubMenuCalendar() {
     const calendarModal = el("calendar-modal");
     calendarModal.addEventListener("touchend", (event) => {
@@ -737,6 +1326,7 @@
     el("hub-menu-close").addEventListener("click", closeHubMenu);
     el("hub-menu-backdrop").addEventListener("click", closeHubMenu);
     el("hub-calendar-open").addEventListener("click", openCalendar);
+    el("hub-assets-open").addEventListener("click", openAssets);
     el("calendar-close").addEventListener("click", closeCalendar);
     calendarModal.addEventListener("click", (event) => {
       if (event.target === calendarModal) closeCalendar();
@@ -789,6 +1379,18 @@
     }
     initMobileHubMenuSwipe();
     initMobileCalendarGestures();
+    el("assets-close").addEventListener("click", closeAssets);
+    el("assets-back").addEventListener("click", () => {
+      selectedAssetExchange = null;
+      renderAssetsView();
+      el("assets-body").scrollTop = 0;
+    });
+    el("assets-refresh").addEventListener("click", () => loadAssets(true));
+    const assetsModal = el("assets-modal");
+    assetsModal.addEventListener("click", (event) => {
+      if (event.target === assetsModal) closeAssets();
+    });
+    initMobileAssetsGestures();
   }
 
   function updateHubClock() {
@@ -2966,6 +3568,7 @@
     if (e.key !== "Escape") return;
     closeHubMenu();
     if (isCalendarOpen()) closeCalendar();
+    if (isAssetsOpen()) closeAssets();
     closeScriptDropdown();
     closeDataSinceTooltips();
     if (!el("log-modal").classList.contains("hidden")) closeLogs();


### PR DESCRIPTION
## 주요 변경사항

- `providers.toml`에 등록된 거래소 계정의 Spot, Futures, Margin, Funding, Earn 자산을 조회합니다.
- 거래소 단위 병렬 수집과 마켓 정보 30분 캐시를 적용해 반복적인 마켓 로딩 비용을 줄였습니다.
- Hub 메뉴에 Assets 화면을 추가하고 거래소별 합산 자산, 계정별 자산 구성, 지갑 유형별 비중을 도넛 그래프로 표시합니다.
- Binance의 1 USDT 미만 자산은 Other로 합산하고 가격을 확인할 수 없는 자산은 화면에서 제외합니다.
- 정상 조회 로그는 줄이고 재시도, 권한 오류, 조회 실패 및 캐시 갱신 실패 로그만 유지합니다.

## 자산 전송

- Binance, Bitget, Bybit, OKX, Hyperliquid의 동일 계정 내 지갑 전송을 지원합니다.
- 설정된 main/sub 계정 관계를 자동으로 식별하고 main 계정에서 sub 계정 또는 sub 계정 간 자산 전송을 지원합니다.
- Bybit Unified/Funding 계정 전송과 main/sub Universal Transfer를 지원합니다.
- Earn 자산은 지원되는 거래소에서 상환 후 지정 지갑 또는 계정으로 전송합니다.
- 전송 전에 사용 가능 잔액과 경로를 다시 검증하고 Review 및 명시적 확인 이후에만 실행합니다.
- 네트워크 오류로 결과가 불명확한 경우 자동 재시도하지 않고 확인이 필요한 상태로 반환합니다.
- 전송이 완료되거나 결과가 불명확한 경우 자산 캐시를 무효화해 다음 조회에서 최신 잔액을 반영합니다.

## 보안

- API 키, 비밀키, 계정 UID, 이메일 및 지갑 주소는 브라우저 응답에 노출하지 않습니다.
- 계정 관계 식별과 실제 거래소 식별자 사용은 서버 내부에서만 수행합니다.