### PR TITLE
거래소 기준 OHLCV 데이터 검사 및 복구 기능 추가

### DIFF
--- a/data_service/api.py
+++ b/data_service/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import ast
 import json
+import threading
 import time
 from datetime import UTC, date, datetime
 from pathlib import Path
@@ -23,6 +24,7 @@ from ai.provider.codex_service import CodexService
 from asset_portfolio import AssetPortfolioError, AssetPortfolioService
 from asset_transfer import AssetTransferError, AssetTransferService
 from calendar_store import CalendarEventStore, CalendarStoreError
+from data_integrity import DataIntegrityCancelled, inspect_data_integrity
 from registry import (
     HistoryNotReadyError,
     SessionExistsError,
@@ -41,6 +43,7 @@ from config import (
 )
 from manual_alerts import send_manual_alert_payload
 from ohlcv_io import make_ccxt_pro_client
+from ohlcv_paths import make_cache_path
 from update_service import UpdateService, UpdateServiceError
 
 # Cache of exchange -> ccxt markets so symbol validation hits the network at most
@@ -697,6 +700,7 @@ def build_control_router(
     r = APIRouter()
     calendar_forecast_runs: dict[str, int] = {}
     calendar_forecast_tasks: dict[str, set[asyncio.Task[Any]]] = {}
+    data_integrity_jobs: dict[str, dict[str, Any]] = {}
 
     @r.get("/api/update/status")
     async def update_status() -> JSONResponse:
@@ -1317,6 +1321,109 @@ def build_control_router(
         except Exception as e:
             return JSONResponse({"error": f"failed to update history_since: {e}"}, status_code=500)
         return JSONResponse({"ok": True, "history_since": value})
+
+    @r.get("/api/sessions/{session_id}/data-integrity")
+    async def check_data_integrity(session_id: str) -> JSONResponse:
+        session = registry.get(session_id)
+        if session is None:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        if not session.feed.history_ready():
+            return JSONResponse({"error": "market data is still preparing"}, status_code=409)
+        spec = session.feed.spec
+        if spec.id in data_integrity_jobs:
+            return JSONResponse({"error": "data integrity operation already running"}, status_code=409)
+        job = {
+            "session_id": session_id,
+            "operation": "check",
+            "cancel_event": threading.Event(),
+            "done_event": asyncio.Event(),
+        }
+        data_integrity_jobs[spec.id] = job
+        try:
+            async with session.feed.data_integrity_lock:
+                report = await asyncio.to_thread(
+                    inspect_data_integrity,
+                    cache_path=make_cache_path(),
+                    provider=spec.provider,
+                    exchange=spec.exchange,
+                    symbol=spec.symbol,
+                    timeframe=spec.timeframe,
+                    start_ts=session.feed.history_start_time(),
+                    cancel_event=job["cancel_event"],
+                )
+        except DataIntegrityCancelled:
+            return JSONResponse({"error": "data integrity check cancelled", "cancelled": True}, status_code=409)
+        except Exception as exc:
+            print(f"[data_integrity] check failed feed={spec.id}: {type(exc).__name__}: {exc}")
+            return JSONResponse(
+                {"error": f"data integrity check failed ({type(exc).__name__})"},
+                status_code=502,
+            )
+        finally:
+            job["done_event"].set()
+            if data_integrity_jobs.get(spec.id) is job:
+                data_integrity_jobs.pop(spec.id, None)
+        return JSONResponse(report)
+
+    @r.post("/api/sessions/{session_id}/data-integrity/repair")
+    async def repair_data_integrity(session_id: str) -> JSONResponse:
+        session = registry.get(session_id)
+        if session is None:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        if not session.feed.history_ready():
+            return JSONResponse({"error": "market data is still preparing"}, status_code=409)
+        spec = session.feed.spec
+        start_ts = session.feed.history_start_time()
+        if spec.id in data_integrity_jobs:
+            return JSONResponse({"error": "data integrity operation already running"}, status_code=409)
+        job = {
+            "session_id": session_id,
+            "operation": "repair",
+            "cancel_event": threading.Event(),
+            "done_event": asyncio.Event(),
+        }
+        data_integrity_jobs[spec.id] = job
+
+        def repair() -> dict:
+            return inspect_data_integrity(
+                cache_path=make_cache_path(),
+                provider=spec.provider,
+                exchange=spec.exchange,
+                symbol=spec.symbol,
+                timeframe=spec.timeframe,
+                start_ts=start_ts,
+                apply_repair=True,
+                cancel_event=job["cancel_event"],
+            )
+
+        try:
+            async with session.feed.data_integrity_lock:
+                report = await registry.repair_data_integrity(session_id, repair)
+        except DataIntegrityCancelled:
+            return JSONResponse({"error": "data integrity repair cancelled", "cancelled": True}, status_code=409)
+        except Exception as exc:
+            print(f"[data_integrity] repair failed feed={spec.id}: {type(exc).__name__}: {exc}")
+            return JSONResponse(
+                {"error": f"data integrity repair failed ({type(exc).__name__})"},
+                status_code=502,
+            )
+        finally:
+            job["done_event"].set()
+            if data_integrity_jobs.get(spec.id) is job:
+                data_integrity_jobs.pop(spec.id, None)
+        return JSONResponse(report)
+
+    @r.post("/api/sessions/{session_id}/data-integrity/cancel")
+    async def cancel_data_integrity(session_id: str) -> JSONResponse:
+        session = registry.get(session_id)
+        if session is None:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        job = data_integrity_jobs.get(session.feed.spec.id)
+        if job is None:
+            return JSONResponse({"ok": True, "cancelled": False})
+        job["cancel_event"].set()
+        await job["done_event"].wait()
+        return JSONResponse({"ok": True, "cancelled": True})
 
     @r.post("/api/sessions/{session_id}/runner/start")
     async def runner_start(session_id: str) -> JSONResponse:

--- a/data_service/data_integrity.py
+++ b/data_service/data_integrity.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import math
+import sqlite3
+import threading
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Iterable
+
+from ohlcv_cache import delete_bars, import_from_ohlcv
+from ohlcv_io import convert_timeframe, download_history_range_to_file
+from pynecore.core.ohlcv_file import OHLCVReader
+
+
+_SQLITE_TIMEOUT_SECONDS = 30.0
+_MAX_SAMPLES = 20
+
+
+class DataIntegrityCancelled(Exception):
+    pass
+
+
+def _raise_if_cancelled(cancel_event: threading.Event | None) -> None:
+    if cancel_event is not None and cancel_event.is_set():
+        raise DataIntegrityCancelled("data integrity operation cancelled")
+
+
+def _connect(cache_path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(cache_path, timeout=_SQLITE_TIMEOUT_SECONDS)
+    conn.execute(f"PRAGMA busy_timeout = {int(_SQLITE_TIMEOUT_SECONDS * 1000)}")
+    return conn
+
+
+def _utc_iso(timestamp: int | None) -> str | None:
+    if timestamp is None:
+        return None
+    return datetime.fromtimestamp(int(timestamp), UTC).isoformat()
+
+
+def _values_differ(local_value: float, reference_value: float, *, volume: bool = False) -> bool:
+    relative_tolerance = 2e-5 if volume else 2e-6
+    absolute_tolerance = 1e-7 if volume else 1e-8
+    return not math.isclose(
+        float(local_value),
+        float(reference_value),
+        rel_tol=relative_tolerance,
+        abs_tol=absolute_tolerance,
+    )
+
+
+def _invalid_reasons(row: tuple[Any, ...], interval_seconds: int) -> list[str]:
+    timestamp, open_price, high, low, close, volume = row
+    reasons: list[str] = []
+    values = (open_price, high, low, close, volume)
+    if not all(math.isfinite(float(value)) for value in values):
+        return ["non-finite value"]
+    if int(timestamp) % interval_seconds != 0:
+        reasons.append("timestamp is off timeframe grid")
+    if min(float(open_price), float(high), float(low), float(close)) <= 0:
+        reasons.append("price is not positive")
+    if float(volume) < 0:
+        reasons.append("volume is negative")
+    price_scale = max(abs(float(open_price)), abs(float(high)), abs(float(low)), abs(float(close)), 1.0)
+    tolerance = price_scale * 2e-6
+    if float(high) + tolerance < max(float(open_price), float(low), float(close)):
+        reasons.append("high is below OHLC range")
+    if float(low) - tolerance > min(float(open_price), float(high), float(close)):
+        reasons.append("low is above OHLC range")
+    return reasons
+
+
+def _append_sample(samples: list[dict[str, Any]], sample: dict[str, Any]) -> None:
+    if len(samples) < _MAX_SAMPLES:
+        samples.append(sample)
+
+
+def _timestamp_ranges(timestamps: Iterable[int], interval_seconds: int) -> list[dict[str, Any]]:
+    ordered = sorted({int(timestamp) for timestamp in timestamps})
+    ranges: list[dict[str, Any]] = []
+    if not ordered:
+        return ranges
+    start = previous = ordered[0]
+    count = 1
+    for timestamp in ordered[1:]:
+        if timestamp == previous + interval_seconds:
+            previous = timestamp
+            count += 1
+            continue
+        ranges.append({
+            "start": start,
+            "end": previous,
+            "start_time": _utc_iso(start),
+            "end_time": _utc_iso(previous),
+            "bars": count,
+        })
+        start = previous = timestamp
+        count = 1
+    ranges.append({
+        "start": start,
+        "end": previous,
+        "start_time": _utc_iso(start),
+        "end_time": _utc_iso(previous),
+        "bars": count,
+    })
+    return ranges[:_MAX_SAMPLES]
+
+
+def inspect_data_integrity(
+    *,
+    cache_path: Path,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    start_ts: int | None,
+    apply_repair: bool = False,
+    cancel_event: threading.Event | None = None,
+) -> dict[str, Any]:
+    _raise_if_cancelled(cancel_event)
+    interval_seconds = int(convert_timeframe(timeframe, to_ms=True) / 1000)
+    now = int(time.time())
+    current_bar_start = (now // interval_seconds) * interval_seconds
+    confirmed_end = current_bar_start - (2 * interval_seconds)
+
+    with _connect(cache_path) as conn:
+        bounds = conn.execute(
+            """
+            SELECT MIN(ts), MAX(ts)
+            FROM bars
+            WHERE provider = ? AND exchange = ? AND symbol = ? AND timeframe = ?
+              AND (? IS NULL OR ts >= ?) AND ts <= ?
+            """,
+            (provider, exchange, symbol, timeframe, start_ts, start_ts, confirmed_end),
+        ).fetchone()
+    local_start = int(bounds[0]) if bounds and bounds[0] is not None else None
+    if local_start is None:
+        return {
+            "status": "no_data",
+            "checked_at": datetime.now(UTC).isoformat(),
+            "bars_scanned": 0,
+            "reference_bars": 0,
+            "repairable": False,
+            "issues": {},
+            "samples": [],
+        }
+
+    scan_start = min(local_start, int(start_ts)) if start_ts is not None else local_start
+    reference_path: Path
+    with TemporaryDirectory() as tmp_dir:
+        reference_path = download_history_range_to_file(
+            provider=provider,
+            exchange=exchange,
+            symbol=symbol,
+            timeframe=timeframe,
+            time_from=datetime.fromtimestamp(scan_start, UTC),
+            time_to=datetime.fromtimestamp(confirmed_end, UTC),
+            ohlv_dir=Path(tmp_dir),
+            on_progress=lambda _progress: _raise_if_cancelled(cancel_event),
+        )
+        _raise_if_cancelled(cancel_event)
+
+        repair_timestamps: set[int] = set()
+        missing_timestamps: list[int] = []
+        samples: list[dict[str, Any]] = []
+        counts = {
+            "missing_local": 0,
+            "extra_local": 0,
+            "mismatched": 0,
+            "invalid": 0,
+            "synthetic_zero_volume": 0,
+        }
+        local_count = 0
+        compared_count = 0
+
+        with _connect(cache_path) as conn, OHLCVReader(reference_path) as reference_reader:
+            local_cursor = iter(conn.execute(
+                """
+                SELECT ts, open, high, low, close, volume
+                FROM bars
+                WHERE provider = ? AND exchange = ? AND symbol = ? AND timeframe = ?
+                  AND ts >= ? AND ts <= ?
+                ORDER BY ts
+                """,
+                (provider, exchange, symbol, timeframe, scan_start, confirmed_end),
+            ))
+            reference_count = reference_reader.size
+            reference_index = 0
+            local_row = next(local_cursor, None)
+            reference_bar = reference_reader.read(0) if reference_count else None
+
+            while local_row is not None or reference_bar is not None:
+                compared_count += 1
+                if compared_count % 256 == 0:
+                    _raise_if_cancelled(cancel_event)
+                local_ts = int(local_row[0]) if local_row is not None else None
+                reference_ts = int(reference_bar.timestamp) if reference_bar is not None else None
+
+                if local_row is not None and (reference_ts is None or local_ts < reference_ts):
+                    local_count += 1
+                    reasons = _invalid_reasons(local_row, interval_seconds)
+                    if reasons:
+                        counts["invalid"] += 1
+                        repair_timestamps.add(local_ts)
+                        _append_sample(samples, {
+                            "type": "invalid",
+                            "timestamp": local_ts,
+                            "time": _utc_iso(local_ts),
+                            "details": ", ".join(reasons),
+                        })
+                    if float(local_row[5]) == 0.0 and not reasons:
+                        counts["synthetic_zero_volume"] += 1
+                    else:
+                        counts["extra_local"] += 1
+                        repair_timestamps.add(local_ts)
+                        _append_sample(samples, {
+                            "type": "extra_local",
+                            "timestamp": local_ts,
+                            "time": _utc_iso(local_ts),
+                            "details": "local candle is absent from exchange data",
+                        })
+                    local_row = next(local_cursor, None)
+                    continue
+
+                if reference_bar is not None and (local_ts is None or reference_ts < local_ts):
+                    counts["missing_local"] += 1
+                    missing_timestamps.append(reference_ts)
+                    _append_sample(samples, {
+                        "type": "missing_local",
+                        "timestamp": reference_ts,
+                        "time": _utc_iso(reference_ts),
+                        "details": "exchange candle is missing from local cache",
+                    })
+                    reference_index += 1
+                    reference_bar = (
+                        reference_reader.read(reference_index)
+                        if reference_index < reference_count else None
+                    )
+                    continue
+
+                assert local_row is not None and reference_bar is not None
+                local_count += 1
+                reasons = _invalid_reasons(local_row, interval_seconds)
+                if reasons:
+                    counts["invalid"] += 1
+                    repair_timestamps.add(local_ts)
+                    _append_sample(samples, {
+                        "type": "invalid",
+                        "timestamp": local_ts,
+                        "time": _utc_iso(local_ts),
+                        "details": ", ".join(reasons),
+                    })
+
+                field_names = ("open", "high", "low", "close", "volume")
+                local_values = local_row[1:]
+                reference_values = (
+                    reference_bar.open,
+                    reference_bar.high,
+                    reference_bar.low,
+                    reference_bar.close,
+                    reference_bar.volume,
+                )
+                mismatched_fields = [
+                    field
+                    for index, field in enumerate(field_names)
+                    if _values_differ(
+                        float(local_values[index]),
+                        float(reference_values[index]),
+                        volume=field == "volume",
+                    )
+                ]
+                if mismatched_fields:
+                    counts["mismatched"] += 1
+                    repair_timestamps.add(local_ts)
+                    _append_sample(samples, {
+                        "type": "mismatched",
+                        "timestamp": local_ts,
+                        "time": _utc_iso(local_ts),
+                        "details": "different " + ", ".join(mismatched_fields),
+                    })
+
+                local_row = next(local_cursor, None)
+                reference_index += 1
+                reference_bar = (
+                    reference_reader.read(reference_index)
+                    if reference_index < reference_count else None
+                )
+
+            reference_reader.close()
+
+        issue_count = sum(counts[key] for key in ("missing_local", "extra_local", "mismatched", "invalid"))
+        report: dict[str, Any] = {
+            "status": "issues" if issue_count else "verified",
+            "checked_at": datetime.now(UTC).isoformat(),
+            "range_start": scan_start,
+            "range_start_time": _utc_iso(scan_start),
+            "range_end": confirmed_end,
+            "range_end_time": _utc_iso(confirmed_end),
+            "bars_scanned": local_count,
+            "reference_bars": reference_count,
+            "repairable": issue_count > 0 and reference_count > 0,
+            "issues": counts,
+            "missing_ranges": _timestamp_ranges(missing_timestamps, interval_seconds),
+            "samples": samples,
+        }
+
+        if apply_repair and report["repairable"]:
+            _raise_if_cancelled(cancel_event)
+            deleted = delete_bars(
+                cache_path,
+                provider,
+                exchange,
+                symbol,
+                timeframe,
+                repair_timestamps,
+            )
+            import_from_ohlcv(
+                cache_path,
+                provider,
+                exchange,
+                symbol,
+                timeframe,
+                reference_path,
+            )
+            report["status"] = "verified"
+            report["repaired_issues"] = counts
+            report["issues"] = {
+                "missing_local": 0,
+                "extra_local": 0,
+                "mismatched": 0,
+                "invalid": 0,
+                "synthetic_zero_volume": counts["synthetic_zero_volume"],
+            }
+            report["bars_scanned"] = reference_count + counts["synthetic_zero_volume"]
+            report["repairable"] = False
+            report["missing_ranges"] = []
+            report["samples"] = []
+            report["repair_applied"] = True
+            report["deleted_bars"] = deleted
+            report["imported_reference_bars"] = reference_count
+        else:
+            report["repair_applied"] = False
+        return report

--- a/data_service/ohlcv_cache.py
+++ b/data_service/ohlcv_cache.py
@@ -182,6 +182,33 @@ def upsert_bars(
             )
 
 
+def delete_bars(
+    db_path: Path,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    timestamps: Iterable[int],
+) -> int:
+    rows = sorted({int(timestamp) for timestamp in timestamps})
+    if not rows:
+        return 0
+    with _CACHE_WRITE_LOCK:
+        with _connect(db_path) as conn:
+            before = conn.total_changes
+            conn.executemany(
+                """
+                DELETE FROM bars
+                WHERE provider = ? AND exchange = ? AND symbol = ? AND timeframe = ? AND ts = ?
+                """,
+                [
+                    (provider, exchange, symbol, timeframe, timestamp)
+                    for timestamp in rows
+                ],
+            )
+            return conn.total_changes - before
+
+
 def import_from_ohlcv(
     db_path: Path,
     provider: str,

--- a/data_service/ohlcv_io.py
+++ b/data_service/ohlcv_io.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, UTC
 import struct
 import time
-from typing import Optional
+from typing import Callable, Optional
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -91,29 +91,52 @@ def download_history_range_into_cache(
     with TemporaryDirectory() as tmp_dir:
         ohlv_dir = Path(tmp_dir)
         try:
-            provider_module = __import__(f"pynecore.providers.{provider}", fromlist=[""])
-            provider_class = getattr(
-                provider_module,
-                [p for p in dir(provider_module) if p.endswith("Provider")][0],
-            )
-            provider_instance = provider_class(
-                symbol=f"{exchange}:{symbol}".upper(),
-                timeframe=convert_timeframe(timeframe),
+            ohlcv_path = download_history_range_to_file(
+                provider=provider,
+                exchange=exchange,
+                symbol=symbol,
+                timeframe=timeframe,
+                time_from=time_from,
+                time_to=time_to,
                 ohlv_dir=ohlv_dir,
-                config_dir=app_state.config_dir,
             )
-            with provider_instance:
-                provider_instance.download_ohlcv(
-                    time_from=time_from.replace(tzinfo=UTC),
-                    time_to=time_to.replace(tzinfo=UTC),
-                    on_progress=None,
-                )
-            assert provider_instance.ohlcv_path is not None
-            import_from_ohlcv(cache_path, provider, exchange, symbol, timeframe, provider_instance.ohlcv_path)
+            import_from_ohlcv(cache_path, provider, exchange, symbol, timeframe, ohlcv_path)
             ok = True
         except Exception as e:
             print(f"[data_service] download_range failed: {e}")
     return ok
+
+
+def download_history_range_to_file(
+    *,
+    provider: str,
+    exchange: str,
+    symbol: str,
+    timeframe: str,
+    time_from: datetime,
+    time_to: datetime,
+    ohlv_dir: Path,
+    on_progress: Callable[[datetime], None] | None = None,
+) -> Path:
+    provider_module = __import__(f"pynecore.providers.{provider}", fromlist=[""])
+    provider_class = getattr(
+        provider_module,
+        [p for p in dir(provider_module) if p.endswith("Provider")][0],
+    )
+    provider_instance = provider_class(
+        symbol=f"{exchange}:{symbol}".upper(),
+        timeframe=convert_timeframe(timeframe),
+        ohlv_dir=ohlv_dir,
+        config_dir=app_state.config_dir,
+    )
+    with provider_instance:
+        provider_instance.download_ohlcv(
+            time_from=time_from.replace(tzinfo=UTC),
+            time_to=time_to.replace(tzinfo=UTC),
+            on_progress=on_progress,
+        )
+    assert provider_instance.ohlcv_path is not None
+    return provider_instance.ohlcv_path
 
 
 def _ohlcv_float(value: float) -> float:

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -9,7 +9,7 @@ from typing import Awaitable, Callable, Dict, List, Optional
 
 from config import MAX_SESSIONS, FeedSpec, SessionSpec, save_sessions
 from collector_loop import fix_missing_bars_loop, watch_trades_loop
-from file_update_loop import file_update_loop
+from file_update_loop import _to_thread_cancel_safe, file_update_loop
 from runner_supervisor import RunnerSupervisor
 from runtime import Feed, Session
 from tv_logos import TradingViewLogoResolver
@@ -365,6 +365,54 @@ class SessionRegistry:
             s.history_resync_pending = True
             await self.supervisor.start(s.spec, s.paths)
         await self.notify_hub()
+
+    async def repair_data_integrity(
+        self,
+        session_id: str,
+        repair: Callable[[], dict],
+    ) -> dict:
+        session = self.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFoundError(session_id)
+        feed = session.feed
+        targets = list(feed.subscribers.values())
+        running = [
+            target
+            for target in targets
+            if self.supervisor.status(target.spec.id) in ("running", "starting")
+        ]
+        for target in running:
+            await self.supervisor.stop(target.spec.id)
+
+        file_task = feed.tasks.pop("file_update_loop", None)
+        if file_task is not None:
+            file_task.cancel()
+            await asyncio.gather(file_task, return_exceptions=True)
+
+        result: dict | None = None
+        repair_error: BaseException | None = None
+        try:
+            result = await _to_thread_cancel_safe(repair)
+        except BaseException as exc:
+            repair_error = exc
+
+        restart_error: BaseException | None = None
+        try:
+            await self._restart_file_update(feed)
+        except BaseException as exc:
+            restart_error = exc
+
+        if restart_error is None:
+            for target in running:
+                target.history_resync_pending = True
+                await self.supervisor.start(target.spec, target.paths)
+        await self.notify_hub()
+
+        if repair_error is not None:
+            raise repair_error
+        if restart_error is not None:
+            raise restart_error
+        return result or {}
 
     async def update_manual_alert_templates(self, session_id: str, templates: list[dict]) -> list[dict]:
         session = self.sessions.get(session_id)

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -73,6 +73,7 @@ class Feed:
         self.state = DataState()
         self.tasks: Dict[str, Any] = {}
         self.history_ready_event = asyncio.Event()
+        self.data_integrity_lock = asyncio.Lock()
         self.collector_error: Optional[str] = None
         self._history_start_mtime: Optional[float] = None
         self._history_start_time: Optional[int] = None

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -25,6 +25,7 @@ body {
   .calendar-body,
   .assets-body,
   .asset-transfer-body,
+  .integrity-issues,
   .calendar-forecast-content,
   .calendar-forecast-error {
     scrollbar-color: #3a4350 #0b0e13;
@@ -36,6 +37,7 @@ body {
   .calendar-body::-webkit-scrollbar,
   .assets-body::-webkit-scrollbar,
   .asset-transfer-body::-webkit-scrollbar,
+  .integrity-issues::-webkit-scrollbar,
   .calendar-forecast-content::-webkit-scrollbar,
   .calendar-forecast-error::-webkit-scrollbar {
     width: 10px;
@@ -47,6 +49,7 @@ body {
   .calendar-body::-webkit-scrollbar-track,
   .assets-body::-webkit-scrollbar-track,
   .asset-transfer-body::-webkit-scrollbar-track,
+  .integrity-issues::-webkit-scrollbar-track,
   .calendar-forecast-content::-webkit-scrollbar-track,
   .calendar-forecast-error::-webkit-scrollbar-track {
     background: #0b0e13;
@@ -57,6 +60,7 @@ body {
   .calendar-body::-webkit-scrollbar-thumb,
   .assets-body::-webkit-scrollbar-thumb,
   .asset-transfer-body::-webkit-scrollbar-thumb,
+  .integrity-issues::-webkit-scrollbar-thumb,
   .calendar-forecast-content::-webkit-scrollbar-thumb,
   .calendar-forecast-error::-webkit-scrollbar-thumb {
     background: #3a4350;
@@ -69,6 +73,7 @@ body {
   .calendar-body::-webkit-scrollbar-thumb:hover,
   .assets-body::-webkit-scrollbar-thumb:hover,
   .asset-transfer-body::-webkit-scrollbar-thumb:hover,
+  .integrity-issues::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-content::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-error::-webkit-scrollbar-thumb:hover {
     background: #4a5565;
@@ -78,7 +83,8 @@ body {
   .log-content::-webkit-scrollbar-corner,
   .calendar-body::-webkit-scrollbar-corner,
   .assets-body::-webkit-scrollbar-corner,
-  .asset-transfer-body::-webkit-scrollbar-corner {
+  .asset-transfer-body::-webkit-scrollbar-corner,
+  .integrity-issues::-webkit-scrollbar-corner {
     background: #0b0e13;
   }
 }
@@ -712,6 +718,9 @@ tr:last-child td { border-bottom: none; }
   display: flex;
   flex-direction: column;
 }
+#settings-modal { z-index: 62; }
+#integrity-cancel-modal { z-index: 70; }
+#settings-close:disabled { visibility: hidden; }
 .modal-header {
   display: flex;
   align-items: center;
@@ -2039,6 +2048,10 @@ tr:last-child td { border-bottom: none; }
   width: 13px;
   height: 13px;
 }
+.data-integrity-btn .icon {
+  width: 13px;
+  height: 13px;
+}
 #script-refresh.btn-icon {
   display: inline-flex;
   align-items: center;
@@ -2079,8 +2092,80 @@ tr:last-child td { border-bottom: none; }
 @keyframes settings-spin { to { transform: rotate(360deg); } }
 .settings-footer {
   padding: 12px 14px; border-top: 1px solid var(--border);
-  display: flex; justify-content: flex-end;
+  display: flex; justify-content: flex-end; gap: 8px;
 }
+.integrity-loading { min-height: 72px; justify-content: center; margin: 0; }
+.integrity-intro {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  line-height: 1.45;
+}
+.integrity-intro strong { color: var(--text); }
+.integrity-intro span { color: var(--muted); font-size: 13px; }
+.integrity-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 0 12px;
+  border-bottom: 1px solid var(--border);
+}
+.integrity-status-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border: 1px solid currentColor;
+  border-radius: 50%;
+  flex: none;
+  font-weight: 700;
+}
+.integrity-status.verified { color: #3fb950; }
+.integrity-status.issues { color: var(--danger); }
+.integrity-status div { display: flex; flex-direction: column; gap: 2px; }
+.integrity-status strong { color: currentColor; }
+.integrity-status span:not(.integrity-status-mark) { color: var(--muted); font-size: 12px; }
+.integrity-section-title {
+  margin-top: 12px;
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.integrity-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 7px 16px;
+  margin-top: 8px;
+  font-size: 13px;
+}
+.integrity-summary span { color: var(--muted); }
+.integrity-summary strong { color: var(--text); font-variant-numeric: tabular-nums; }
+.integrity-check-range strong { font-size: 11px; font-weight: 500; }
+.integrity-range {
+  margin-top: 7px;
+  color: var(--text);
+  font-size: 11px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+.integrity-note { margin-top: 8px; line-height: 1.4; }
+.integrity-issues {
+  max-height: 150px;
+  overflow-y: auto;
+  margin-top: 7px;
+  border-top: 1px solid var(--border);
+}
+.integrity-issue {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 12px;
+}
+.integrity-issue span:last-child { color: var(--muted); }
 
 /* remove confirmation modal */
 .confirm-body { padding: 14px; display: flex; flex-direction: column; gap: 8px; }

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=63" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=69" />
 </head>
 <body>
   <header class="topbar">
@@ -345,7 +345,25 @@
         <div id="settings-error" class="error"></div>
       </div>
       <div class="settings-footer">
+        <button id="settings-cancel" class="btn" type="button" hidden>Cancel</button>
         <button id="settings-save" class="btn btn-primary">Save</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="integrity-cancel-modal" class="modal hidden" aria-hidden="true">
+    <div class="modal-box modal-box-sm" role="dialog" aria-modal="true" aria-labelledby="integrity-cancel-title">
+      <div class="modal-header">
+        <span id="integrity-cancel-title">Cancel data check?</span>
+        <button id="integrity-cancel-close" class="btn" type="button" title="Close" aria-label="Close">&times;</button>
+      </div>
+      <div class="confirm-body">
+        <div id="integrity-cancel-message" class="confirm-message"></div>
+        <div id="integrity-cancel-error" class="error"></div>
+      </div>
+      <div class="confirm-footer">
+        <button id="integrity-cancel-keep" class="btn" type="button">Keep running</button>
+        <button id="integrity-cancel-confirm" class="btn btn-danger-primary" type="button">Cancel check</button>
       </div>
     </div>
   </div>
@@ -461,6 +479,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=70"></script>
+  <script src="/static/dashboard.js?v=76"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -2817,6 +2817,13 @@
             `<path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"></path>` +
           `</svg>` +
         `</button>` +
+        `<button class="btn btn-icon data-integrity-btn" data-act="data-integrity" ` +
+        `title="Verify OHLCV data" aria-label="Verify OHLCV data">` +
+          `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">` +
+            `<circle cx="11" cy="11" r="8"></circle>` +
+            `<path d="m21 21-4.3-4.3"></path>` +
+          `</svg>` +
+        `</button>` +
         `<span data-field="history-loading" class="muted">loading</span>` +
         `</span></td>` +
       `<td data-label="Last bar" class="muted">${lastBarCell({})}</td>` +
@@ -2860,6 +2867,7 @@
           toggleDataSinceTooltip(tr);
         }
       } else if (act === "data-edit") openSettings(id, "data-since");
+      else if (act === "data-integrity") openSettings(id, "data-integrity");
       else if (act === "delete") openRemoveConfirm(id);
       else if (act === "logs") openLogs(id);
       else if (act === "webhook-settings") openSettings(id, "webhook");
@@ -4775,21 +4783,192 @@
   });
   // ---- per-session webhook/telegram settings modal ------------------------
   let settingsSession = null;
-  let settingsMode = null; // "webhook" | "telegram"
+  let settingsMode = null; // "webhook" | "telegram" | "data-since" | "data-integrity"
   let settingsOriginalHistorySince = null;
+  let settingsIntegrityAction = null;
+  let settingsIntegrityReport = null;
+  let settingsIntegrityRunning = null; // "check" | "repair"
+  let settingsIntegrityCancelRequested = false;
+  let integrityCancelSubmitting = false;
+
+  function setIntegrityOperation(operation) {
+    settingsIntegrityRunning = operation;
+    const running = Boolean(operation);
+    el("settings-cancel").hidden = !running;
+    el("settings-close").disabled = running;
+    if (running) el("settings-save").hidden = true;
+    if (!running) closeIntegrityCancelConfirm(true);
+  }
+
+  function integrityCount(value) {
+    const count = Number(value);
+    return Number.isFinite(count) ? count.toLocaleString("en-US") : "0";
+  }
+
+  function integrityTime(value) {
+    if (!value) return "-";
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? String(value) : formatUtcDate(date);
+  }
+
+  function integrityTimeframeSeconds(timeframe) {
+    const match = /^(\d+)([mhd])$/.exec(String(timeframe || ""));
+    if (!match) return null;
+    const value = Number(match[1]);
+    const multiplier = match[2] === "m" ? 60 : match[2] === "h" ? 3600 : 86400;
+    return value * multiplier;
+  }
+
+  function renderDataIntegrityIntro(id) {
+    const session = sessions.find((item) => sessionId(item) === id) || {};
+    const start = Number(session.data_since_time);
+    const interval = integrityTimeframeSeconds(session.timeframe);
+    const now = Math.floor(Date.now() / 1000);
+    const end = interval ? Math.floor(now / interval) * interval - (2 * interval) : null;
+    const startText = Number.isFinite(start) && start > 0
+      ? formatUtcDate(new Date(start * 1000))
+      : "-";
+    const endText = Number.isFinite(end) && end > 0
+      ? formatUtcDate(new Date(end * 1000))
+      : "-";
+    settingsIntegrityAction = "check";
+    setIntegrityOperation(null);
+    el("settings-fields").innerHTML =
+      `<div class="integrity-intro">` +
+        `<strong>Compare local OHLCV with the exchange</strong>` +
+        `<span>Checks missing candles, different values, invalid OHLCV, and extra local candles.</span>` +
+      `</div>` +
+      `<div class="integrity-section-title integrity-check-range-title">Check range</div>` +
+      `<div class="integrity-summary integrity-check-range">` +
+        `<span>Start candle</span><strong class="mono">${esc(startText)}</strong>` +
+        `<span>End candle</span><strong class="mono">${esc(endText)}</strong>` +
+      `</div>`;
+    const saveBtn = el("settings-save");
+    saveBtn.hidden = false;
+    saveBtn.disabled = false;
+    saveBtn.textContent = "Check";
+  }
+
+  function renderDataIntegrityReport(report) {
+    settingsIntegrityReport = report;
+    const issues = report && report.issues ? report.issues : {};
+    const repaired = Boolean(report && report.repair_applied);
+    const hasIssues = report && report.status === "issues";
+    const noData = report && report.status === "no_data";
+    const statusClass = repaired || (!hasIssues && !noData) ? "verified" : "issues";
+    const statusTitle = repaired
+      ? "Repair completed"
+      : noData ? "No confirmed candles" : hasIssues ? "Issues found" : "Verified";
+    const statusText = repaired
+      ? `${integrityCount(report.imported_reference_bars)} exchange candles were applied.`
+      : noData
+        ? "The local cache does not contain confirmed candles in this data range."
+        : hasIssues
+          ? "Local confirmed candles differ from the exchange reference."
+          : "Local confirmed candles match the exchange reference.";
+    const rangeText = report && report.range_start_time && report.range_end_time
+      ? `${integrityTime(report.range_start_time)} → ${integrityTime(report.range_end_time)}`
+      : "-";
+    const samples = Array.isArray(report && report.samples) ? report.samples : [];
+    const sampleHtml = samples.length
+      ? `<div class="integrity-section-title">Issue samples</div>` +
+        `<div class="integrity-issues">${samples.map((sample) => (
+          `<div class="integrity-issue">` +
+            `<span class="mono">${esc(integrityTime(sample.time || sample.timestamp))}</span>` +
+            `<span>${esc(sample.details || sample.type || "Issue")}</span>` +
+          `</div>`
+        )).join("")}</div>`
+      : "";
+    const zeroVolume = Number(issues.synthetic_zero_volume || 0);
+    el("settings-fields").innerHTML =
+      `<div class="integrity-status ${statusClass}">` +
+        `<span class="integrity-status-mark" aria-hidden="true">${statusClass === "verified" ? "✓" : "!"}</span>` +
+        `<div><strong>${esc(statusTitle)}</strong><span>${esc(statusText)}</span></div>` +
+      `</div>` +
+      `<div class="integrity-section-title">Comparison</div>` +
+      `<div class="integrity-summary">` +
+        `<span>Local candles</span><strong>${integrityCount(report && report.bars_scanned)}</strong>` +
+        `<span>Exchange candles</span><strong>${integrityCount(report && report.reference_bars)}</strong>` +
+        `<span>Missing locally</span><strong>${integrityCount(issues.missing_local)}</strong>` +
+        `<span>Different values</span><strong>${integrityCount(issues.mismatched)}</strong>` +
+        `<span>Invalid OHLCV</span><strong>${integrityCount(issues.invalid)}</strong>` +
+        `<span>Extra local candles</span><strong>${integrityCount(issues.extra_local)}</strong>` +
+      `</div>` +
+      `<div class="integrity-section-title">Range</div>` +
+      `<div class="integrity-range mono">${esc(rangeText)}</div>` +
+      (zeroVolume > 0
+        ? `<div class="muted integrity-note">${integrityCount(zeroVolume)} zero-volume synthetic candles were ignored.</div>`
+        : "") +
+      sampleHtml +
+      `<div class="muted integrity-note">The current candle and the immediately preceding candle are excluded.</div>`;
+
+    setIntegrityOperation(null);
+    const saveBtn = el("settings-save");
+    if (repaired) {
+      settingsIntegrityAction = "verify";
+      saveBtn.hidden = false;
+      saveBtn.textContent = "Verify again";
+    } else if (report && report.repairable) {
+      settingsIntegrityAction = "repair";
+      saveBtn.hidden = false;
+      saveBtn.textContent = "Repair";
+    } else {
+      settingsIntegrityAction = null;
+      saveBtn.hidden = true;
+    }
+    saveBtn.disabled = false;
+  }
+
+  async function loadDataIntegrity(id) {
+    settingsIntegrityAction = null;
+    settingsIntegrityCancelRequested = false;
+    setIntegrityOperation("check");
+    el("settings-fields").innerHTML =
+      `<div class="settings-loading integrity-loading">` +
+        `<span class="settings-spinner" aria-hidden="true"></span>` +
+        `<span>Comparing confirmed candles with exchange data…</span>` +
+      `</div>`;
+    try {
+      const report = await api(`/api/sessions/${encodeURIComponent(id)}/data-integrity`);
+      if (settingsSession !== id || settingsMode !== "data-integrity") return;
+      if (settingsIntegrityCancelRequested) return;
+      renderDataIntegrityReport(report);
+    } catch (e) {
+      if (settingsSession !== id || settingsMode !== "data-integrity") return;
+      if (settingsIntegrityCancelRequested) return;
+      setIntegrityOperation(null);
+      el("settings-fields").innerHTML = "";
+      el("settings-error").textContent = e.message;
+    }
+  }
 
   async function openSettings(id, mode) {
     settingsSession = id;
     settingsMode = mode;
     settingsOriginalHistorySince = null;
+    settingsIntegrityAction = null;
+    settingsIntegrityReport = null;
+    settingsIntegrityRunning = null;
+    settingsIntegrityCancelRequested = false;
     el("settings-error").textContent = "";
+    const saveBtn = el("settings-save");
+    el("settings-cancel").hidden = true;
+    el("settings-close").disabled = false;
+    saveBtn.hidden = false;
+    saveBtn.disabled = false;
+    saveBtn.textContent = "Save";
     el("settings-title").textContent =
       (mode === "webhook" ? "Webhook URL — "
         : mode === "telegram" ? "Telegram bot — "
+        : mode === "data-integrity" ? "Data integrity — "
         : "Data since — ") + id;
     el("settings-fields").innerHTML = "loading…";
     el("settings-modal").classList.remove("hidden");
     lockBodyScroll();
+    if (mode === "data-integrity") {
+      renderDataIntegrityIntro(id);
+      return;
+    }
     if (mode === "data-since") {
       const s = sessions.find((x) => sessionId(x) === id) || {};
       const shared = sessions
@@ -4841,15 +5020,22 @@
     }
   }
 
-  function closeSettings() {
+  function closeSettings(force = false) {
     if (el("settings-modal").classList.contains("hidden")) return;
+    if (settingsIntegrityRunning && !force) return;
     el("settings-modal").classList.add("hidden");
     unlockBodyScroll();
     const saveBtn = el("settings-save");
-    if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = "Save"; }
+    if (saveBtn) { saveBtn.hidden = false; saveBtn.disabled = false; saveBtn.textContent = "Save"; }
+    el("settings-cancel").hidden = true;
+    el("settings-close").disabled = false;
     settingsSession = null;
     settingsMode = null;
     settingsOriginalHistorySince = null;
+    settingsIntegrityAction = null;
+    settingsIntegrityReport = null;
+    settingsIntegrityRunning = null;
+    settingsIntegrityCancelRequested = false;
   }
 
   function setDataSinceLoading(on) {
@@ -4866,6 +5052,47 @@
 
   async function saveSettings() {
     if (!settingsSession) return;
+    if (settingsMode === "data-integrity") {
+      const sid = settingsSession;
+      if (settingsIntegrityAction === "check" || settingsIntegrityAction === "verify") {
+        el("settings-error").textContent = "";
+        await loadDataIntegrity(sid);
+        return;
+      }
+      if (settingsIntegrityAction !== "repair") return;
+      const saveBtn = el("settings-save");
+      settingsIntegrityCancelRequested = false;
+      setIntegrityOperation("repair");
+      el("settings-error").textContent = "";
+      el("settings-fields").innerHTML =
+        `<div class="settings-loading integrity-loading">` +
+          `<span class="settings-spinner" aria-hidden="true"></span>` +
+          `<span>Repairing local OHLCV data…</span>` +
+        `</div>`;
+      try {
+        const report = await api(
+          `/api/sessions/${encodeURIComponent(sid)}/data-integrity/repair`,
+          { method: "POST" },
+        );
+        if (settingsSession === sid && settingsMode === "data-integrity") {
+          if (settingsIntegrityCancelRequested) return;
+          renderDataIntegrityReport(report);
+        }
+      } catch (e) {
+        if (settingsSession === sid && settingsMode === "data-integrity") {
+          if (settingsIntegrityCancelRequested) return;
+          setIntegrityOperation(null);
+          if (settingsIntegrityReport) renderDataIntegrityReport(settingsIntegrityReport);
+          el("settings-error").textContent = e.message;
+          if (!settingsIntegrityReport) {
+            saveBtn.hidden = false;
+            saveBtn.disabled = false;
+            saveBtn.textContent = "Repair";
+          }
+        }
+      }
+      return;
+    }
     if (settingsMode === "data-since") {
       const inputEl = el("settings-history-since");
       const value = (inputEl ? inputEl.value : "").trim();
@@ -4915,10 +5142,77 @@
     }
   }
 
-  el("settings-close").addEventListener("click", closeSettings);
+  function closeIntegrityCancelConfirm(force = false) {
+    if (integrityCancelSubmitting && !force) return;
+    const modal = el("integrity-cancel-modal");
+    if (modal.classList.contains("hidden")) return;
+    modal.classList.add("hidden");
+    modal.setAttribute("aria-hidden", "true");
+    el("integrity-cancel-error").textContent = "";
+  }
+
+  function openIntegrityCancelConfirm() {
+    const operation = settingsIntegrityRunning;
+    if (!operation || !settingsSession) return;
+    const repair = operation === "repair";
+    integrityCancelSubmitting = false;
+    el("integrity-cancel-title").textContent = repair ? "Cancel repair?" : "Cancel data check?";
+    el("integrity-cancel-message").textContent = repair
+      ? "The repair will be stopped. Any cache write already in progress will finish safely before cancellation."
+      : "The exchange download and candle comparison will be stopped.";
+    el("integrity-cancel-confirm").textContent = repair ? "Cancel repair" : "Cancel check";
+    el("integrity-cancel-confirm").disabled = false;
+    el("integrity-cancel-keep").disabled = false;
+    el("integrity-cancel-close").disabled = false;
+    el("integrity-cancel-error").textContent = "";
+    const modal = el("integrity-cancel-modal");
+    modal.classList.remove("hidden");
+    modal.setAttribute("aria-hidden", "false");
+  }
+
+  async function confirmIntegrityCancel() {
+    if (!settingsIntegrityRunning || !settingsSession || integrityCancelSubmitting) return;
+    const sid = settingsSession;
+    integrityCancelSubmitting = true;
+    settingsIntegrityCancelRequested = true;
+    el("integrity-cancel-confirm").disabled = true;
+    el("integrity-cancel-keep").disabled = true;
+    el("integrity-cancel-close").disabled = true;
+    el("integrity-cancel-confirm").textContent = "Cancelling…";
+    const loadingText = el("settings-fields").querySelector(".integrity-loading span:last-child");
+    if (loadingText) loadingText.textContent = "Cancelling operation…";
+    try {
+      await api(`/api/sessions/${encodeURIComponent(sid)}/data-integrity/cancel`, {
+        method: "POST",
+      });
+    } catch (e) {
+      settingsIntegrityCancelRequested = false;
+      integrityCancelSubmitting = false;
+      el("integrity-cancel-error").textContent = e.message;
+      el("integrity-cancel-confirm").disabled = false;
+      el("integrity-cancel-keep").disabled = false;
+      el("integrity-cancel-close").disabled = false;
+      el("integrity-cancel-confirm").textContent = settingsIntegrityRunning === "repair"
+        ? "Cancel repair"
+        : "Cancel check";
+      return;
+    }
+    integrityCancelSubmitting = false;
+    closeIntegrityCancelConfirm(true);
+    closeSettings(true);
+  }
+
+  el("settings-close").addEventListener("click", () => closeSettings());
+  el("settings-cancel").addEventListener("click", openIntegrityCancelConfirm);
   el("settings-save").addEventListener("click", saveSettings);
   el("settings-modal").addEventListener("click", (e) => {
     if (e.target === el("settings-modal")) closeSettings();
+  });
+  el("integrity-cancel-close").addEventListener("click", () => closeIntegrityCancelConfirm());
+  el("integrity-cancel-keep").addEventListener("click", () => closeIntegrityCancelConfirm());
+  el("integrity-cancel-confirm").addEventListener("click", confirmIntegrityCancel);
+  el("integrity-cancel-modal").addEventListener("click", (e) => {
+    if (e.target === el("integrity-cancel-modal")) closeIntegrityCancelConfirm();
   });
   el("remove-close").addEventListener("click", closeRemoveConfirm);
   el("remove-cancel").addEventListener("click", closeRemoveConfirm);
@@ -4929,6 +5223,10 @@
 
   document.addEventListener("keydown", (e) => {
     if (e.key !== "Escape") return;
+    if (!el("integrity-cancel-modal").classList.contains("hidden")) {
+      closeIntegrityCancelConfirm();
+      return;
+    }
     closeHubMenu();
     if (isCalendarOpen()) closeCalendar();
     if (isAssetTransferOpen()) closeAssetTransfer();


### PR DESCRIPTION
## 변경 사항

- 대시보드 Data 열에 OHLCV 데이터 검사 버튼을 추가했습니다.
- 검사 전 실제 시작 봉과 종료 봉을 확인할 수 있는 검사 범위 안내 화면을 추가했습니다.
- 현재 진행 봉과 직전 봉을 제외하고 로컬 캐시의 확정봉을 거래소 데이터와 직접 비교합니다.
- 누락 봉, OHLCV 값 불일치, 잘못된 봉 구조, 로컬에만 존재하는 봉을 구분해 표시합니다.
- 거래소 정책에 따라 로컬에서 생성된 정상적인 zero-volume 합성봉은 오류에서 제외합니다.
- 문제가 발견된 경우 거래소 데이터를 기준으로 캐시를 복구하는 Repair 기능을 추가했습니다.
- Repair 시 동일 feed를 공유하는 runner와 file updater를 중지하고, 복구 완료 후 기존 실행 상태로 재시작합니다.
- Check와 Repair를 백그라운드 작업으로 실행하고 동일 feed의 중복 작업을 방지합니다.
- 실행 중에는 모달 닫기를 제한하고, 확인 절차를 거쳐 작업을 안전하게 취소할 수 있도록 했습니다.

## 동작 범위

Check는 캐시를 읽기만 하며 feed 수집과 전략 계산을 중지하지 않습니다. Repair는 복구 대상 feed에 연결된 runner와 file updater에만 일시적으로 영향을 주며 다른 feed는 계속 동작합니다.