### PR TITLE
수동 알림 템플릿에 AI 지시 실행 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,8 +304,9 @@ They are useful when you want discretionary control in addition to fully
 automated strategy alerts.
 
 Open a chart, click the alert menu gear, and configure **Manual Alert
-Templates**. Each template has a `TITLE` and a JSON `MESSAGE`. Templates are
-stored with the session, so they are shared between desktop and mobile browsers.
+Templates**. Each template has a `TITLE`, a JSON `MESSAGE`, and an optional
+`AI INSTRUCTION`. Templates are stored with the session, so they are shared
+between desktop and mobile browsers.
 
 To send a manual alert:
 
@@ -323,6 +324,14 @@ multiple triggers, move each one by dragging its alert label on the price axis,
 remove one with the label `X`, or use `Send` to send a one-off manual alert
 immediately.
 
+When a template has an `AI INSTRUCTION`, PyneReal queues it after the template's
+webhook is sent successfully. This applies to both direct `Send` and automatic
+price-trigger delivery. The AI receives the exact session and alert context, and
+its instruction and result appear in shared dashboard chat as
+`[Manual Alert AI]`. The AI instruction is not included in the webhook JSON.
+Webhook failure prevents the AI instruction from running; an unavailable or
+failed AI service does not roll back a successful webhook.
+
 Manual alerts are independent from the Webhook checkbox. The checkbox controls
 strategy-generated alerts only; a manual alert can still be sent while the
 checkbox is off. A valid webhook URL is still required. PyneReal sends the final
@@ -332,7 +341,7 @@ If Telegram credentials are configured for the session, or through the root
 `.env` fallback, PyneReal also sends a Telegram manual-alert message after the
 webhook send succeeds. This does not depend on the Telegram checkbox.
 
-Supported placeholders:
+The JSON `MESSAGE` and optional `AI INSTRUCTION` support these placeholders:
 
 - `{{price}}`: the selected chart price. Drag the manual alert menu to adjust it.
 - `{{market}}`: the latest live price at the final `Send` click.

--- a/ai/INSTRUCTIONS.md
+++ b/ai/INSTRUCTIONS.md
@@ -74,6 +74,10 @@ internals when an existing script already provides the required data.
   `strategy.entry` or `strategy.close` is an explicit user request authored in
   the strategy. Execute only its stated scope and use the exact session ID
   supplied by the server.
+- A server-verified instruction generated from a configured Manual Alert
+  template is also an explicit user request. Its webhook has already succeeded;
+  execute only the supplied instruction for the exact session ID and alert
+  context.
 - Do not ask the user to identify the session for an automated strategy
   instruction. If another required value or template is missing, report the
   missing requirement instead of guessing.
@@ -89,7 +93,8 @@ internals when an existing script already provides the required data.
   session, ask the user for both its title and message format. Then pass both
   custom template fields so the tool adds the template and trigger together.
   Do not tell the user to add it in the dashboard, and do not invent either
-  value.
+  value. Include `custom_template_ai` only when the user also explicitly
+  supplies an AI instruction for that template.
 - For a session that has configured templates, use the exact selected template
   index when the requested template already exists.
 - Call `set_manual_alert_trigger` only after all required values are explicit.
@@ -108,6 +113,8 @@ internals when an existing script already provides the required data.
   deletion request and dedicated tool.
 - Setting a trigger does not send an alert immediately. The existing data
   service fires and removes it when market price touches the persisted line.
+- A template's optional AI instruction runs after successful direct or
+  price-trigger webhook delivery. It does not run when webhook delivery fails.
 
 ## Session Calendar
 

--- a/ai/README.md
+++ b/ai/README.md
@@ -49,8 +49,10 @@ Dashboard Codex threads use three server-controlled dynamic tools:
 The AI must resolve the exact session, price, and template before setting a
 trigger. When the requested template is missing, a user-supplied title and
 message format are persisted as a new session template together with the price
