### PR TITLE
대시보드 자동 업데이트 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,8 @@ workdir/config/providers.toml
 workdir/config/sessions.json
 workdir/config/ai_chat.json
 workdir/config/calendar_events.json
+workdir/config/update_request.json
+workdir/config/update_state.json
 workdir/output/realtime/
 
 # Ignore SQLite cache files but keep the directory

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -167,6 +167,7 @@ class CodexService:
         developer_instructions: str = DEFAULT_DEVELOPER_INSTRUCTIONS,
         timeout_seconds: float = 600,
         chat_state_path: Path | None = None,
+        startup_enabled: bool = True,
     ) -> None:
         self.project_root = project_root.resolve()
         self.session_registry = session_registry
@@ -184,7 +185,7 @@ class CodexService:
             chat_state_path or self.project_root / "workdir" / "config" / "ai_chat.json"
         ).resolve()
         self._codex: AsyncCodex | None = None
-        self._disabled = False
+        self._disabled = not startup_enabled
         self._lifecycle_lock = asyncio.Lock()
         self._conversations_lock = asyncio.Lock()
         self._models_lock = asyncio.Lock()

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -41,6 +41,7 @@ from config import (
 )
 from manual_alerts import send_manual_alert_payload
 from ohlcv_io import make_ccxt_pro_client
+from update_service import UpdateService, UpdateServiceError
 
 # Cache of exchange -> ccxt markets so symbol validation hits the network at most
 # once per exchange for the hub's lifetime.
@@ -691,10 +692,38 @@ def build_control_router(
     calendar_store: CalendarEventStore,
     asset_portfolio_service: AssetPortfolioService,
     asset_transfer_service: AssetTransferService,
+    update_service: UpdateService,
 ) -> APIRouter:
     r = APIRouter()
     calendar_forecast_runs: dict[str, int] = {}
     calendar_forecast_tasks: dict[str, set[asyncio.Task[Any]]] = {}
+
+    @r.get("/api/update/status")
+    async def update_status() -> JSONResponse:
+        try:
+            result = await update_service.status()
+        except Exception as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
+    @r.post("/api/update/check")
+    async def update_check() -> JSONResponse:
+        try:
+            result = await update_service.check()
+        except UpdateServiceError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=exc.status_code)
+        return JSONResponse(result)
+
+    @r.post("/api/update/start")
+    async def update_start(payload: dict = Body(default_factory=dict)) -> JSONResponse:
+        confirmation_token = payload.get("confirmation_token")
+        if not isinstance(confirmation_token, str) or not confirmation_token:
+            return JSONResponse({"error": "confirmation_token is required"}, status_code=400)
+        try:
+            result = await update_service.start(confirmation_token)
+        except UpdateServiceError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=exc.status_code)
+        return JSONResponse(result, status_code=202)
 
     @r.get("/api/assets")
     async def get_assets(refresh: bool = False) -> JSONResponse:

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from config import ensure_provider_config, load_hub_config, load_initial_session
 from registry import SessionRegistry
 from api import build_session_api_router, build_control_router, build_validation_router
 from ui import build_ui_router
