### PR TITLE
Pine 호환 bgcolor 차트 배경색 기능 추가

### DIFF
--- a/data_service/api.py
+++ b/data_service/api.py
@@ -434,18 +434,29 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
                 candles = candles[start_idx:]
 
                 for title, options in plot_options.items():
+                    kind = str(options.get("kind") or "line")
                     series_data = []
                     for candle in candles:
                         value = candle.extra_fields.get(title)
                         series_data.append({
                             "time": int(candle.timestamp),
-                            "value": None if (value == "" or value is None) else float(value),
+                            "value": (
+                                None
+                                if value is None or str(value) == ""
+                                else int(value) if kind == "bgcolor" else float(value)
+                            ),
                         })
                     result.append({
                         "title": title,
+                        "kind": kind,
                         "color": options.get("color"),
                         "linewidth": options.get("linewidth"),
                         "style": options.get("style"),
+                        "offset": options.get("offset", 0),
+                        "editable": options.get("editable", True),
+                        "show_last": options.get("show_last"),
+                        "force_overlay": options.get("force_overlay", False),
+                        "order": options.get("order", 0),
                         "data": series_data,
                     })
                 reader.close()

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -23,6 +23,12 @@ _MAX_AI_INSTRUCTION_CHARS = 4_000
 _MAX_PROCESSED_AI_INSTRUCTION_EVENTS = 500
 
 
+def _plot_wire_value(value: Any, kind: str) -> float | int | None:
+    if value is None or str(value) == "":
+        return None
+    return int(value) if kind == "bgcolor" else float(value)
+
+
 # ======================================================================
 # Paths
 # ======================================================================
@@ -366,13 +372,15 @@ class Session:
                             if candle is None:
                                 return
 
-                            for title in self.plot_options.keys():
+                            for title, options in self.plot_options.items():
+                                kind = str(options.get("kind") or "line")
                                 value = candle.extra_fields.get(title)
                                 plot_data_event = {
                                     "type": "plot_data",
                                     "title": title,
+                                    "kind": kind,
                                     "time": int(candle.timestamp),
-                                    "value": None if (value == "" or value is None) else float(value),
+                                    "value": _plot_wire_value(value, kind),
                                 }
                                 await self.send_to_charts(plot_data_event)
                             reader.close()

