### PR TITLE
확정봉 처리 지연 병목 개선

### DIFF
--- a/data_service/asset_portfolio.py
+++ b/data_service/asset_portfolio.py
@@ -24,6 +24,7 @@ from ai.scripts.asset import (
     read_provider_config,
     remove_binance_earn_receipts,
 )
+from schedule_utils import seconds_until_post_bar_task_slot
 
 
 _LOCAL_QUOTES = {
@@ -634,6 +635,17 @@ class AssetPortfolioService:
     async def _market_refresh_loop(self) -> None:
         first_refresh = True
         while not self._market_stop.is_set():
+            post_bar_delay = seconds_until_post_bar_task_slot()
+            if post_bar_delay > 0.0:
+                try:
+                    await asyncio.wait_for(
+                        self._market_stop.wait(),
+                        timeout=post_bar_delay,
+                    )
+                except TimeoutError:
+                    pass
+                if self._market_stop.is_set():
+                    break
             try:
                 await self._refresh_market_cache()
             except Exception as exc:

--- a/data_service/collector_loop.py
+++ b/data_service/collector_loop.py
@@ -78,7 +78,7 @@ async def fix_missing_bars_loop(
     timeframe: str,
     state: DataState,
     check_interval_sec: float = 0.1,
-    time_sync_interval_sec: float = 30.0,
+    time_sync_interval_sec: float = 10 * 60,
 ) -> None:
     tf_ms = convert_timeframe(timeframe, to_ms=True)
     grace_ms = 0.2 * 1000

--- a/data_service/exchange_clock.py
+++ b/data_service/exchange_clock.py
@@ -9,58 +9,96 @@ import ccxt.pro as ccxt
 
 from ohlcv_io import make_ccxt_pro_client
 from log_utils import log_with_time
+from schedule_utils import seconds_until_post_bar_task_window
+
+
+_DEFAULT_SYNC_INTERVAL_SECONDS = 10 * 60
 
 
 @dataclass
 class ExchangeClock:
     exchange_name: str
-    sync_interval_sec: float = 30.0
+    sync_interval_sec: float = _DEFAULT_SYNC_INTERVAL_SECONDS
     time_offset_ms: float = 0.0
-    next_sync: float = 0.0
     backoff_sec: float = 5.0
     ref_count: int = 0
-    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     ex: object | None = None
+    stop_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
+    sync_task: asyncio.Task[None] | None = field(default=None, repr=False)
 
     async def now_ms(self) -> float:
-        mono = time.monotonic()
-        if mono < self.next_sync:
-            return time.time() * 1000 + self.time_offset_ms
+        return time.time() * 1000 + self.time_offset_ms
 
-        async with self.lock:
-            mono = time.monotonic()
-            if mono < self.next_sync:
-                return time.time() * 1000 + self.time_offset_ms
+    def start(self) -> None:
+        if self.sync_task is not None and not self.sync_task.done():
+            return
+        self.stop_event.clear()
+        self.sync_task = asyncio.create_task(
+            self._sync_loop(),
+            name=f"exchange-clock-{self.exchange_name.lower()}",
+        )
 
-            if self.ex is None:
-                self.ex = make_ccxt_pro_client(ccxt, self.exchange_name)
+    async def _sync_loop(self) -> None:
+        delay = seconds_until_post_bar_task_window()
+        while not self.stop_event.is_set():
+            if await self._wait_until_stopped(delay):
+                return
 
-            try:
-                server_ms = await self.ex.fetch_time()
-                if server_ms is None:
-                    raise RuntimeError("fetch_time returned None")
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                delay = self.backoff_sec
-                jitter = random.uniform(0.0, min(1.0, delay * 0.2))
-                self.next_sync = mono + delay + jitter
-                self.backoff_sec = min(delay * 2.0, 60.0)
-                await self.close()
-                log_with_time(
-                    f"[exchange_clock] {self.exchange_name} fetch_time error: "
-                    f"{type(e).__name__}: {e}; using cached/local clock, "
-                    f"retrying in {delay:g}s"
-                )
-                return time.time() * 1000 + self.time_offset_ms
+            started = time.monotonic()
+            next_interval = await self._sync_once()
+            elapsed = time.monotonic() - started
+            if await self._wait_until_stopped(max(0.0, next_interval - elapsed)):
+                return
+            delay = seconds_until_post_bar_task_window()
 
-            self.time_offset_ms = server_ms - time.time() * 1000
-            jitter = random.uniform(0.0, min(2.0, self.sync_interval_sec * 0.1))
-            self.next_sync = mono + self.sync_interval_sec + jitter
-            self.backoff_sec = 5.0
-            return time.time() * 1000 + self.time_offset_ms
+    async def _sync_once(self) -> float:
+        if self.ex is None:
+            self.ex = make_ccxt_pro_client(ccxt, self.exchange_name)
+
+        try:
+            server_ms = await self.ex.fetch_time()
+            if server_ms is None:
+                raise RuntimeError("fetch_time returned None")
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            delay = self.backoff_sec
+            jitter = random.uniform(0.0, min(1.0, delay * 0.2))
+            self.backoff_sec = min(delay * 2.0, 60.0)
+            await self._close_exchange()
+            log_with_time(
+                f"[exchange_clock] {self.exchange_name} fetch_time error: "
+                f"{type(e).__name__}: {e}; using cached/local clock, "
+                f"retrying in {delay:g}s"
+            )
+            return delay + jitter
+
+        self.time_offset_ms = server_ms - time.time() * 1000
+        self.backoff_sec = 5.0
+        return self.sync_interval_sec + random.uniform(
+            0.0,
+            min(2.0, self.sync_interval_sec * 0.1),
+        )
+
+    async def _wait_until_stopped(self, delay: float) -> bool:
+        if delay <= 0.0:
+            return self.stop_event.is_set()
+        try:
+            await asyncio.wait_for(self.stop_event.wait(), timeout=delay)
+        except TimeoutError:
+            return False
+        return True
 
     async def close(self) -> None:
+        self.stop_event.set()
+        task = self.sync_task
+        self.sync_task = None
+        if task is not None and task is not asyncio.current_task():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+        await self._close_exchange()
+
+    async def _close_exchange(self) -> None:
         if self.ex is None:
             return
         try:
@@ -74,7 +112,10 @@ class ExchangeClock:
 _CLOCKS: dict[str, ExchangeClock] = {}
 
 
-def retain_exchange_clock(exchange_name: str, sync_interval_sec: float = 30.0) -> ExchangeClock:
+def retain_exchange_clock(
+    exchange_name: str,
+    sync_interval_sec: float = _DEFAULT_SYNC_INTERVAL_SECONDS,
+) -> ExchangeClock:
     key = exchange_name.lower()
     clock = _CLOCKS.get(key)
     if clock is None:
@@ -83,6 +124,7 @@ def retain_exchange_clock(exchange_name: str, sync_interval_sec: float = 30.0) -
     else:
         clock.sync_interval_sec = sync_interval_sec
     clock.ref_count += 1
+    clock.start()
     return clock
 
 

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -107,7 +107,14 @@ class Feed:
             if session.runner_count <= 0:
                 continue
             session_payload = dict(payload)
-            if session.strategy_evaluation_enabled:
+            if (
+                session.strategy_evaluation_enabled
+                and payload.get("type") in {
+                    "prerun_ready",
+                    "prerun_ready_after_history_download",
+                    "run_ready",
+                }
+            ):
                 generation_id = await session.begin_calculation(session_payload)
                 if generation_id is not None:
                     session_payload["calculation_generation_id"] = generation_id
@@ -508,10 +515,23 @@ class Session:
             self.plot_options.update(event.get("data", {}))
             confirmed_bar_index = event.get("confirmed_bar_index", -1)
             confirmed_bar_time = event.get("confirmed_bar_time")
+            plot_values = event.get("values")
 
             if self.plot_options and (confirmed_bar_time is not None or confirmed_bar_index >= 0):
                 try:
-                    if plot_path.exists():
+                    if isinstance(plot_values, dict) and confirmed_bar_time is not None:
+                        for title, options in self.plot_options.items():
+                            kind = str(options.get("kind") or "line")
+                            await self.send_to_charts({
+                                "type": "plot_data",
+                                "title": title,
+                                "kind": kind,
+                                "time": int(confirmed_bar_time),
+                                "value": _plot_wire_value(plot_values.get(title), kind),
+                            })
+                    elif plot_path.exists():
+                        # Backward-compatible fallback for runners that do not include
+                        # current values in the plot_options event.
                         from pynecore.core.csv_file import CSVReader
                         with CSVReader(plot_path) as reader:
                             candle = None

--- a/data_service/schedule_utils.py
+++ b/data_service/schedule_utils.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import time
+
+
+POST_BAR_TASK_OFFSET_SECONDS = 10.0
+POST_BAR_TASK_WINDOW_SECONDS = 10.0
+
+
+def seconds_until_post_bar_task_slot(
+    now_seconds: float | None = None,
+) -> float:
+    """Return the delay until the next minute boundary plus 10 seconds."""
+
+    current = time.time() if now_seconds is None else now_seconds
+    second = current % 60.0
+    delay = (POST_BAR_TASK_OFFSET_SECONDS - second) % 60.0
+    return 0.0 if delay < 0.001 else delay
+
+
+def seconds_until_post_bar_task_window(
+    now_seconds: float | None = None,
+) -> float:
+    """Return the delay until the post-bar background-task window."""
+
+    current = time.time() if now_seconds is None else now_seconds
+    second = current % 60.0
+    window_start = POST_BAR_TASK_OFFSET_SECONDS
+    window_end = window_start + POST_BAR_TASK_WINDOW_SECONDS
+
+    if window_start <= second < window_end:
+        return 0.0
+    if second < window_start:
+        return window_start - second
+    return 60.0 - second + window_start

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import os
 import sys
+import time
 import tomllib
 import ast
 from script_hash import compute_script_hashes, load_script_hashes, write_script_hashes
@@ -13,7 +14,7 @@ from collections import deque
 from functools import partial
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator, Optional
+from typing import Any, Iterator, Optional
 
 import numpy as np
 import websockets
@@ -568,14 +569,52 @@ def bar_list_to_ohlcv(bar: list) -> OHLCV:
     )
 
 
