### PR TITLE
전량 청산 시 부동소수점 dust 잔량 수정

### DIFF
--- a/pynecore/lib/strategy/__init__.py
+++ b/pynecore/lib/strategy/__init__.py
@@ -1464,7 +1464,10 @@ def close(id: str, comment: str | NA[str] = na_str, qty: float | NA[float] = na_
 
 
 # noinspection PyProtectedMember,PyShadowingNames
-def close_all(comment: str | NA[str] = na_str, alert_message: str | NA[str] = na_str, immediately: bool = False):
+def close_all(comment: str | NA[str] = na_str, alert_message: str | NA[str] = na_str,
+              immediately: bool = False,
+              record: bool = False, record_data: str | None = None,
+              ai: str | NA[str] = na_str):
     """
     Creates an order to close an open position completely, regardless of the identifiers of the entry
     orders that opened or added to it.
@@ -1472,6 +1475,9 @@ def close_all(comment: str | NA[str] = na_str, alert_message: str | NA[str] = na
     :param comment: Additional notes on the filled order
     :param alert_message: Custom text for the alert that fires when an order fills
     :param immediately: If true, the closing order executes on the same tick when the strategy places it
+    :param record: Whether to record the close data or not
+    :param record_data: Extra data to record
+    :param ai: Instruction sent to the configured AI service when the order fills
     """
     if lib._lib_semaphore:
         return
@@ -1481,13 +1487,26 @@ def close_all(comment: str | NA[str] = na_str, alert_message: str | NA[str] = na
         return
 
     exit_id = 'Close position order'
+    bar_time = lib._time
+    alert_message = f'{{"timestamp": {bar_time}, "message": {alert_message}}}' if alert_message else None
+    ai_instruction = None if isinstance(ai, NA) else str(ai).strip() or None
     order = Order(None, -position.size, exit_id=exit_id, order_type=_order_type_close,
-                  comment=comment, alert_message=alert_message)
+                  comment=None if isinstance(comment, NA) else comment,
+                  alert_message=None if isinstance(alert_message, NA) else alert_message,
+                  ai_instruction=ai_instruction)
 
     # Add order to position (this will handle orderbook and exit_orders)
     position._add_order(order)
     if immediately:
         position.fill_order(order, position.c, position.h, position.l)
+
+    if record:
+        record_message = (f'{{"time": {str(datetime.fromtimestamp(int(bar_time / 1000)))}, '
+                          f'"bar": {order.bar_index}, '
+                          f'"comment": "{comment}", '
+                          f'"alert": {alert_message}, '
+                          f'"data": {record_data}}}')
+        write_record(record_message)
 
 
 # noinspection PyProtectedMember,PyShadowingNames,PyShadowingBuiltins

--- a/pynecore/lib/strategy/__init__.py
+++ b/pynecore/lib/strategy/__init__.py
@@ -661,11 +661,14 @@ class Position:
                     # Modify sizes
                     self.size += size
                     # Handle too small sizes because of floating point inaccuracy and rounding
-                    if _size_round(self.size) == 0.0:
+                    position_flat = _size_round(self.size) == 0.0
+                    if position_flat:
                         size -= self.size
                         self.size = 0.0
                     self.sign = 0.0 if self.size == 0.0 else 1.0 if self.size > 0.0 else -1.0
                     trade.size += size
+                    if position_flat:
+                        trade.size = 0.0
                     order.size -= size
 
                     # Cancel exit orders for closed trades (TradingView behavior)
@@ -1329,15 +1332,17 @@ class Position:
 # noinspection PyProtectedMember
 def _size_round(qty: float) -> float:
     """
-    Round size to the nearest possible value
+    Round a size down to the nearest tradable lot.
 
     :param qty: The quantity to round
     :return: The rounded quantity
     """
     rfactor = syminfo._size_round_factor  # noqa
-    qrf = int(abs(qty) * rfactor * 10.0) * 0.1  # We need to floor to one decimal place
+    scaled = abs(qty) * rfactor
+    nearest = round(scaled)
+    lots = nearest if abs(scaled - nearest) <= scaled * 1e-12 + 1e-9 else int(scaled)
     sign = 1 if qty > 0 else -1
-    return sign * int(qrf) / rfactor
+    return sign * lots / rfactor
 
 
 # noinspection PyShadowingNames
@@ -1425,12 +1430,13 @@ def close(id: str, comment: str | NA[str] = na_str, qty: float | NA[float] = na_
         return
 
     if isinstance(qty, NA):
-        size = -position.size * (qty_percent * 0.01) if not isinstance(qty_percent, NA) \
-            else -position.size
+        if not isinstance(qty_percent, NA):
+            size = _size_round(-position.size * (qty_percent * 0.01))
+        else:
+            size = -position.size
     else:
-        size = -position.sign * qty
+        size = _size_round(-position.sign * qty)
 
-    size = _size_round(size)
     if size == 0.0:
         return
 


### PR DESCRIPTION
## 개요

명시적인 전량 청산 이후 부동소수점 및 lot 단위 반올림 차이로 미세 잔량과 open trade가 남는 문제를 수정합니다. 엔진이 사용자의 전량 청산 의도를 추정하지 않고 Pine의 `strategy.close()` 및 `strategy.close_all()` 의미를 그대로 유지하도록 정리했습니다.

## 변경사항

- 정확한 lot 경계에 가까운 수량만 ULP 허용 범위에서 보정
- `strategy.close()`에서 `qty`를 생략한 전량 청산은 실제 보유 수량을 다시 반올림하지 않도록 수정
- 청산 후 lot 기준 flat인 부동소수점 잔량을 마지막 체결에 흡수하고 open trade 수량을 0으로 정리
- 명시된 `qty`가 실제 잔량과 가까워도 전량 청산으로 임의 해석하지 않도록 유지
- `strategy.close_all()`에 timestamp 포장, `record`, `record_data`, AI 지시 전달을 추가해 기존 주문 알림 계약과 통일

## 검증

- BTC 510,680봉 변경 전후 전체 알림 시그널 2,060개가 시각, 순서, 내용, SHA-256까지 일치
- BTC `close_all()` 체결 381회에서 tiny 잔량 및 open trade 합계 불일치 0회
- CL 19,943봉 `close_all()` 체결 11회에서 tiny 잔량 및 open trade 합계 불일치 0회
- 명시적 부분 청산은 잔량을 유지하고 전량 청산으로 추정되지 않음을 확인
- 확정봉 주문이 다음 봉에서 체결될 때 Alert 및 AI callback이 각각 한 번만 호출됨을 확인

## 범위

이번 PR은 `pynecore/lib/strategy/__init__.py`의 공용 엔진 변경만 포함합니다. Git에서 제외된 사용자 전략 스크립트와 로컬 설계 문서는 포함하지 않습니다.