-trigger. A combined "delete all in this session, then set this trigger" request
-uses the setting tool's atomic replacement option.
+trigger. The template may also contain an explicit optional AI instruction,
+which runs only after successful direct or price-trigger webhook delivery. A
+combined "delete all in this session, then set this trigger" request uses the
+setting tool's atomic replacement option.
 
 ## Session Calendar
 

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -474,11 +474,13 @@ class CodexService:
     async def handle_strategy_instruction(self, session: Any, event: dict[str, Any]) -> None:
         instruction = str(event.get("instruction") or "").strip()
         event_id = str(event.get("event_id") or "").strip()
+        source = self._instruction_source(event)
+        event_log_id = event_id[-8:] if source == "manual_alert" else event_id[:8]
         if not instruction or not event_id:
             return
         if self._disabled:
             print(
-                f"[ai] strategy instruction skipped session={session.spec.id} "
+                f"[ai] {source} instruction skipped session={session.spec.id} "
                 "reason=AI service disabled"
             )
             return
@@ -486,27 +488,31 @@ class CodexService:
         self._pending_shared_chats += 1
         task = asyncio.create_task(
             self._run_strategy_instruction(session, event),
-            name=f"codex-strategy-{event_id[:8]}",
+            name=f"codex-{source.replace('_', '-')}-{event_log_id}",
         )
         self._shared_chat_tasks.add(task)
         task.add_done_callback(self._shared_chat_tasks.discard)
         await self._notify_strategy_chat_changed()
         print(
-            f"[ai] strategy instruction queued session={session.spec.id} "
-            f"event={event_id[:8]} action={event.get('action') or 'order'}"
+            f"[ai] {source} instruction queued session={session.spec.id} "
+            f"event={event_log_id} action={event.get('action') or 'order'}"
         )
 
     async def _run_strategy_instruction(self, session: Any, event: dict[str, Any]) -> None:
         conversation_id: str | None = None
         instruction = str(event.get("instruction") or "").strip()
         label = self._strategy_instruction_label(session, event)
+        prefix = self._instruction_prefix(event)
+        source = self._instruction_source(event)
+        event_id = str(event.get("event_id") or "")
+        event_log_id = event_id[-8:] if source == "manual_alert" else event_id[:8]
         session_lock = self._strategy_instruction_locks.setdefault(
             str(session.spec.id),
             asyncio.Lock(),
         )
         try:
             async with session_lock:
-                await self._append_chat_message("user", f"[Strategy AI] {label}\n{instruction}")
+                await self._append_chat_message("user", f"{prefix} {label}\n{instruction}")
                 await self._notify_strategy_chat_changed()
 
                 answer = ""
@@ -527,23 +533,23 @@ class CodexService:
                 if answer:
                     await self._append_chat_message(
                         "assistant",
-                        f"[Strategy AI] {label}\n{answer}",
+                        f"{prefix} {label}\n{answer}",
                     )
                 print(
-                    f"[ai] strategy instruction completed session={session.spec.id} "
-                    f"event={str(event.get('event_id') or '')[:8]}"
+                    f"[ai] {source} instruction completed session={session.spec.id} "
+                    f"event={event_log_id}"
                 )
         except asyncio.CancelledError:
             raise
         except Exception as e:
             await self._append_chat_message(
                 "assistant",
-                f"Strategy AI failed for {label}: {e}",
+                f"{prefix} failed for {label}: {e}",
                 error=True,
             )
             print(
-                f"[ai] strategy instruction failed session={session.spec.id} "
-                f"event={str(event.get('event_id') or '')[:8]}: {e}"
+                f"[ai] {source} instruction failed session={session.spec.id} "
+                f"event={event_log_id}: {e}"
             )
         finally:
             if conversation_id:
@@ -558,7 +564,20 @@ class CodexService:
             print(f"[ai] strategy chat state notification failed: {e}")
 
     @staticmethod
+    def _instruction_source(event: dict[str, Any]) -> str:
+        return "manual_alert" if event.get("source") == "manual_alert" else "strategy"
+
+    @classmethod
+    def _instruction_prefix(cls, event: dict[str, Any]) -> str:
+        return "[Manual Alert AI]" if cls._instruction_source(event) == "manual_alert" else "[Strategy AI]"
+
+    @staticmethod
     def _strategy_instruction_label(session: Any, event: dict[str, Any]) -> str:
+        if event.get("source") == "manual_alert":
+            mode = "trigger" if event.get("mode") == "trigger" else "send"
+            title = str(event.get("template_title") or "").strip()
+            title_label = f" {title}" if title else ""
+            return f"{session.spec.symbol} {session.spec.timeframe} {mode}{title_label}"
         action = str(event.get("action") or "order")
         order_id = str(event.get("order_id") or "").strip()
         order_label = f" {order_id}" if order_id else ""
@@ -566,6 +585,42 @@ class CodexService:
 
     @staticmethod
     def _build_strategy_instruction_prompt(session: Any, event: dict[str, Any]) -> str:
+        if event.get("source") == "manual_alert":
+            context = {
+                "session_id": session.spec.id,
+                "provider": session.spec.provider,
+                "exchange": session.spec.exchange,
+                "symbol": session.spec.symbol,
+                "market_type": session.spec.market_type,
+                "timeframe": session.spec.timeframe,
+                "strategy": session.chart_info.get("script_title") or session.spec.script_name,
+                "event_id": event.get("event_id"),
+                "mode": event.get("mode"),
+                "template_title": event.get("template_title"),
+                "trigger_id": event.get("trigger_id"),
+                "trigger_price": event.get("trigger_price"),
+                "market_price": event.get("market_price"),
+                "alert_time": event.get("time"),
+                "webhook_sent": event.get("webhook_sent"),
+                "telegram_sent": event.get("telegram_sent"),
+                "telegram_failed": event.get("telegram_failed"),
+            }
+            return (
+                "This is a server-verified Manual Alert AI instruction explicitly configured "
+                "by the user in a Manual Alert template. The webhook was delivered successfully "
+                "before this instruction was queued. Treat it as an explicit user request and "
+                "execute it now. For any session state change, use only the exact session_id "
+                "below; do not ask the user to identify the session and do not apply the "
+                "instruction to another session. Do not broaden the requested action. If a "
+                "required template or value is missing, report what is missing instead of "
+                "inventing it. Respond in the same language as the instruction unless the "
+                "instruction explicitly requests another language. Use that same language for "
+                "any requested Telegram delivery.\n\n"
+                f"Exact session and Manual Alert context:\n"
+                f"{json.dumps(context, ensure_ascii=False)}\n\n"
+                f"Instruction:\n{str(event.get('instruction') or '').strip()}"
+            )
+
         context = {
             "session_id": session.spec.id,
             "provider": session.spec.provider,

--- a/ai/scripts/manual_alert_tool.py
+++ b/ai/scripts/manual_alert_tool.py
@@ -16,6 +16,7 @@ _DELETE_TOOL_NAME = "delete_manual_alert_triggers"
 _MAX_MANUAL_ALERT_TRIGGERS = 50
 _MAX_MANUAL_ALERT_TEMPLATES = 50
 _TEMPLATE_MESSAGE_PREVIEW_CHARS = 500
+_TEMPLATE_AI_PREVIEW_CHARS = 500
 
 
 class ManualAlertToolError(ValueError):
@@ -85,6 +86,9 @@ class ManualAlertRegistryBridge:
                     "message_preview": str(template.get("message") or "")[
                         :_TEMPLATE_MESSAGE_PREVIEW_CHARS
                     ],
+                    "ai_instruction_preview": str(template.get("ai") or "")[
+                        :_TEMPLATE_AI_PREVIEW_CHARS
+                    ],
                 }
                 for index, template in enumerate(spec.manual_alert_templates)
             ]
@@ -131,8 +135,13 @@ class ManualAlertRegistryBridge:
         template_index = arguments.get("template_index")
         custom_title = arguments.get("custom_template_title")
         custom_message = arguments.get("custom_template_message")
+        custom_ai = arguments.get("custom_template_ai")
 