-def run_prerun_steps(runner: ScriptRunner, prerun_range: int) -> None:
+def _plot_wire_value(value: Any, kind: str) -> float | int | None:
+    if value is None or str(value) == "":
+        return None
+    try:
+        if kind == "bgcolor":
+            return int(value)
+        text = format(value, ".8g") if isinstance(value, float) else str(value)
+        return float(text)
+    except (TypeError, ValueError):
+        return None
+
+
+def _plot_values_from_step(
+    step_res: tuple | None,
+    expected_timestamp: int | None,
+) -> dict[str, float | int | None] | None:
+    if not isinstance(step_res, tuple) or len(step_res) < 2:
+        return None
+    candle, values = step_res[0], step_res[1]
+    if not isinstance(candle, OHLCV) or not isinstance(values, dict):
+        return None
+    if expected_timestamp is not None and int(candle.timestamp) != expected_timestamp:
+        return None
+    return {
+        title: _plot_wire_value(values.get(title), str(options.get("kind") or "line"))
+        for title, options in plot_options.items()
+    }
+
+
+def run_prerun_steps(
+    runner: ScriptRunner,
+    prerun_range: int,
+    plot_timestamp: int | None = None,
+) -> dict[str, float | int | None] | None:
+    plot_values = None
     for _ in range(prerun_range):
         step_res = runner.step()
         if step_res is None:
             break