--- a/data_service/templates/bgcolor.js
+++ b/data_service/templates/bgcolor.js
@@ -1,0 +1,213 @@
+var App = window.App || (window.App = {});
+
+class BgColorPaneRenderer {
+  constructor(source) {
+    this.source = source;
+  }
+
+  draw() {}
+
+  drawBackground(target) {
+    const segments = this.source.visibleSegments();
+    if (!segments.length) return;
+
+    target.useBitmapCoordinateSpace((scope) => {
+      const ctx = scope.context;
+      const ratio = scope.horizontalPixelRatio;
+      const maxWidth = scope.bitmapSize.width;
+      const timeScale = this.source.chart.timeScale();
+      const halfBarSpacing = Math.max(0, Number(timeScale.options().barSpacing) || 0) / 2;
+      for (const segment of segments) {
+        const leftCenter = timeScale.logicalToCoordinate(segment.start);
+        const rightCenter = timeScale.logicalToCoordinate(segment.end);
+        const left = leftCenter == null ? null : leftCenter - halfBarSpacing;
+        const right = rightCenter == null ? null : rightCenter + halfBarSpacing;
+        if (left == null || right == null) continue;
+
+        const x1 = Math.max(0, Math.floor(Math.min(left, right) * ratio));
+        const x2 = Math.min(maxWidth, Math.ceil(Math.max(left, right) * ratio));
+        if (x2 <= x1) continue;
+        ctx.fillStyle = segment.color;
+        ctx.fillRect(x1, 0, x2 - x1, scope.bitmapSize.height);
+      }
+    });
+  }
+}
+
+class BgColorPaneView {
+  constructor(source) {
+    this.rendererInstance = new BgColorPaneRenderer(source);
+  }
+
+  update() {}
+
+  renderer() {
+    return this.rendererInstance;
+  }
+
+  zOrder() {
+    return "bottom";
+  }
+}
+
+class BgColorPanePrimitive {
+  constructor(chart, collections) {
+    this.chart = chart;
+    this.collections = collections;
+    this.layers = new Map();
+    this.segmentGroups = [];
+    this.dirty = true;
+    this.requestUpdate = null;
+    this.views = [new BgColorPaneView(this)];
+  }
+
+  attached({ requestUpdate }) {
+    this.requestUpdate = requestUpdate;
+    this.invalidate();
+  }
+
+  detached() {
+    this.requestUpdate = null;
+  }
+
+  updateAllViews() {
+    this.views.forEach(view => view.update());
+  }
+
+  paneViews() {
+    return this.views;
+  }
+
+  setLayer(plot, data) {
+    const title = String(plot.title || "");
+    if (!title) return;
+    const points = new Map();
+    for (const point of Array.isArray(data) ? data : []) {
+      const time = Number(point && point.time);
+      if (!Number.isFinite(time)) continue;
+      points.set(time, this.normalizeColorValue(point.value));
+    }
+    this.layers.set(title, {
+      title,
+      offset: this.normalizeInteger(plot.offset, 0),
+      showLast: plot.show_last == null ? null : Math.max(0, this.normalizeInteger(plot.show_last, 0)),
+      order: this.normalizeInteger(plot.order, this.layers.size),
+      points
+    });
+    this.invalidate();
+  }
+
+  updatePoint(title, time, value) {
+    const layer = this.layers.get(String(title || ""));
+    const pointTime = Number(time);
+    if (!layer || !Number.isFinite(pointTime)) return;
+    layer.points.set(pointTime, this.normalizeColorValue(value));
+    this.invalidate();
+  }
+
+  onOhlcvChanged() {
+    this.invalidate();
+  }
+
+  clear() {
+    this.layers.clear();
+    this.segmentGroups = [];
+    this.invalidate();
+  }
+
+  invalidate() {
+    this.dirty = true;
+    if (this.requestUpdate) this.requestUpdate();
+  }
+
+  normalizeInteger(value, fallback) {
+    const number = Number(value);
+    return Number.isFinite(number) ? Math.trunc(number) : fallback;
+  }
+
+  normalizeColorValue(value) {
+    if (value == null || value === "") return null;
+    const number = Number(value);
+    if (!Number.isFinite(number) || number < 0 || number > 0xFFFFFFFF) return null;
+    return Math.trunc(number);
+  }
+
+  colorToCss(value) {
+    const rgba = Number(value) >>> 0;
+    const red = (rgba >>> 24) & 0xFF;
+    const green = (rgba >>> 16) & 0xFF;
+    const blue = (rgba >>> 8) & 0xFF;
+    const alpha = rgba & 0xFF;
+    return alpha === 0 ? null : `rgba(${red}, ${green}, ${blue}, ${alpha / 255})`;
+  }
+
+  rebuildSegments() {
+    const indexByTime = this.collections.ohlcvIndexByTime;
+    const layers = Array.from(this.layers.values()).sort((a, b) => (
+      a.order - b.order || a.title.localeCompare(b.title)
+    ));
+    const segmentGroups = [];
+
+    for (const layer of layers) {
+      const layerSegments = [];
+      const points = [];
+      for (const [time, value] of layer.points.entries()) {
+        const sourceIndex = indexByTime.get(Number(time));
+        if (sourceIndex == null) continue;
+        points.push({ sourceIndex, value });
+      }
+      points.sort((a, b) => a.sourceIndex - b.sourceIndex);
+      const lastSourceIndex = points.length ? points[points.length - 1].sourceIndex : -1;
+      const minimumSourceIndex = layer.showLast == null
+        ? -Infinity
+        : lastSourceIndex - layer.showLast + 1;
+      let active = null;
+
+      for (const point of points) {
+        if (point.sourceIndex < minimumSourceIndex) continue;
+        const color = this.colorToCss(point.value);
+        if (!color) {
+          active = null;
+          continue;
+        }
+        const targetIndex = point.sourceIndex + layer.offset;
+        if (active && active.color === color && targetIndex === active.end + 1) {
+          active.end = targetIndex;
+          continue;
+        }
+        active = { start: targetIndex, end: targetIndex, color };
+        layerSegments.push(active);
+      }
+      segmentGroups.push(layerSegments);
+    }
+
+    this.segmentGroups = segmentGroups;
+    this.dirty = false;
+  }
+
+  visibleSegments() {
+    if (this.dirty) this.rebuildSegments();
+    const range = this.chart.timeScale().getVisibleLogicalRange();
+    if (!range) return [];
+    const minimum = range.from - 1;
+    const maximum = range.to + 1;
+    const visible = [];
+    for (const segments of this.segmentGroups) {
+      let low = 0;
+      let high = segments.length;
+      while (low < high) {
+        const middle = (low + high) >> 1;
+        if (segments[middle].end < minimum) low = middle + 1;
+        else high = middle;
+      }
+      for (let index = low; index < segments.length; index++) {
+        const segment = segments[index];
+        if (segment.start > maximum) break;
+        visible.push(segment);
+      }
+    }
+    return visible;
+  }
+}
+
+App.BgColorPanePrimitive = BgColorPanePrimitive;