-        has_custom_template = custom_title is not None or custom_message is not None
+        has_custom_template = (
+            custom_title is not None
+            or custom_message is not None
+            or custom_ai is not None
+        )
         if template_index is not None and has_custom_template:
             raise ManualAlertToolError(
                 "use either template_index or custom template fields, not both"
@@ -150,10 +159,11 @@ class ManualAlertRegistryBridge:
             sanitized = sanitize_manual_alert_templates([{
                 "title": custom_title,
                 "message": custom_message,
+                "ai": custom_ai or "",
             }])
             if len(sanitized) != 1:
                 raise ManualAlertToolError(
-                    "custom_template_title and custom_template_message must both be valid"
+                    "custom template title, message, and optional AI instruction must be valid"
                 )
             template = sanitized[0]
             exact_template_index = next(
@@ -177,7 +187,7 @@ class ManualAlertRegistryBridge:
                 )
                 if title_conflict is not None:
                     raise ManualAlertToolError(
-                        "a template with this title already exists with a different message"
+                        "a template with this title already exists with different content"
                     )
                 if len(templates) >= _MAX_MANUAL_ALERT_TEMPLATES:
                     raise ManualAlertToolError(
@@ -355,6 +365,7 @@ class ManualAlertRegistryBridge:
             "trigger_id": str(trigger.get("id") or ""),
             "price": trigger.get("price"),
             "template_title": str(template.get("title") or ""),
+            "has_ai_instruction": bool(str(template.get("ai") or "").strip()),
             "template_source": template_source,
             "template_index": template_index,
             "template_added": template_added,
@@ -432,6 +443,14 @@ class ManualAlertTools:
                             "minLength": 1,
                             "maxLength": 5000,
                             "description": "User-supplied message format for a template that is not configured.",
+                        },
+                        "custom_template_ai": {
+                            "type": "string",
+                            "maxLength": 4000,
+                            "description": (
+                                "Optional user-supplied AI instruction for a new template. "
+                                "It runs only after the Manual Alert webhook succeeds."
+                            ),
                         },
                         "replace_existing_triggers": {
                             "type": "boolean",
@@ -554,6 +573,7 @@ class ManualAlertTools:
             "template_index",
             "custom_template_title",
             "custom_template_message",
+            "custom_template_ai",
             "replace_existing_triggers",
         }
         unexpected = sorted(set(arguments) - allowed)
@@ -586,10 +606,15 @@ class ManualAlertTools:
         custom_message = arguments.get("custom_template_message")
         if custom_message is not None and not isinstance(custom_message, str):
             raise ManualAlertToolError("custom_template_message must be a string")
+        custom_ai = arguments.get("custom_template_ai")
+        if custom_ai is not None and not isinstance(custom_ai, str):
+            raise ManualAlertToolError("custom_template_ai must be a string")
         if isinstance(custom_title, str) and len(custom_title.strip()) > 100:
             raise ManualAlertToolError("custom_template_title exceeds 100 characters")
         if isinstance(custom_message, str) and len(custom_message.strip()) > 5000:
             raise ManualAlertToolError("custom_template_message exceeds 5000 characters")
+        if isinstance(custom_ai, str) and len(custom_ai.strip()) > 4000:
+            raise ManualAlertToolError("custom_template_ai exceeds 4000 characters")
         replace_existing = arguments.get("replace_existing_triggers", False)
         if not isinstance(replace_existing, bool):
             raise ManualAlertToolError("replace_existing_triggers must be boolean")

--- a/ai/workflows/set_manual_alert.md
+++ b/ai/workflows/set_manual_alert.md
@@ -12,7 +12,8 @@ price trigger.
 5. If the requested template does not exist, ask the user for both its title
    and message format. Preserve the supplied format exactly and pass both custom
    fields so the tool adds the template and trigger in one operation. Do not
-   tell the user to add it through the dashboard.
+   tell the user to add it through the dashboard. Pass `custom_template_ai`
+   only when the user explicitly supplies an AI instruction for the template.
 6. If more than one session matches, ask a concise question using a meaningful
    distinction such as exchange, timeframe, or strategy name. If another value
    is missing or ambiguous, ask for it and stop without calling the setting
@@ -27,3 +28,4 @@ preserves all configured templates. Do not call the deletion tool first.
 
 Do not send the alert immediately. Do not edit `sessions.json` directly. The
 data service persists the trigger and handles price-touch firing and removal.
+An optional template AI instruction runs only after the webhook succeeds.

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -571,7 +571,10 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
             return JSONResponse({"error": "templates can contain at most 50 items"}, status_code=400)
         sanitized = sanitize_manual_alert_templates(templates)
         if len(sanitized) != len(templates):
-            return JSONResponse({"error": "each template requires string title and message"}, status_code=400)
+            return JSONResponse(
+                {"error": "each template requires string title, message, and optional AI instruction"},
+                status_code=400,
+            )
         try:
             updated = await registry.update_manual_alert_templates(session_id, sanitized)
         except SessionNotFoundError:
@@ -612,6 +615,9 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
             return JSONResponse({"error": "session not found"}, status_code=404)
         if "message" not in payload:
             return JSONResponse({"error": "message is required"}, status_code=400)
+        ai_instruction = payload.get("ai_instruction")
+        if ai_instruction is not None and not isinstance(ai_instruction, str):
+            return JSONResponse({"error": "ai_instruction must be string"}, status_code=400)
 
         try:
             script_title, _, _, _ = _load_script_source_info(rt.spec, rt.chart_info)
@@ -625,6 +631,11 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
             return JSONResponse({"error": str(e)}, status_code=400)
         except Exception as e:
             return JSONResponse({"error": f"webhook send failed: {e}"}, status_code=502)
+        await rt.dispatch_manual_alert_ai_instruction(
+            payload,
+            result,
+            mode="send",
+        )
         return JSONResponse(result)
 
     return r

--- a/data_service/config.py
+++ b/data_service/config.py
@@ -47,13 +47,22 @@ def sanitize_manual_alert_templates(raw: object) -> list[dict]:
             continue
         title = item.get("title")
         message = item.get("message")
-        if not isinstance(title, str) or not isinstance(message, str):
+        ai_instruction = item.get("ai", "")
+        if (
+            not isinstance(title, str)
+            or not isinstance(message, str)
+            or not isinstance(ai_instruction, str)
+        ):
             continue
         title = title.strip()[:100]
         message = message.strip()
+        ai_instruction = ai_instruction.strip()
         if not title or not message:
             continue
-        templates.append({"title": title, "message": message[:5000]})
+        template = {"title": title, "message": message[:5000]}
+        if ai_instruction:
+            template["ai"] = ai_instruction[:4000]
+        templates.append(template)
     return templates
 
 

--- a/data_service/manual_alerts.py
+++ b/data_service/manual_alerts.py
@@ -207,6 +207,17 @@ def build_manual_alert_message(template: dict, spec: SessionSpec,
     return replace_alert_template_value(parsed, spec, full_context)
 
 
+def build_manual_alert_ai_instruction(template: dict, spec: SessionSpec,
+                                      context: dict[str, Any]) -> str:
+    title = str(template.get("title") or "")
+    instruction = str(template.get("ai") or "").strip()
+    if not instruction:
+        return ""
+    full_context = {**context, "title": title}
+    rendered = replace_alert_template_value(instruction, spec, full_context)
+    return str(rendered).strip()
+
+
 def build_manual_alert_payload(*, template: dict, spec: SessionSpec,
                                price: float, market: float | None,
                                time: int | None) -> dict[str, Any]:
@@ -216,10 +227,14 @@ def build_manual_alert_payload(*, template: dict, spec: SessionSpec,
         "time": time,
         "title": template.get("title") or "",
     }
-    return {
+    payload = {
         "title": template.get("title") or "",
         "price": price,
         "market": market,
         "time": time,
         "message": build_manual_alert_message(template, spec, context),
     }
+    ai_instruction = build_manual_alert_ai_instruction(template, spec, context)
+    if ai_instruction:
+        payload["ai_instruction"] = ai_instruction
+    return payload

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import uuid
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
@@ -511,6 +512,12 @@ class Session:
                 f"trigger={trigger_id or '?'} price={trigger_price}: {e}"
             )
         else:
+            await self.dispatch_manual_alert_ai_instruction(
+                payload,
+                result,
+                mode="trigger",
+                trigger_id=trigger_id,
+            )
             await self.send_to_charts({
                 "type": "manual_alert_trigger_fired",
                 "triggers": self.manual_alert_triggers_payload(),
@@ -545,6 +552,54 @@ class Session:
             self._manual_alert_trigger_last_bar_time[trigger_id] = bar_time
             self._manual_alert_trigger_sending_ids.add(trigger_id)
             asyncio.create_task(self._send_manual_alert_trigger(dict(trigger), trigger_price, market_price, bar_time))
+
+    async def dispatch_manual_alert_ai_instruction(
+        self,
+        payload: dict,
+        delivery_result: dict,
+        *,
+        mode: str,
+        trigger_id: str = "",
+    ) -> bool:
+        instruction = str(payload.get("ai_instruction") or "").strip()
+        if not instruction:
+            return False
+        if len(instruction) > _MAX_AI_INSTRUCTION_CHARS:
+            log_with_time(
+                f"[{self.spec.id}] Manual Alert AI instruction skipped: instruction too long"
+            )
+            return False
+        if self.on_ai_instruction is None:
+            log_with_time(
+                f"[{self.spec.id}] Manual Alert AI instruction skipped: no handler"
+            )
+            return False
+
+        telegram = delivery_result.get("telegram")
+        telegram = telegram if isinstance(telegram, dict) else {}
+        event = {
+            "event_id": f"manual-alert-{uuid.uuid4().hex}",
+            "instruction": instruction,
+            "source": "manual_alert",
+            "action": "manual_alert",
+            "mode": "trigger" if mode == "trigger" else "send",
+            "time": payload.get("time"),
+            "template_title": str(payload.get("title") or ""),
+            "trigger_id": str(trigger_id or ""),
+            "trigger_price": payload.get("price"),
+            "market_price": payload.get("market"),
+            "webhook_sent": True,
+            "telegram_sent": bool(telegram.get("sent", False)),
+            "telegram_failed": bool(telegram.get("error")),
+        }
+        try:
+            await self.on_ai_instruction(self, event)
+        except Exception as e:
+            log_with_time(
+                f"[{self.spec.id}] Manual Alert AI instruction dispatch failed: {e}"
+            )
+            return False
+        return True
 
     # ------------------------------------------------------------------
     # Status snapshot (merges feed data-plane state)

--- a/data_service/templates/data.js
+++ b/data_service/templates/data.js
@@ -588,6 +588,11 @@ App.data = {
   normalizeManualAlertTemplates(templates) {
     return Array.isArray(templates)
       ? templates.filter(t => t && typeof t.title === "string" && typeof t.message === "string")
+          .map(t => ({
+            title: t.title,
+            message: t.message,
+            ...(typeof t.ai === "string" && t.ai.trim() ? { ai: t.ai } : {})
+          }))
       : [];
   },
   async loadManualAlertTemplates() {

--- a/data_service/templates/index.html
+++ b/data_service/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Chart</title>
-  <link rel="stylesheet" href="/static/styles.css" />
+  <link rel="stylesheet" href="/static/styles.css?v=3" />
   <script src="https://cdn.jsdelivr.net/npm/lightweight-charts@5.0.9/dist/lightweight-charts.standalone.production.js"></script>
 </head>
 <body>
@@ -87,8 +87,8 @@
       </div>
     </div>
     <div id="alert-template-help" class="template-help hidden">
-      <div><strong>Purpose</strong>: send a one-off manual webhook alert from the chart at a selected price.</div>
-      <div><strong>Use</strong>: double-click or double-tap the chart, choose a template, drag the menu to adjust price, then Send.</div>
+      <div><strong>Purpose</strong>: send a manual webhook alert now or when live price reaches a trigger.</div>
+      <div><strong>AI</strong>: when AI is enabled, an optional instruction runs after the webhook is sent successfully.</div>
       <div>
         <strong>Placeholders</strong>:
         <span class="template-placeholder-list">
@@ -109,6 +109,7 @@
       <div class="template-table-head">
         <div>TITLE</div>
         <div>MESSAGE</div>
+        <div>AI INSTRUCTION</div>
         <div></div>
       </div>
       <div id="alert-template-rows"></div>
@@ -144,7 +145,7 @@
     <div class="manual-alert-confirm-body">
       <div>Webhook URL</div>
       <div id="manual-alert-confirm-url" class="manual-alert-confirm-url"></div>
-      <div class="manual-alert-confirm-note">Telegram will also be sent if credentials are configured.</div>
+      <div id="manual-alert-confirm-note" class="manual-alert-confirm-note">Telegram will also be sent if credentials are configured.</div>
     </div>
     <div class="manual-alert-confirm-actions">
       <button id="manual-alert-confirm-cancel" class="template-btn" type="button">Cancel</button>
@@ -153,10 +154,10 @@
   </section>
   <!--RUNTIME_CONFIG-->
   <script src="/static/state.js?v=2"></script>
-  <script src="/static/ui.js"></script>
+  <script src="/static/ui.js?v=2"></script>
   <script src="/static/chart.js?v=2"></script>
   <script src="/static/measure.js"></script>
-  <script src="/static/data.js?v=2"></script>
+  <script src="/static/data.js?v=3"></script>
   <script src="/static/ws.js?v=2"></script>
   <script src="/static/main.js"></script>
 </body>

--- a/data_service/templates/styles.css
+++ b/data_service/templates/styles.css
@@ -307,7 +307,7 @@ body.measure-active #chart {
   top: 72px;
   left: 50%;
   z-index: 30;
-  width: min(760px, calc(100vw - 32px));
+  width: min(980px, calc(100vw - 32px));
   max-height: calc(100dvh - 112px);
   display: flex;
   flex-direction: column;
@@ -431,7 +431,7 @@ body.measure-active #chart {
 .template-table-head,
 .template-row {
   display: grid;
-  grid-template-columns: minmax(120px, 180px) minmax(260px, 1fr) 34px;
+  grid-template-columns: minmax(120px, 170px) minmax(240px, 1fr) minmax(240px, 1fr) 34px;
   gap: 8px;
   align-items: start;
   padding: 10px 14px;
@@ -469,6 +469,10 @@ body.measure-active #chart {
   padding: 8px 9px;
   resize: vertical;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+.template-row .template-ai-input {
+  height: 53px;
+  min-height: 53px;
 }
 .template-btn,
 .template-remove {
@@ -1141,6 +1145,12 @@ body.source-open .source-panel {
     grid-column: 1 / -1;
     grid-row: 2;
     resize: vertical;
+  }
+
+  .template-row .template-ai-input {
+    grid-row: 3;
+    height: 53px;
+    min-height: 53px;
   }
 
   .template-remove {

--- a/data_service/templates/ui.js
+++ b/data_service/templates/ui.js
@@ -31,6 +31,7 @@ App.ui = {
     manualAlertConfirmBackdrop: document.getElementById("manual-alert-confirm-backdrop"),
     manualAlertConfirm: document.getElementById("manual-alert-confirm"),
     manualAlertConfirmUrl: document.getElementById("manual-alert-confirm-url"),
+    manualAlertConfirmNote: document.getElementById("manual-alert-confirm-note"),
     manualAlertConfirmCancel: document.getElementById("manual-alert-confirm-cancel"),
     manualAlertConfirmSend: document.getElementById("manual-alert-confirm-send"),
     webhookToggle: document.getElementById("alert-webhook-toggle"),
@@ -220,12 +221,13 @@ App.ui = {
       });
     });
   },
-  addAlertTemplateRow(template = { title: "", message: "{}" }) {
+  addAlertTemplateRow(template = { title: "", message: "{}", ai: "" }) {
     const row = document.createElement("div");
     row.className = "template-row";
     row.innerHTML =
       `<input type="text" class="template-title-input" value="${this.escapeHtml(template.title || "")}" placeholder="TITLE" spellcheck="false">` +
       `<textarea class="template-message-input" placeholder="MESSAGE JSON" spellcheck="false">${this.escapeHtml(template.message || "{}")}</textarea>` +
+      `<textarea class="template-ai-input" placeholder="AI runs when this alert triggers (optional)" spellcheck="false">${this.escapeHtml(template.ai || "")}</textarea>` +
       `<button class="template-remove" title="Remove" aria-label="Remove">&times;</button>`;
     row.querySelector(".template-remove").addEventListener("click", () => {
       row.remove();
@@ -243,15 +245,17 @@ App.ui = {
     for (const row of rows) {
       const title = row.querySelector(".template-title-input").value.trim();
       const message = row.querySelector(".template-message-input").value.trim();
-      if (!title && !message) continue;
+      const ai = row.querySelector(".template-ai-input").value.trim();
+      if (!title && !message && !ai) continue;
       if (!title) return { ok: false, error: "TITLE is required" };
       if (!message) return { ok: false, error: "MESSAGE is required" };
+      if (ai.length > 4000) return { ok: false, error: `AI instruction is too long: ${title}` };
       try {
         this.parseAlertTemplateMessage(message, { price: 1, market: 1, time: 0, title });
       } catch (e) {
         return { ok: false, error: `Invalid JSON: ${title}` };
       }
-      templates.push({ title, message });
+      templates.push({ title, message, ...(ai ? { ai } : {}) });
     }
     return { ok: true, templates };
   },
@@ -366,6 +370,14 @@ App.ui = {
   buildManualAlertMessage(template, context) {
     const parsed = this.parseAlertTemplateMessage(template.message, { ...context, title: template.title });
     return this.replaceAlertTemplateValue(parsed, { ...context, title: template.title });
+  },
+  buildManualAlertAiInstruction(template, context) {
+    const instruction = String(template.ai || "").trim();
+    if (!instruction) return "";
+    return String(this.replaceAlertTemplateValue(
+      instruction,
+      { ...context, title: template.title }
+    )).trim();
   },
   currentMarketPrice() {
     const lastPrice = Number(App.state.lastPrice);
@@ -491,7 +503,8 @@ App.ui = {
       price,
       template: {
         title: template.title,
-        message: template.message
+        message: template.message,
+        ...(template.ai ? { ai: template.ai } : {})
       }
     };
   },
@@ -568,13 +581,16 @@ App.ui = {
       market: this.currentMarketPrice(),
       title: template.title
     };
-    return {
+    const payload = {
       title: template.title,
       price: context.price,
       market: context.market,
       time: context.time,
       message: this.buildManualAlertMessage(template, context)
     };
+    const aiInstruction = this.buildManualAlertAiInstruction(template, context);
+    if (aiInstruction) payload.ai_instruction = aiInstruction;
+    return payload;
   },
   clampManualAlertMenuPosition(left, top) {
     const menu = this.elements.manualAlertMenu;
@@ -624,6 +640,12 @@ App.ui = {
     this.manualAlertPendingSend = payload;
     App.state.manualAlertConfirmOpen = true;
     this.elements.manualAlertConfirmUrl.textContent = url;
+    const hasAiInstruction = Boolean(
+      payload && payload.template && String(payload.template.ai || "").trim()
+    );
+    this.elements.manualAlertConfirmNote.textContent = hasAiInstruction
+      ? "Telegram will also be sent if configured. The AI instruction will run after a successful webhook when AI is enabled."
+      : "Telegram will also be sent if credentials are configured.";
     this.elements.manualAlertConfirmBackdrop.classList.remove("hidden");
     this.elements.manualAlertConfirm.classList.remove("hidden");
     this.elements.manualAlertConfirm.setAttribute("aria-hidden", "false");


### PR DESCRIPTION
## 변경사항

- Manual Alert 템플릿에 선택형 `AI INSTRUCTION` 입력과 저장 구조를 추가했습니다.
- 직접 Send 또는 가격 트리거 웹훅이 성공한 뒤 세션 범위의 AI 지시를 비동기로 실행합니다.
- AI 지시를 웹훅 JSON과 분리하고 기존 가격 및 세션 placeholder를 지원합니다.
- AI 비활성화 또는 AI 실행 실패가 기존 수동 알림 전송 흐름에 영향을 주지 않도록 격리했습니다.
- 실행 요청과 결과를 공유 AI 채팅에 `[Manual Alert AI]` 문맥으로 표시합니다.
- AI 도구를 통한 템플릿 생성과 관련 지침 및 README에 선택형 AI 지시 사용법을 반영했습니다.

## 동작 기준

- 웹훅 전송이 실패하면 AI 지시는 실행하지 않습니다.
- AI 지시가 없는 기존 템플릿은 이전과 동일하게 동작합니다.
- AI 지시는 명시된 세션과 알림 문맥에만 적용됩니다.