+        current_values = _plot_values_from_step(step_res, plot_timestamp)
+        if current_values is not None:
+            plot_values = current_values
     # Flush plot writer to ensure all data is written
     if runner.plot_writer:
         runner.plot_writer.flush()
+    return plot_values
 
 
 @dataclass
@@ -867,6 +906,11 @@ async def main():
                 and int(last_visible_bar.timestamp) == int(reader.end_timestamp)
             )
             prerun_range = size - 1 if has_unconfirmed_visible_bar else size
+            confirmed_bar_index = runner.last_bar_index - 1
+            confirmed_bar = get_runner_candle(runner, confirmed_bar_index)
+            confirmed_bar_time = (
+                int(confirmed_bar.timestamp) if confirmed_bar is not None else None
+            )
             runner.script.pre_run = True
             if mtype == "prerun_ready_after_history_download":
                 prerun_range = size
@@ -885,7 +929,12 @@ async def main():
                 and msg.get("history_resync")
             )
             try:
-                await asyncio.to_thread(run_prerun_steps, runner, prerun_range)
+                prerun_plot_values = await asyncio.to_thread(
+                    run_prerun_steps,
+                    runner,
+                    prerun_range,
+                    confirmed_bar_time,
+                )
             finally:
                 SUPPRESS_EXTERNAL_NOTIFICATIONS = False
             pending_full_reemit = False