--- a/data_service/templates/chart.js
+++ b/data_service/templates/chart.js
@@ -7,6 +7,7 @@ App.chart = {
   volumeSeries: null,
   entryMarkerSeries: null,
   closeMarkerSeries: null,
+  bgcolorPrimitive: null,
   currentPriceLine: null,
   manualAlertPreviewPriceLine: null,
   manualAlertTriggerItems: new Map(),
@@ -811,6 +812,9 @@ App.chart = {
       }
     );
 
+    this.bgcolorPrimitive = new App.BgColorPanePrimitive(this.chart, App.collections);
+    this.chart.panes()[0].attachPrimitive(this.bgcolorPrimitive);
+
     this.volumeSeries = this.chart.addSeries(
       LightweightCharts.HistogramSeries,
       {
@@ -896,6 +900,9 @@ App.chart = {
     }
     collections.plotSeriesList.length = 0;
     collections.plotSeriesMap.clear();
+    if (this.bgcolorPrimitive) {
+      this.bgcolorPrimitive.clear();
+    }
     collections.markers.length = 0;
     collections.markerKeys.clear();
     collections.plotcharMarkers.length = 0;

--- a/data_service/templates/data.js
+++ b/data_service/templates/data.js
@@ -4,7 +4,7 @@ App.data = {
   STYLE_CIRCLES: 2,
   STYLE_CROSS: 4,
   STYLE_LINEBR: 7,
-  rebuildOhlcvCache(data) {
+  rebuildOhlcvCache(data, notifyBgcolor = true) {
     const collections = App.collections;
     collections.ohlcvData = Array.isArray(data)
       ? data
@@ -30,6 +30,9 @@ App.data = {
     if (App.measure) {
       App.measure.scheduleRender();
     }
+    if (notifyBgcolor && App.chart && App.chart.bgcolorPrimitive) {
+      App.chart.bgcolorPrimitive.onOhlcvChanged();
+    }
   },
   upsertOhlcvCache(bar) {
     if (!bar || !Number.isFinite(Number(bar.time))) return;
@@ -46,7 +49,7 @@ App.data = {
     const existingIndex = collections.ohlcvIndexByTime.get(time);
     if (existingIndex != null) {
       collections.ohlcvData[existingIndex] = cachedBar;
-      this.rebuildOhlcvCache(collections.ohlcvData);
+      this.rebuildOhlcvCache(collections.ohlcvData, false);
       return;
     }
     const last = collections.ohlcvData[collections.ohlcvData.length - 1];
@@ -142,6 +145,13 @@ App.data = {
     return controller;
   },
   createPlotSeries(chart, collections, plot, seriesData) {
+    if (plot.kind === "bgcolor") {
+      if (chart.bgcolorPrimitive) {
+        chart.bgcolorPrimitive.setLayer(plot, seriesData);
+      }
+      collections.plotSeriesMap.set(plot.title, { type: "bgcolor" });
+      return;
+    }
     const { title, color, linewidth, style } = plot;
     const { options, isLineBreakStyle } = this.buildPlotSeriesOptions(color, linewidth, style);
     if (isLineBreakStyle) {
@@ -156,6 +166,13 @@ App.data = {
   updatePlotSeries(chart, collections, title, time, value) {
     const controller = collections.plotSeriesMap.get(title);
     if (!controller) {
+      return;
+    }
+
+    if (controller.type === "bgcolor") {
+      if (chart.bgcolorPrimitive) {
+        chart.bgcolorPrimitive.updatePoint(title, time, value);
+      }
       return;
     }
 
@@ -329,9 +346,16 @@ App.data = {
             const seriesData = [];
             if (plot.data && Array.isArray(plot.data)) {
               plot.data.forEach(point => {
-                const linePoint = App.data.toLinePoint(point.time, point.value);
-                if (linePoint) {
-                  seriesData.push(linePoint);
+                if (plot.kind === "bgcolor") {
+                  const pointTime = Number(point.time);
+                  if (Number.isFinite(pointTime)) {
+                    seriesData.push({ time: pointTime, value: point.value });
+                  }
+                } else {
+                  const linePoint = App.data.toLinePoint(point.time, point.value);
+                  if (linePoint) {
+                    seriesData.push(linePoint);
+                  }
                 }
               });
             }

--- a/data_service/templates/index.html
+++ b/data_service/templates/index.html
@@ -155,9 +155,10 @@
   <!--RUNTIME_CONFIG-->
   <script src="/static/state.js?v=2"></script>
   <script src="/static/ui.js?v=2"></script>
-  <script src="/static/chart.js?v=2"></script>
+  <script src="/static/bgcolor.js?v=2"></script>
+  <script src="/static/chart.js?v=3"></script>
   <script src="/static/measure.js"></script>
-  <script src="/static/data.js?v=3"></script>
+  <script src="/static/data.js?v=4"></script>
   <script src="/static/ws.js?v=2"></script>
   <script src="/static/main.js"></script>
 </body>

--- a/data_service/ui.py
+++ b/data_service/ui.py
@@ -12,6 +12,7 @@ _STATIC_FILES = {
     "styles.css": "text/css",
     "state.js": "text/javascript",
     "ui.js": "text/javascript",
+    "bgcolor.js": "text/javascript",
     "chart.js": "text/javascript",
     "measure.js": "text/javascript",
     "data.js": "text/javascript",

--- a/pynecore/lib/__init__.py
+++ b/pynecore/lib/__init__.py
@@ -20,7 +20,7 @@ from ..core.script import script, input
 from ..types.series import Series
 from ..types.na import NA
 from . import syminfo  # This should be imported before core.datetime to avoid circular import!
-from . import barstate, string, log, math, plot, hline, linefill, alert, request
+from . import barstate, string, log, math, plot, bgcolor, hline, linefill, alert, request
 from . import timeframe as timeframe_module
 from . import session as session_module
 
@@ -104,6 +104,7 @@ _security_ctx = None
 #
 
 if TYPE_CHECKING:
+    from bgcolor import bgcolor
     from hline import hline
     from plot import plot
     from alert import alert
@@ -220,10 +221,6 @@ def timestamp(year: int | float, month: int | float, day: int | float, hour: int
 # TODO: implement creating plot metadata to be able to plot in a different module
 
 def barcolor(*_, **__):
-    ...
-
-
-def bgcolor(*_, **__):
     ...
 
 

--- a/pynecore/lib/bgcolor.py
+++ b/pynecore/lib/bgcolor.py
@@ -1,0 +1,69 @@
+import sys
+
+from ..core.callable_module import CallableModule
+from ..types.color import Color
+from ..types.na import NA
+
+
+def _color_value(value: Color | str | NA | None) -> int | NA:
+    if value is None or isinstance(value, NA):
+        return NA()
+    if isinstance(value, str):
+        value = Color(value)
+    if not isinstance(value, Color):
+        raise TypeError("bgcolor color must be a Color, hex string, na, or None")
+    return value.value
+
+
+# noinspection PyProtectedMember
+def bgcolor(color: Color | str | NA | None, offset: int = 0, editable: bool = True,
+            show_last: int | None = None, title: str | None = None,
+            force_overlay: bool = False, *_, **__) -> None:
+    """Record a per-bar background color for chart rendering."""
+    from .. import lib
+
+    if lib._lib_semaphore:
+        return
+
+    if lib.bar_index == 0 and sys._getframe(2).f_code.co_name != 'main':  # noqa
+        raise RuntimeError("The bgcolor function can only be called from the main function!")
+
+    if not isinstance(offset, int) or isinstance(offset, bool):
+        raise TypeError("bgcolor offset must be an int")
+    if not isinstance(editable, bool):
+        raise TypeError("bgcolor editable must be a bool")
+    if show_last is not None and (
+        not isinstance(show_last, int) or isinstance(show_last, bool) or show_last < 0
+    ):
+        raise ValueError("bgcolor show_last must be a non-negative int or None")
+    if not isinstance(force_overlay, bool):
+        raise TypeError("bgcolor force_overlay must be a bool")
+    if title is not None and not isinstance(title, str):
+        raise TypeError("bgcolor title must be a string or None")
+
+    base_title = title if title is not None else "Background"
+    resolved_title = base_title
+    suffix = 0
+    while resolved_title in lib._plot_data:
+        resolved_title = f"{base_title} {suffix}"
+        suffix += 1
+
+    order = len(lib._plot_data)
+    encoded_color = NA() if color is lib.na else _color_value(color)
+    if isinstance(encoded_color, int) and not 0 <= encoded_color <= 0xFFFFFFFF:
+        raise ValueError("bgcolor color must fit the 0xRRGGBBAA format")
+    lib._plot_data[resolved_title] = encoded_color
+
+    if lib.bar_index == 0 and lib._script and lib._script.on_plot_callback:
+        lib._script.on_plot_callback({
+            "title": resolved_title,
+            "kind": "bgcolor",
+            "offset": offset,
+            "editable": editable,
+            "show_last": show_last,
+            "force_overlay": force_overlay,
+            "order": order,
+        })
+
+
+CallableModule(__name__)

--- a/pynecore/lib/bgcolor.pyi
+++ b/pynecore/lib/bgcolor.pyi
@@ -1,0 +1,20 @@
+from ..core.callable_module import CallableModule
+from ..types.color import Color
+from ..types.na import NA
+
+
+class BgColorModule(CallableModule):
+    def __call__(
+        self,
+        color: Color | str | NA | None,
+        offset: int = 0,
+        editable: bool = True,
+        show_last: int | None = None,
+        title: str | None = None,
+        force_overlay: bool = False,
+        *args,
+        **kwargs,
+    ) -> None: ...
+
+
+bgcolor: BgColorModule = BgColorModule(__name__)

--- a/pynecore/lib/color.py
+++ b/pynecore/lib/color.py
@@ -53,14 +53,14 @@ def b(color: Color) -> int:
     return color.b
 
 
-def t(color: Color) -> int:
+def t(color: Color) -> float:
     """
     Return the transparency of a color
 
     :param color: Color
     :return: The transparency of the color, 0-100 (0: not transparent, 100: invisible)
     """
-    return color.a
+    return color.t
 
 
 # noinspection PyShadowingNames
@@ -73,8 +73,7 @@ def new(color: Color | str, transp: float = 0) -> Color:
     """
     if isinstance(color, str):
         color = Color(color)
-    color.t = transp
-    return color
+    return Color.rgb(color.r, color.g, color.b, transp)
 
 
 # noinspection PyShadowingNames

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -278,11 +278,23 @@ def on_close_event(trade, runner=None):
 def on_plot_event(plot_data):
     """Callback for plot events - stores/updates plot options"""
     title = plot_data['title']
-    new_options = {
-        "color": plot_data.get('color'),
-        "linewidth": plot_data.get('linewidth'),
-        "style": plot_data.get('style'),
-    }
+    kind = plot_data.get("kind", "line")
+    if kind == "bgcolor":
+        new_options = {
+            "kind": "bgcolor",
+            "offset": plot_data.get("offset", 0),
+            "editable": plot_data.get("editable", True),
+            "show_last": plot_data.get("show_last"),
+            "force_overlay": plot_data.get("force_overlay", False),
+            "order": plot_data.get("order", 0),
+        }
+    else:
+        new_options = {
+            "kind": "line",
+            "color": plot_data.get('color'),
+            "linewidth": plot_data.get('linewidth'),
+            "style": plot_data.get('style'),
+        }
 
     # Check if title exists and options are the same
     if title in plot_options:

--- a/workdir/scripts/demo/demo_1m.py
+++ b/workdir/scripts/demo/demo_1m.py
@@ -3,7 +3,7 @@
 """
 from pynecore import Persistent
 from pynecore.lib import script, close, ta, strategy, time, plot, color, na, plotchar, request, syminfo, low, barmerge, \
-    log, bar_index, is_na
+    log, bar_index, is_na, bgcolor
 from pynecore.types import Series
 
 
@@ -54,6 +54,14 @@ def main():
     plot(bbUpper, title="BB Upper", color=color.red, linewidth=1, style=plot.style_line)
     plot(bbBasis, title="BB Basis", color=color.blue, linewidth=1, style=plot.style_line)
     plot(bbLower, title="BB Lower", color=color.green, linewidth=1, style=plot.style_line)
+
+    # Background Color Example
+    bgcolor(
+        color.new(color.red, 85) if rsi > 70
+        else color.new(color.green, 85) if rsi < 30
+        else na,
+        title="RSI Zone",
+    )
 
     # Plotchar Example
     plotchar(rsi < 30, title="RSI Low", text="RSI Low", location=plot.location_belowbar, color=color.green)


### PR DESCRIPTION
## 변경 사항

- Pine Script와 유사한 `bgcolor()` callable API를 추가했습니다.
- RGBA 색상, `na`, `offset`, `show_last`, 복수 background layer 메타데이터를 지원합니다.
- Runner와 data service가 배경색 값을 32비트 정수로 보존하고 과거 REST 데이터와 실시간 WebSocket 이벤트로 전달하도록 확장했습니다.
- Lightweight Charts pane primitive를 추가해 배경을 캔들 및 거래량 뒤에 렌더링합니다.
- 연속된 동일 색상 봉을 하나의 구간으로 병합하고 현재 visible range만 그리도록 구성했습니다.
- 차트 reset, history re-sync 및 동일 timestamp 실시간 업데이트 시 배경 상태가 올바르게 갱신되도록 처리했습니다.
- `color.new()`이 원본 색상 상수를 변경하지 않고 새 색상을 반환하도록 수정했습니다.
- `color.t()`가 alpha byte 대신 0~100 범위의 투명도를 반환하도록 바로잡았습니다.
- `demo_1m.py`에 RSI 과매수·과매도 구간을 표시하는 `bgcolor()` 예시를 추가했습니다.

## 검증

- Python 컴파일 및 JavaScript 문법 검사
- RGBA 정수/null CSV 및 API 직렬화 확인
- callable metadata, `offset`, `show_last`, 동일 timestamp 업데이트 확인
- 데스크톱과 모바일 Chrome에서 봉별 배경 렌더링 확인
- `color.new()` 원본 불변성과 투명도 변환 확인