+from update_service import UpdateService
 
 _BANNER = r"""
     ____                   ____             __
@@ -36,6 +38,7 @@ def build_app(
     calendar_store: CalendarEventStore,
     asset_portfolio_service: AssetPortfolioService,
     asset_transfer_service: AssetTransferService,
+    update_service: UpdateService,
 ) -> FastAPI:
     app = FastAPI()
     app.include_router(build_ui_router())
@@ -46,6 +49,7 @@ def build_app(
             calendar_store,
             asset_portfolio_service,
             asset_transfer_service,
+            update_service,
         )
     )
     app.include_router(build_validation_router())
@@ -150,6 +154,15 @@ async def main() -> None:
         project_root=_PROJECT_ROOT,
         session_registry=registry,
         calendar_store=calendar_store,
+        startup_enabled=os.environ.get("PYNEREAL_UPDATE_AI_ENABLED") != "0",
+    )
+    update_shutdown = asyncio.Event()
+    update_service = UpdateService(
+        repo_root=_PROJECT_ROOT,
+        registry=registry,
+        port=cfg.port,
+        ai_enabled=lambda: codex_service.enabled,
+        request_shutdown=update_shutdown.set,
     )
     registry.set_ai_instruction_handler(codex_service.handle_strategy_instruction)
     try:
@@ -162,6 +175,7 @@ async def main() -> None:
         calendar_store,
         asset_portfolio_service,
         asset_transfer_service,
+        update_service,
     )
 
     await registry.start_all(specs)
@@ -172,9 +186,32 @@ async def main() -> None:
         uvicorn.Config(app, host=cfg.host, port=cfg.port, loop="asyncio", lifespan="off",
                        ws_ping_interval=None, ws_ping_timeout=None)
     )
+
+    async def stop_server_for_update() -> None:
+        await update_shutdown.wait()
+        server.should_exit = True
+
+    async def finish_update_after_start() -> None:
+        while not server.started and not server.should_exit:
+            await asyncio.sleep(0.05)
+        if server.started:
+            await update_service.finish_restart()
+
+    update_shutdown_task = asyncio.create_task(stop_server_for_update())
+    update_finish_task = (
+        asyncio.create_task(finish_update_after_start())
+        if update_service.pending_restart()
+        else None
+    )
     try:
         await server.serve()
     finally:
+        update_shutdown_task.cancel()
+        shutdown_tasks = [update_shutdown_task]
+        if update_finish_task is not None:
+            update_finish_task.cancel()
+            shutdown_tasks.append(update_finish_task)
+        await asyncio.gather(*shutdown_tasks, return_exceptions=True)
         heartbeat.cancel()
         try:
             await registry.shutdown()
@@ -183,6 +220,8 @@ async def main() -> None:
                 await asset_portfolio_service.close()
             finally:
                 await codex_service.close()
+    if update_shutdown.is_set():
+        update_service.apply_and_restart()
 
 
 if __name__ == "__main__":

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -192,6 +192,45 @@ body {
 /* the money-bag glyph fills its em square more than the calendar's, so it reads
    wider at the same font-size — nudge it down to match Calendar's footprint */
 #hub-assets-open .hub-menu-emoji { font-size: 16px; }
+.hub-menu-footer {
+  position: relative;
+  margin-top: auto;
+  padding: 28px 14px 14px;
+  border-top: 1px solid var(--border);
+}
+.hub-menu-version-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.hub-version {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hub-update-button {
+  flex: none;
+  min-width: 68px;
+  padding: 5px 10px;
+}
+.hub-update-message {
+  position: absolute;
+  top: 8px;
+  right: 14px;
+  left: 14px;
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 14px;
+  text-align: right;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.hub-update-message.error { color: #ff7b72; margin: 0; min-height: 0; }
 
 .conn {
   font-size: 12px;
@@ -2057,6 +2096,33 @@ tr:last-child td { border-bottom: none; }
   display: flex;
   justify-content: flex-end;
   gap: 8px;
+}
+.update-revisions {
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: #f2f5f8;
+  font-size: 12px;
+  line-height: 1.5;
+}
+#update-modal { z-index: 90; }
+#update-modal.updating .modal-header button,
+#update-modal.updating #update-cancel { visibility: hidden; }
+#update-modal.completed .modal-header button { visibility: hidden; }
+#update-modal.completed .confirm-footer { display: none; }
+#update-detail.update-detail-pending::after {
+  content: "...";
+  display: inline-block;
+  width: 0;
+  overflow: hidden;
+  margin-left: 3px;
+  vertical-align: bottom;
+  white-space: nowrap;
+  animation: update-detail-dots 1.2s steps(4, end) infinite;
+}
+@keyframes update-detail-dots {
+  to { width: 14px; }
 }
 
 /* ---- AI chat: floating 🐸 button + chat panel ---- */

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=59" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=62" />
 </head>
 <body>
   <header class="topbar">
@@ -40,6 +40,13 @@
         <span>Calendar</span>
       </button>
     </nav>
+    <div class="hub-menu-footer">
+      <div id="hub-update-message" class="hub-update-message" aria-live="polite"></div>
+      <div class="hub-menu-version-row">
+        <span id="hub-version" class="hub-version mono">-------</span>
+        <button id="hub-update-button" class="btn hub-update-button" type="button">Update</button>
+      </div>
+    </div>
   </aside>
 
   <section class="card collapsible collapsed" id="add-card">
@@ -362,6 +369,27 @@
     </div>
   </div>
 
+  <div id="update-modal" class="modal hidden" aria-hidden="true">
+    <div class="modal-box modal-box-sm" role="dialog" aria-modal="true" aria-labelledby="update-title">
+      <div class="modal-header">
+        <span id="update-title">Update PyneReal</span>
+        <button id="update-close" class="btn" type="button" title="Close" aria-label="Close">&times;</button>
+      </div>
+      <div class="confirm-body">
+        <div id="update-confirm-message" class="confirm-message">
+          Running sessions will stop while the update is installed, then resume automatically.
+        </div>
+        <div id="update-revisions" class="update-revisions mono"></div>
+        <div id="update-detail" class="muted"></div>
+        <div id="update-error" class="error"></div>
+      </div>
+      <div class="confirm-footer">
+        <button id="update-cancel" class="btn" type="button">Cancel</button>
+        <button id="update-confirm" class="btn btn-primary" type="button">Update</button>
+      </div>
+    </div>
+  </div>
+
   <button id="ai-chat-fab" class="ai-chat-fab hidden" type="button" aria-label="Open AI chat" aria-expanded="false">
     <svg class="pepe" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false">
       <path d="M32 10C18 10 9 19 9 31c0 7 3 13 8 17 4 3.2 9.3 5 15 5s11-1.8 15-5c5-4 8-10 8-17 0-12-9-21-23-21z" fill="#5B9E4D" stroke="#2f5c28" stroke-width="1.8" stroke-linejoin="round"/>
@@ -433,6 +461,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=61"></script>
+  <script src="/static/dashboard.js?v=67"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -62,6 +62,11 @@
   let assetTransferReview = null;
   let assetTransferMode = "options";
   let assetTransferSubmitting = false;
+  let updateConfirmationToken = "";
+  let updatePollTimer = null;
+  let updateMessageTimer = null;
+  let updateCompleteTimer = null;
+  let updateRestartPending = false;
 
   const el = (id) => document.getElementById(id);
 
@@ -337,6 +342,7 @@
     menu.setAttribute("aria-hidden", "false");
     backdrop.setAttribute("aria-hidden", "false");
     el("hub-menu-button").setAttribute("aria-expanded", "true");
+    loadUpdateStatus();
   }
 
   function closeHubMenu() {
@@ -2226,6 +2232,13 @@
     el("hub-menu-backdrop").addEventListener("click", closeHubMenu);
     el("hub-calendar-open").addEventListener("click", openCalendar);
     el("hub-assets-open").addEventListener("click", openAssets);
+    el("hub-update-button").addEventListener("click", checkForUpdate);
+    el("update-close").addEventListener("click", closeUpdateModal);
+    el("update-cancel").addEventListener("click", closeUpdateModal);
+    el("update-confirm").addEventListener("click", startUpdate);
+    el("update-modal").addEventListener("click", (event) => {
+      if (event.target === el("update-modal")) closeUpdateModal();
+    });
     el("calendar-close").addEventListener("click", closeCalendar);
     calendarModal.addEventListener("click", (event) => {
       if (event.target === calendarModal) closeCalendar();
@@ -2953,6 +2966,221 @@
     const data = await resp.json().catch(() => ({}));
     if (!resp.ok) throw new Error(data.error || `HTTP ${resp.status}`);
     return data;
+  }
+
+  function setUpdateMessage(message, isError = false, autoClearMs = 0) {
+    const node = el("hub-update-message");
+    if (updateMessageTimer !== null) {
+      clearTimeout(updateMessageTimer);
+      updateMessageTimer = null;
+    }
+    node.textContent = String(message || "");
+    node.classList.toggle("error", Boolean(isError));
+    node.title = node.textContent;
+    if (autoClearMs > 0 && node.textContent) {
+      updateMessageTimer = window.setTimeout(() => {
+        updateMessageTimer = null;
+        node.textContent = "";
+        node.title = "";
+        node.classList.remove("error");
+      }, autoClearMs);
+    }
+  }
+
+  function updateInProgress(status) {
+    return ["stopping", "updating", "restarting", "resuming_runners"].includes(status);
+  }
+
+  function setUpdateDetail(message, pending = false) {
+    const node = el("update-detail");
+    node.textContent = String(message || "").replace(/\s*\.{3}$/, "");
+    node.classList.toggle("update-detail-pending", Boolean(pending));
+  }
+
+  function applyUpdateStatus(payload) {
+    if (!payload || typeof payload !== "object") return;
+    el("hub-version").textContent = String(payload.display || payload.commit || "-------");
+    const state = payload.update && typeof payload.update === "object" ? payload.update : {};
+    const status = String(state.status || "");
+    const button = el("hub-update-button");
+    if (updateRestartPending && state.message) {
+      setUpdateDetail(state.message, updateInProgress(status));
+    }
+    if (updateInProgress(status)) {
+      button.disabled = true;
+      button.textContent = "Updating";
+      setUpdateMessage(state.message || "Updating...");
+      return;
+    }
+    button.disabled = false;
+    button.textContent = "Update";
+    if (status === "failed") {
+      const failedAt = Number(state.updated_at || 0) * 1000;
+      const remaining = Math.max(0, 5000 - (Date.now() - failedAt));
+      if (remaining > 0) {
+        setUpdateMessage(state.error || state.message || "Update failed.", true, remaining);
+      } else {
+        setUpdateMessage("");
+      }
+    } else if (status === "completed" && state.commit === payload.commit) {
+      setUpdateMessage("");
+    }
+  }
+
+  async function loadUpdateStatus() {
+    try {
+      const payload = await api("/api/update/status");
+      applyUpdateStatus(payload);
+      const status = String(payload.update && payload.update.status || "");
+      if (updateRestartPending && status === "completed" && payload.update.commit === payload.commit) {
+        showUpdateCompleted();
+        return;
+      }
+      if (updateRestartPending && status === "failed") {
+        updateRestartPending = false;
+        showUpdateFailure(payload.update.error || payload.update.message || "Update failed.");
+      }
+      if (updateInProgress(status)) scheduleUpdatePoll();
+    } catch (error) {
+      if (updateRestartPending) {
+        setUpdateDetail("Running git pull", true);
+        scheduleUpdatePoll();
+      }
+    }
+  }
+
+  function scheduleUpdatePoll() {
+    if (updatePollTimer !== null) return;
+    updatePollTimer = window.setTimeout(() => {
+      updatePollTimer = null;
+      loadUpdateStatus();
+    }, 1000);
+  }
+
+  function closeUpdateModal() {
+    if (updateRestartPending) return;
+    if (updateCompleteTimer !== null) {
+      clearTimeout(updateCompleteTimer);
+      updateCompleteTimer = null;
+    }
+    const modal = el("update-modal");
+    modal.classList.add("hidden");
+    modal.classList.remove("updating", "completed");
+    modal.setAttribute("aria-hidden", "true");
+    updateConfirmationToken = "";
+  }
+
+  function openUpdateConfirmation(result) {
+    closeHubMenu();
+    setUpdateMessage("");
+    updateConfirmationToken = String(result.confirmation_token || "");
+    const current = result.version
+      ? `${result.version} · ${result.commit}`
+      : result.commit;
+    const target = result.target_version
+      ? `${result.target_version} · ${result.target_commit}`
+      : result.target_commit;
+    el("update-revisions").textContent = `${current}  →  ${target}`;
+    setUpdateDetail(
+      `${result.branch} · ${result.behind} new commit${result.behind === 1 ? "" : "s"}`,
+    );
+    el("update-error").textContent = "";
+    el("update-confirm-message").textContent =
+      "Running sessions will stop while the update is installed, then resume automatically.";
+    el("update-confirm").disabled = false;
+    el("update-confirm").textContent = "Update";
+    el("update-cancel").textContent = "Cancel";
+    const modal = el("update-modal");
+    modal.classList.remove("hidden", "updating", "completed");
+    modal.setAttribute("aria-hidden", "false");
+  }
+
+  function showUpdateCompleted() {
+    updateRestartPending = false;
+    setUpdateMessage("");
+    const modal = el("update-modal");
+    modal.classList.remove("hidden", "updating");
+    modal.classList.add("completed");
+    modal.setAttribute("aria-hidden", "false");
+    el("update-confirm-message").textContent = "Update completed.";
+    setUpdateDetail("Data service restarted and running sessions were restored.");
+    el("update-error").textContent = "";
+    if (updateCompleteTimer !== null) clearTimeout(updateCompleteTimer);
+    updateCompleteTimer = window.setTimeout(() => {
+      updateCompleteTimer = null;
+      closeUpdateModal();
+      window.location.reload();
+    }, 4000);
+  }
+
+  function showUpdateFailure(message) {
+    const modal = el("update-modal");
+    modal.classList.remove("hidden", "updating", "completed");
+    modal.setAttribute("aria-hidden", "false");
+    el("update-confirm-message").textContent = "The update could not be completed.";
+    el("update-detail").classList.remove("update-detail-pending");
+    el("update-error").textContent = String(message || "Update failed.");
+    el("update-confirm").disabled = true;
+    el("update-confirm").textContent = "Update";
+    el("update-cancel").textContent = "Close";
+    setUpdateMessage(message || "Update failed.", true, 5000);
+  }
+
+  async function checkForUpdate() {
+    const button = el("hub-update-button");
+    button.disabled = true;
+    button.textContent = "Checking";
+    setUpdateMessage("Checking for updates...");
+    try {
+      const result = await api("/api/update/check", { method: "POST" });
+      el("hub-version").textContent = String(result.display || result.commit || "-------");
+      if (!result.available) {
+        const blocked = Boolean(result.blocked_reason);
+        setUpdateMessage(
+          result.blocked_reason || "No updates available.",
+          blocked,
+          blocked ? 5000 : 0,
+        );
+        return;
+      }
+      if (!result.can_update) {
+        setUpdateMessage(
+          result.blocked_reason || "Update requires manual action.",
+          true,
+          5000,
+        );
+        return;
+      }
+      openUpdateConfirmation(result);
+    } catch (error) {
+      setUpdateMessage(error.message || "Update check failed.", true, 5000);
+    } finally {
+      button.disabled = false;
+      button.textContent = "Update";
+    }
+  }
+
+  async function startUpdate() {
+    if (!updateConfirmationToken) return;
+    el("update-confirm").disabled = true;
+    el("update-confirm").textContent = "Updating";
+    el("update-error").textContent = "";
+    setUpdateDetail("Stopping runners and data service", true);
+    el("update-modal").classList.add("updating");
+    try {
+      await api("/api/update/start", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirmation_token: updateConfirmationToken }),
+      });
+      updateConfirmationToken = "";
+      updateRestartPending = true;
+      setUpdateMessage("Updating...");
+      scheduleUpdatePoll();
+    } catch (error) {
+      updateRestartPending = false;
+      showUpdateFailure(error.message || "Update failed to start.");
+    }
   }
 
   async function streamSse(path, opts, onEvent) {

--- a/data_service/update_service.py
+++ b/data_service/update_service.py
@@ -1,0 +1,422 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import secrets
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable
+
+
+class UpdateServiceError(RuntimeError):
+    def __init__(self, message: str, status_code: int = 400) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+def _write_json_atomic(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(
+        json.dumps(payload, ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+    os.replace(tmp_path, path)
+
+
+def read_update_state(path: Path) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+    return value if isinstance(value, dict) else {}
+
+
+def write_update_state(path: Path, **values: Any) -> None:
+    state = read_update_state(path)
+    state.update(values)
+    state["updated_at"] = int(time.time())
+    _write_json_atomic(path, state)
+
+
+class UpdateService:
+    _CONFIRM_TTL_SECONDS = 120
+
+    def __init__(
+        self,
+        repo_root: Path,
+        registry: Any,
+        port: int,
+        ai_enabled: Callable[[], bool],
+        request_shutdown: Callable[[], None],
+    ) -> None:
+        self.repo_root = repo_root.resolve()
+        self.registry = registry
+        self.port = port
+        self.ai_enabled = ai_enabled
+        self.request_shutdown = request_shutdown
+        self.state_path = self.repo_root / "workdir" / "config" / "update_state.json"
+        self.request_path = self.repo_root / "workdir" / "config" / "update_request.json"
+        self._lock = asyncio.Lock()
+        self._confirmation: dict[str, Any] | None = None
+
+    async def status(self) -> dict[str, Any]:
+        repo = await asyncio.to_thread(self._repo_info)
+        self._update_in_progress()
+        return {
+            **repo,
+            "update": read_update_state(self.state_path),
+        }
+
+    async def check(self) -> dict[str, Any]:
+        async with self._lock:
+            if self._update_in_progress():
+                raise UpdateServiceError("an update is already in progress", 409)
+            try:
+                result = await asyncio.to_thread(self._check_sync, True)
+            except (OSError, subprocess.SubprocessError) as exc:
+                raise UpdateServiceError(f"update check failed: {exc}", 503) from exc
+
+            self._confirmation = None
+            if result["available"] and result["can_update"]:
+                token = secrets.token_urlsafe(24)
+                self._confirmation = {
+                    "token": token,
+                    "head": result["commit"],
+                    "target": result["target_commit"],
+                    "expires_at": time.monotonic() + self._CONFIRM_TTL_SECONDS,
+                }
+                result["confirmation_token"] = token
+            return result
+
+    async def start(self, confirmation_token: str) -> dict[str, Any]:
+        async with self._lock:
+            confirmation = self._confirmation
+            self._confirmation = None
+            if (
+                not confirmation
+                or not secrets.compare_digest(
+                    str(confirmation.get("token", "")), confirmation_token
+                )
+                or time.monotonic() > float(confirmation.get("expires_at", 0))
+            ):
+                raise UpdateServiceError("update confirmation expired; check again", 409)
+            if self._update_in_progress():
+                raise UpdateServiceError("an update is already in progress", 409)
+
+            check = await asyncio.to_thread(self._check_sync, False)
+            if not check["available"]:
+                raise UpdateServiceError("no update is available", 409)
+            if not check["can_update"]:
+                raise UpdateServiceError(check["blocked_reason"], 409)
+            if (
+                check["commit"] != confirmation["head"]
+                or check["target_commit"] != confirmation["target"]
+            ):
+                raise UpdateServiceError("repository changed; check for updates again", 409)
+
+            active_runner_ids = [
+                session_id
+                for session_id in self.registry.sessions
+                if self.registry.supervisor.is_active(session_id)
+            ]
+            request = {
+                "repo_root": str(self.repo_root),
+                "parent_pid": os.getpid(),
+                "python": sys.executable,
+                "data_service_main": str(self.repo_root / "data_service" / "main.py"),
+                "port": self.port,
+                "branch": check["branch"],
+                "from_commit": check["commit"],
+                "target_commit": check["target_commit"],
+                "active_runner_ids": active_runner_ids,
+                "ai_enabled": bool(self.ai_enabled()),
+            }
+            _write_json_atomic(self.request_path, request)
+            write_update_state(
+                self.state_path,
+                status="stopping",
+                branch=check["branch"],
+                from_commit=check["commit"],
+                target_commit=check["target_commit"],
+                message="Stopping runners and data service",
+                error="",
+                owner_pid=os.getpid(),
+            )
+
+            asyncio.get_running_loop().call_later(0.35, self.request_shutdown)
+            return {
+                "ok": True,
+                "active_runners": len(active_runner_ids),
+                "target_commit": check["target_commit"],
+            }
+
+    def _update_in_progress(self) -> bool:
+        state = read_update_state(self.state_path)
+        if state.get("status") not in {
+            "stopping",
+            "updating",
+            "restarting",
+            "resuming_runners",
+        }:
+            return False
+        try:
+            owner_pid = int(state.get("owner_pid", 0))
+            if owner_pid <= 0:
+                return True
+            os.kill(owner_pid, 0)
+            return True
+        except (ProcessLookupError, ValueError, TypeError):
+            write_update_state(
+                self.state_path,
+                status="failed",
+                message="The update process stopped unexpectedly.",
+                error="update process is no longer running",
+            )
+            return False
+        except PermissionError:
+            return True
+
+    def pending_restart(self) -> bool:
+        state = read_update_state(self.state_path)
+        try:
+            owner_pid = int(state.get("owner_pid", 0))
+        except (TypeError, ValueError):
+            return False
+        return state.get("status") == "restarting" and owner_pid == os.getpid()
+
+    def apply_and_restart(self) -> None:
+        request = read_update_state(self.request_path)
+        update_error = ""
+        if not request:
+            update_error = "update request data is missing"
+            write_update_state(
+                self.state_path,
+                status="failed",
+                message="Update request data is missing.",
+                error=update_error,
+            )
+        else:
+            try:
+                write_update_state(
+                    self.state_path,
+                    status="updating",
+                    message="Running git pull",
+                )
+                output = self._git("pull", "--ff-only", timeout=180)
+                if output:
+                    print(f"[update] {output}")
+                write_update_state(
+                    self.state_path,
+                    status="updating",
+                    message="Clearing Python caches",
+                )
+                removed = self._remove_bytecode_caches()
+                print(f"[update] removed {removed} __pycache__ directories")
+            except Exception as exc:
+                update_error = str(exc)
+                print(f"[update] update failed: {exc}", file=sys.stderr)
+
+        write_update_state(
+            self.state_path,
+            status="restarting",
+            message="Restarting data service",
+            error=update_error,
+        )
+        env = os.environ.copy()
+        env["PYNEREAL_UPDATE_AI_ENABLED"] = "1" if request.get("ai_enabled") else "0"
+        python = str(request.get("python") or sys.executable)
+        main_path = str(
+            request.get("data_service_main")
+            or self.repo_root / "data_service" / "main.py"
+        )
+        try:
+            os.execve(python, [python, "-u", main_path], env)
+        except OSError as exc:
+            write_update_state(
+                self.state_path,
+                status="failed",
+                message="Data service could not be restarted.",
+                error=f"{update_error}; {exc}" if update_error else str(exc),
+            )
+            raise
+
+    async def finish_restart(self, timeout: float = 900) -> None:
+        request = read_update_state(self.request_path)
+        state = read_update_state(self.state_path)
+        pending = {
+            str(item)
+            for item in request.get("active_runner_ids", [])
+            if isinstance(item, str) and item
+        }
+        update_error = str(state.get("error") or "")
+        write_update_state(
+            self.state_path,
+            status="resuming_runners",
+            message="Waiting for market data and resuming runners",
+        )
+        deadline = time.monotonic() + timeout
+        while pending and time.monotonic() < deadline:
+            for session_id in list(pending):
+                session = self.registry.get(session_id)
+                if session is None:
+                    continue
+                if self.registry.supervisor.is_active(session_id):
+                    pending.remove(session_id)
+                    continue
+                if not session.feed.history_ready():
+                    continue
+                try:
+                    await self.registry.start_runner(session_id)
+                except Exception:
+                    continue
+                pending.remove(session_id)
+            if pending:
+                await asyncio.sleep(1)
+
+        commit = self._git("rev-parse", "--short=7", "HEAD")
+        if update_error:
+            write_update_state(
+                self.state_path,
+                status="failed",
+                message="Update failed; the previous version was restarted.",
+                error=update_error,
+                commit=commit,
+                pending_runner_ids=sorted(pending),
+            )
+        elif pending:
+            write_update_state(
+                self.state_path,
+                status="failed",
+                message="Updated, but some runners could not be resumed.",
+                error=f"runners not resumed: {', '.join(sorted(pending))}",
+                commit=commit,
+                pending_runner_ids=sorted(pending),
+            )
+        else:
+            write_update_state(
+                self.state_path,
+                status="completed",
+                message="Update completed.",
+                error="",
+                commit=commit,
+                pending_runner_ids=[],
+            )
+
+    def _remove_bytecode_caches(self) -> int:
+        removed = 0
+        for root, dirs, _ in os.walk(self.repo_root, topdown=True):
+            for name in [item for item in dirs if item == "__pycache__"]:
+                shutil.rmtree(Path(root) / name, ignore_errors=True)
+                dirs.remove(name)
+                removed += 1
+        return removed
+
+    def _git(self, *args: str, timeout: float = 60) -> str:
+        completed = subprocess.run(
+            ["git", *args],
+            cwd=self.repo_root,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=timeout,
+        )
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise subprocess.SubprocessError(detail or f"git {' '.join(args)} failed")
+        return completed.stdout.strip()
+
+    def _repo_info(self, ref: str = "HEAD") -> dict[str, Any]:
+        branch = self._git("rev-parse", "--abbrev-ref", "HEAD")
+        commit = self._git("rev-parse", "--short=7", ref)
+        version = ""
+        if branch == "main":
+            try:
+                version = self._git(
+                    "describe", "--tags", "--abbrev=0", "--match", "v[0-9]*", ref
+                )
+            except subprocess.SubprocessError:
+                pass
+        display = f"{version} · {commit}" if version else commit
+        return {
+            "branch": branch,
+            "commit": commit,
+            "version": version,
+            "display": display,
+        }
+
+    def _check_sync(self, fetch: bool) -> dict[str, Any]:
+        info = self._repo_info()
+        try:
+            upstream = self._git(
+                "rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{upstream}"
+            )
+        except subprocess.SubprocessError:
+            return {
+                **info,
+                "upstream": "",
+                "available": False,
+                "can_update": False,
+                "blocked_reason": "current branch has no tracking branch",
+                "target_commit": info["commit"],
+                "target_version": info["version"],
+            }
+
+        if fetch:
+            self._git("fetch", "--quiet", timeout=120)
+
+        counts = self._git("rev-list", "--left-right", "--count", "HEAD...@{upstream}")
+        ahead_text, behind_text = counts.split()
+        ahead, behind = int(ahead_text), int(behind_text)
+        target_commit = self._git("rev-parse", "--short=7", "@{upstream}")
+        target_version = ""
+        if info["branch"] == "main":
+            try:
+                target_version = self._git(
+                    "describe",
+                    "--tags",
+                    "--abbrev=0",
+                    "--match",
+                    "v[0-9]*",
+                    "@{upstream}",
+                )
+            except subprocess.SubprocessError:
+                pass
+
+        available = behind > 0
+        blocked_reason = ""
+        if available and ahead > 0:
+            blocked_reason = "local and remote branches have diverged; update manually"
+        elif available:
+            incoming = set(
+                filter(None, self._git("diff", "--name-only", "HEAD..@{upstream}").splitlines())
+            )
+            local = set(filter(None, self._git("diff", "--name-only", "HEAD").splitlines()))
+            local.update(
+                filter(
+                    None,
+                    self._git("ls-files", "--others", "--exclude-standard").splitlines(),
+                )
+            )
+            conflicts = sorted(incoming & local)
+            if conflicts:
+                preview = ", ".join(conflicts[:3])
+                if len(conflicts) > 3:
+                    preview += f" and {len(conflicts) - 3} more"
+                blocked_reason = f"local changes overlap update files: {preview}"
+
+        return {
+            **info,
+            "upstream": upstream,
+            "available": available,
+            "can_update": available and not blocked_reason,
+            "blocked_reason": blocked_reason,
+            "target_commit": target_commit,
+            "target_version": target_version,
+            "ahead": ahead,
+            "behind": behind,
+        }


### PR DESCRIPTION
## 개요

대시보드 메뉴에서 현재 브랜치의 업데이트를 확인하고, 실행 중인 Runner와 data service를 안전하게 재시작하는 자동 업데이트 기능을 추가합니다.

## 주요 변경사항

- 메뉴 하단에 현재 버전과 커밋 해시 및 Update 버튼 표시
- main 브랜치는 최신 버전 태그와 커밋 해시, 기타 브랜치는 커밋 해시만 표시
- 현재 tracking branch를 fetch하여 업데이트 가능 여부 확인
- 업데이트가 없거나 upstream이 없는 경우 메뉴에 상태 안내
- 업데이트가 있으면 일회용 확인 토큰을 사용하는 커스텀 확인창 표시
- 실행 중인 Runner 목록을 저장한 후 Runner와 data service를 정상 종료
- git pull --ff-only 수행 후 저장소 전체 Python __pycache__ 정리
- 동일 PID에서 data service를 재실행하여 터미널 및 systemd 제어 유지
- 재시작 후 데이터 준비가 끝난 기존 Runner만 자동 복구
- 사용자가 정지해 둔 Runner는 정지 상태 유지
- Runner 종료, git pull, 캐시 정리, 서버 재시작, Runner 복구 단계를 움직이는 점 애니메이션으로 표시
- 업데이트 완료 팝업을 4초간 표시한 뒤 닫고 최신 정적 리소스로 새로고침
- 오류 안내는 5초 후 제거하며 확인창 취소 시 Checking 문구 정리

## 안전장치

- fast-forward 업데이트만 허용하고 브랜치가 diverged된 경우 실행 차단
- 원격 변경 파일과 로컬 수정 및 미추적 파일이 겹치면 업데이트 차단
- 확인 단계에서 발급된 단기 토큰 없이는 업데이트 실행 불가
- 업데이트 실패 시 현재 코드를 다시 실행하고 기존 Runner 복구 시도
- AI 활성화 상태를 재시작 과정에서 유지
- 업데이트 요청 및 상태 파일은 Git 추적에서 제외

## 검증

- 임시 원격 테스트 브랜치에서 실제 fetch, pull, 캐시 제거 및 동일 PID 재시작 확인
- 실행 중 Runner 자동 복구와 수동 정지 Runner 상태 유지 확인
- 브라우저 재연결, 단계별 진행 애니메이션 및 완료 팝업 확인
- Python 구문 검사와 dashboard JavaScript 구문 검사 통과