@@ -949,17 +998,14 @@ async def main():
             # Send plot options to data_service
             if plot_options:
                 try:
-                    # Plot CSV rows are keyed by candle timestamp. Timestamp lookup avoids
-                    # using a raw file index that may include hidden OKX bars.
-                    confirmed_bar_index = runner.last_bar_index - 1
-                    confirmed_bar = get_runner_candle(runner, confirmed_bar_index)
-                    confirmed_bar_time = int(confirmed_bar.timestamp) if confirmed_bar is not None else None
                     plot_options_event = {
                         "type": "plot_options",
                         "data": plot_options,
                         "confirmed_bar_index": confirmed_bar_index,
                         "confirmed_bar_time": confirmed_bar_time,
                     }
+                    if prerun_plot_values is not None:
+                        plot_options_event["values"] = prerun_plot_values
                     await ws.send(json.dumps(plot_options_event))
                     # print(f"[runner] Sent plot_options: {plot_options}")
                 except Exception as e:
@@ -1085,10 +1131,17 @@ async def main():
 
                 # Calculate the last confirmed bar
                 ctx.runner.script.pre_run = False
+                confirmed_plot_values = None
                 while True:
                     step_res = ctx.runner.step()
                     if step_res is None:
                         break
+                    current_values = _plot_values_from_step(
+                        step_res,
+                        int(confirmed_ohlcv.timestamp),
+                    )
+                    if current_values is not None:
+                        confirmed_plot_values = current_values
 
                 # Hidden-bar fix:
                 # 새로 열린 봉이 volume 0 hidden bar 면 new_ohlcv 가 stream 에 append 되지
@@ -1137,6 +1190,8 @@ async def main():
                             "confirmed_bar_index": confirmed_bar_index,
                             "confirmed_bar_time": int(confirmed_ohlcv.timestamp),
                         }
+                        if confirmed_plot_values is not None:
+                            plot_options_event["values"] = confirmed_plot_values
                         await ws.send(json.dumps(plot_options_event))
                         # print(f"[runner] Sent plot_options: {plot_options}")
                     except Exception as e:


### PR DESCRIPTION
## 개요

여러 전략 세션이 동시에 확정봉을 처리할 때 일부 Runner 계산 완료가 봉 경계보다 1~2초 늦어지는 문제를 개선합니다.

구간별 계측 결과 전략 계산이나 SQLite가 아니라, data service가 매 확정봉마다 각 세션의 최신 plot 값을 찾기 위해 `plot.csv` 전체를 순차 조회하는 동기 작업이 핵심 병목으로 확인됐습니다.

## 변경 사항

- Runner가 `ScriptRunner.step()`에서 이미 계산한 현재 확정봉의 plot 값을 WebSocket 이벤트에 포함합니다.
- data service는 전달받은 값을 기존 `plot_data` 형식으로 차트에 직접 전송합니다.
- 값이 없는 구버전 Runner 이벤트에는 기존 CSV 조회 fallback을 유지합니다.
- plot CSV 기록과 과거 차트 로딩 및 재접속 복원 경로는 그대로 유지합니다.
- 거래소 `fetch_time()` 호출을 확정봉 경로에서 분리하고 10분 간격의 백그라운드 동기화로 변경합니다.
- 시간 동기화와 자산 market metadata 갱신을 봉 경계 이후 구간에 실행합니다.
- 실제 `pre_run` 및 `run_ready` 계산 이벤트에서만 전략 평가 generation을 생성합니다.

## 측정 결과

기존 CCXT OHLCV collector를 유지한 상태에서 11개 Runner와 10개 feed를 장시간 측정했습니다.

- 표본: 1,232개
- 전체 처리 median: 180.6ms
- P90: 282.3ms
- P99: 359.5ms
- 최대: 392.6ms
- 500ms 이상: 0건
- 1초 이상: 0건
- Runner, SQLite lock 및 traceback: 0건

## 영향 범위

전략의 진입·청산·포지션 회계와 지표 계산은 변경하지 않습니다. `pre_run`, `run_ready`, alert, webhook, Telegram, AI instruction, OHLCV cache, trade marker 및 과거 plot 복원 동작도 기존 경로를 유지합니다.