### PR TITLE
수동 얼럿 raw trade 판정 및 실패 알림 개선

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,13 +333,14 @@ Webhook failure prevents the AI instruction from running; an unavailable or
 failed AI service does not roll back a successful webhook.
 
 Manual alerts are independent from the Webhook checkbox. The checkbox controls
-strategy-generated alerts only; a manual alert can still be sent while the
-checkbox is off. A valid webhook URL is still required. PyneReal sends the final
-JSON message directly to that URL.
+strategy-generated alerts only; a manual alert still attempts to send the final
+JSON message directly to its configured webhook URL while the checkbox is off.
 
 If Telegram credentials are configured for the session, or through the root
-`.env` fallback, PyneReal also sends a Telegram manual-alert message after the
-webhook send succeeds. This does not depend on the Telegram checkbox.
+`.env` fallback, PyneReal sends a Telegram manual-alert message after the webhook
+attempt finishes. The message reports whether the webhook was sent or failed,
+and a webhook failure does not prevent this Telegram notification. This does not
+depend on the Telegram checkbox.
 
 The JSON `MESSAGE` and optional `AI INSTRUCTION` support these placeholders:
 

--- a/data_service/collector_loop.py
+++ b/data_service/collector_loop.py
@@ -23,6 +23,7 @@ async def watch_trades_loop(
     timeframe: str,
     state: DataState,
     on_bar: Callable[[list], Awaitable[None]],
+    on_trades: Callable[[list], None] | None = None,
     market_type: str = "",
 ) -> None:
     ex = make_ccxt_pro_client(ccxt, exchange_name, market_type=market_type, symbol=symbol)
@@ -42,6 +43,9 @@ async def watch_trades_loop(
             try:
                 ws_trades = await ex.watch_trades(symbol, since, None, {})
                 bar_to_push = None
+
+                if on_trades is not None:
+                    on_trades(ws_trades)
 
                 async with state.lock:
                     state.collected_trades.extend(ws_trades)

--- a/data_service/manual_alerts.py
+++ b/data_service/manual_alerts.py
@@ -70,6 +70,15 @@ def post_telegram_message(token: str, chat_id: str, text: str) -> dict:
         raise RuntimeError(type(e).__name__) from e
 
 
+def webhook_delivery_status(error: BaseException | str) -> str:
+    reason = str(error).strip()
+    if not reason and isinstance(error, BaseException):
+        reason = type(error).__name__
+    if len(reason) > 117:
+        reason = reason[:117] + "..."
+    return f"Failed({reason or 'unknown error'})"
+
+
 def manual_alert_signal_text(message: Any) -> str:
     if isinstance(message, str):
         return message
@@ -100,12 +109,25 @@ def send_manual_alert_payload(*, spec: SessionSpec, script_title: str | None,
 
     wh = spec.webhook
     url = (wh.get("url") or "").strip() or default_webhook_url()
+    webhook_result: dict[str, Any] = {"sent": False}
     if not url:
-        raise ValueError("webhook url is empty")
-    if not url.startswith(("http://", "https://")):
-        raise ValueError("webhook url must start with http:// or https://")
+        webhook_result["error"] = "webhook url is empty"
+    elif not url.startswith(("http://", "https://")):
+        webhook_result["error"] = "webhook url must start with http:// or https://"
+    else:
+        try:
+            webhook_result = {
+                "sent": True,
+                **post_json_webhook(url, payload["message"], spec.exchange),
+            }
+        except Exception as e:
+            webhook_result = {"sent": False, "error": str(e) or type(e).__name__}
 
-    webhook_result = post_json_webhook(url, payload["message"], spec.exchange)
+    webhook_status = (
+        "Sent"
+        if webhook_result.get("sent")
+        else webhook_delivery_status(str(webhook_result.get("error") or "unknown error"))
+    )
 
     token = (wh.get("telegram_token") or "").strip() or default_telegram_token()
     chat_id = (wh.get("telegram_chat_id") or "").strip() or default_telegram_chat_id()
@@ -116,7 +138,7 @@ def send_manual_alert_payload(*, spec: SessionSpec, script_title: str | None,
             timeframe=spec.timeframe,
             ticker=spec.symbol,
             message=payload["message"],
-            webhook_status="Sent",
+            webhook_status=webhook_status,
         )
         try:
             telegram_result = {

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -187,6 +187,7 @@ class SessionRegistry:
         feed.tasks = {
             "watch_trades_loop": asyncio.create_task(self._guard_feed(feed, "watch_trades_loop", watch_trades_loop(
                 spec.exchange, spec.symbol, spec.timeframe, feed.state, feed.broadcast_bar,
+                on_trades=feed.broadcast_trades,
                 market_type=spec.market_type))),
             "fix_missing_bars_loop": asyncio.create_task(self._guard_feed(feed, "fix_missing_bars_loop", fix_missing_bars_loop(
                 spec.exchange, spec.timeframe, feed.state))),

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import time
 import uuid
 from collections import deque
 from dataclasses import dataclass
@@ -23,6 +24,7 @@ from ws_manager import WSManager
 
 _MAX_AI_INSTRUCTION_CHARS = 4_000
 _MAX_PROCESSED_AI_INSTRUCTION_EVENTS = 500
+_MAX_RECENT_RAW_TRADE_KEYS = 10_000
 
 
 def _plot_wire_value(value: Any, kind: str) -> float | int | None:
@@ -79,12 +81,16 @@ class Feed:
         self.collector_error: Optional[str] = None
         self._history_start_mtime: Optional[float] = None
         self._history_start_time: Optional[int] = None
-        self._last_broadcast_close: Optional[float] = None
+        self._raw_trade_sequence = 0
+        self._last_raw_trade_price: Optional[float] = None
+        self._last_raw_trade_time_ms: Optional[int] = None
+        self._raw_trade_stream_started = False
+        self._recent_raw_trade_keys: deque[tuple[Any, ...]] = deque()
+        self._recent_raw_trade_key_set: set[tuple[Any, ...]] = set()
         # session_id -> Session
         self.subscribers: Dict[str, "Session"] = {}
 
     async def broadcast_bar(self, bar: list) -> None:
-        prev_price = self._last_broadcast_close
         payload = {
             "type": "bar",
             "data": {
@@ -96,10 +102,83 @@ class Feed:
                 "volume": float(bar[5]),
             },
         }
-        self._last_broadcast_close = payload["data"]["close"]
         for session in list(self.subscribers.values()):
-            await session.maybe_fire_manual_alert_trigger(payload["data"], prev_price)
             await session.send_to_charts(payload)
+
+    @staticmethod
+    def _raw_trade_key(trade: dict[str, Any]) -> tuple[Any, ...]:
+        trade_id = trade.get("id")
+        if trade_id is not None and str(trade_id) != "":
+            return ("id", str(trade_id))
+        return (
+            "values",
+            trade.get("timestamp"),
+            trade.get("price"),
+            trade.get("amount"),
+            trade.get("side"),
+            trade.get("order"),
+        )
+
+    def _remember_raw_trade_key(self, key: tuple[Any, ...]) -> bool:
+        if key in self._recent_raw_trade_key_set:
+            return False
+        if len(self._recent_raw_trade_keys) >= _MAX_RECENT_RAW_TRADE_KEYS:
+            expired = self._recent_raw_trade_keys.popleft()
+            self._recent_raw_trade_key_set.discard(expired)
+        self._recent_raw_trade_keys.append(key)
+        self._recent_raw_trade_key_set.add(key)
+        return True
+
+    def raw_trade_cursor(self) -> tuple[int, float | None, int | None]:
+        return (
+            self._raw_trade_sequence,
+            self._last_raw_trade_price,
+            self._last_raw_trade_time_ms,
+        )
+
+    def broadcast_trades(self, trades: list) -> None:
+        initial_batch = not self._raw_trade_stream_started
+        new_trades: list[tuple[int, dict[str, Any]]] = []
+        for index, trade in enumerate(trades):
+            if not isinstance(trade, dict):
+                continue
+            if not self._remember_raw_trade_key(self._raw_trade_key(trade)):
+                continue
+            new_trades.append((index, trade))
+
+        def sort_key(item: tuple[int, dict[str, Any]]) -> tuple[int, int]:
+            index, trade = item
+            try:
+                timestamp = int(trade.get("timestamp"))
+            except (TypeError, ValueError):
+                timestamp = 0
+            return timestamp, index
+
+        new_trades.sort(key=sort_key)
+        for _, trade in new_trades:
+            try:
+                price = float(trade.get("price"))
+            except (TypeError, ValueError):
+                continue
+            try:
+                trade_time_ms = int(trade.get("timestamp"))
+            except (TypeError, ValueError):
+                trade_time_ms = None
+
+            self._raw_trade_sequence += 1
+            self._last_raw_trade_price = price
+            if trade_time_ms is not None:
+                self._last_raw_trade_time_ms = trade_time_ms
+            for session in list(self.subscribers.values()):
+                if not session.spec.manual_alert_triggers:
+                    continue
+                session.maybe_fire_manual_alert_trade(
+                    price=price,
+                    trade_time_ms=trade_time_ms,
+                    sequence=self._raw_trade_sequence,
+                    initial_batch=initial_batch,
+                )
+        self._raw_trade_stream_started = True
 
     async def emit_event(self, payload: dict) -> None:
         # prerun_ready / run_ready fan out to every runner subscribed to this feed.
@@ -221,7 +300,8 @@ class Session:
         self._processed_ai_instruction_ids: set[str] = set()
         self._processed_ai_instruction_order: deque[str] = deque()
         self._manual_alert_trigger_sending_ids: set[str] = set()
-        self._manual_alert_trigger_last_bar_time: dict[str, int] = {}
+        self._manual_alert_trigger_gates: dict[str, dict[str, Any]] = {}
+        self.reset_manual_alert_trigger_gate()
 
     @property
     def ohlcv_path(self) -> Path:
@@ -625,9 +705,44 @@ class Session:
     def manual_alert_triggers_payload(self) -> list[dict]:
         return [dict(t) for t in self.spec.manual_alert_triggers]
 
+    @staticmethod
+    def _manual_alert_trigger_signature(trigger: dict) -> str:
+        return json.dumps(
+            {
+                "price": trigger.get("price"),
+                "template": trigger.get("template"),
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        )
+
     def reset_manual_alert_trigger_gate(self) -> None:
-        self._manual_alert_trigger_last_bar_time.clear()
-        self._manual_alert_trigger_sending_ids.clear()
+        sequence, last_price, last_trade_time_ms = self.feed.raw_trade_cursor()
+        armed_at_ms = int(time.time() * 1000)
+        active_ids: set[str] = set()
+        gates: dict[str, dict[str, Any]] = {}
+        for trigger in self.spec.manual_alert_triggers:
+            if not trigger.get("enabled"):
+                continue
+            trigger_id = str(trigger.get("id") or "")
+            if not trigger_id:
+                continue
+            active_ids.add(trigger_id)
+            signature = self._manual_alert_trigger_signature(trigger)
+            previous = self._manual_alert_trigger_gates.get(trigger_id)
+            if previous is not None and previous.get("signature") == signature:
+                gates[trigger_id] = previous
+                continue
+            gates[trigger_id] = {
+                "signature": signature,
+                "armed_sequence": sequence,
+                "armed_at_ms": armed_at_ms,
+                "last_price": last_price,
+                "last_trade_time_ms": last_trade_time_ms,
+            }
+        self._manual_alert_trigger_gates = gates
+        self._manual_alert_trigger_sending_ids.intersection_update(active_ids)
 
     async def push_manual_alert_trigger(self) -> None:
         await self.send_to_charts({
@@ -647,13 +762,13 @@ class Session:
             return Path(self.spec.script_name).stem
         return None
 
-    def _manual_alert_trigger_touched(self, bar: dict, prev_price: float | None,
+    @staticmethod
+    def _manual_alert_trigger_touched(prev_price: float | None, market_price: float,
                                       trigger_price: float) -> bool:
-        close = float(bar.get("close"))
         if prev_price is None:
-            prev_price = float(bar.get("open", close))
-        low = min(float(prev_price), close)
-        high = max(float(prev_price), close)
+            return market_price == trigger_price
+        low = min(float(prev_price), market_price)
+        high = max(float(prev_price), market_price)
         return low <= trigger_price <= high
 
     def _remove_manual_alert_trigger(self, trigger_id: str) -> bool:
@@ -662,6 +777,7 @@ class Session:
         if len(remaining) == len(triggers):
             return False
         self.spec = self.spec.with_manual_alert_triggers(remaining)
+        self._manual_alert_trigger_gates.pop(trigger_id, None)
         return True
 
     async def _discard_manual_alert_trigger(self, trigger_id: str) -> None:
@@ -709,31 +825,65 @@ class Session:
             if trigger_id:
                 self._manual_alert_trigger_sending_ids.discard(trigger_id)
 
-    async def maybe_fire_manual_alert_trigger(self, bar: dict, prev_price: float | None) -> None:
-        try:
-            bar_time = int(bar.get("time"))
-            market_price = float(bar.get("close"))
-        except (TypeError, ValueError):
-            return
-
+    def maybe_fire_manual_alert_trade(
+        self,
+        *,
+        price: float,
+        trade_time_ms: int | None,
+        sequence: int,
+        initial_batch: bool,
+    ) -> None:
         for trigger in self.spec.manual_alert_triggers:
             if not trigger.get("enabled"):
                 continue
             trigger_id = str(trigger.get("id") or "")
             if not trigger_id or trigger_id in self._manual_alert_trigger_sending_ids:
                 continue
+            gate = self._manual_alert_trigger_gates.get(trigger_id)
+            if gate is None or sequence <= int(gate.get("armed_sequence", 0)):
+                continue
             try:
                 trigger_price = float(trigger.get("price"))
             except (TypeError, ValueError):
                 continue
-            if self._manual_alert_trigger_last_bar_time.get(trigger_id) == bar_time:
+
+            last_trade_time_ms = gate.get("last_trade_time_ms")
+            if (
+                trade_time_ms is not None
+                and last_trade_time_ms is not None
+                and trade_time_ms < int(last_trade_time_ms)
+            ):
                 continue
-            if not self._manual_alert_trigger_touched(bar, prev_price, trigger_price):
+            armed_at_ms = int(gate.get("armed_at_ms", 0))
+            if trade_time_ms is not None and trade_time_ms < armed_at_ms:
+                gate["last_price"] = price
+                gate["last_trade_time_ms"] = trade_time_ms
+                continue
+            if initial_batch and trade_time_ms is None:
+                gate["last_price"] = price
                 continue
 
-            self._manual_alert_trigger_last_bar_time[trigger_id] = bar_time
+            previous_price = gate.get("last_price")
+            gate["last_price"] = price
+            if trade_time_ms is not None:
+                gate["last_trade_time_ms"] = trade_time_ms
+            if not self._manual_alert_trigger_touched(previous_price, price, trigger_price):
+                continue
+
+            event_time = (
+                trade_time_ms // 1000
+                if trade_time_ms is not None
+                else int(time.time())
+            )
             self._manual_alert_trigger_sending_ids.add(trigger_id)
-            asyncio.create_task(self._send_manual_alert_trigger(dict(trigger), trigger_price, market_price, bar_time))
+            asyncio.create_task(
+                self._send_manual_alert_trigger(
+                    dict(trigger),
+                    trigger_price,
+                    price,
+                    event_time,
+                )
+            )
 
     async def dispatch_manual_alert_ai_instruction(
         self,

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -804,6 +804,18 @@ class Session:
                 script_title=self._manual_alert_script_title(),
                 payload=payload,
             )
+            webhook = result.get("webhook") if isinstance(result, dict) else None
+            if isinstance(webhook, dict) and webhook.get("error"):
+                log_with_time(
+                    f"[manual_alert_trigger] webhook failed for {self.spec.id}: "
+                    f"{webhook['error']}"
+                )
+            telegram = result.get("telegram") if isinstance(result, dict) else None
+            if isinstance(telegram, dict) and telegram.get("error"):
+                log_with_time(
+                    f"[manual_alert_trigger] Telegram failed for {self.spec.id}: "
+                    f"{telegram['error']}"
+                )
         except Exception as e:
             log_with_time(
                 f"[manual_alert_trigger] send failed for {self.spec.id} "
@@ -895,6 +907,9 @@ class Session:
     ) -> bool:
         instruction = str(payload.get("ai_instruction") or "").strip()
         if not instruction:
+            return False
+        webhook = delivery_result.get("webhook")
+        if not isinstance(webhook, dict) or not webhook.get("sent"):
             return False
         if len(instruction) > _MAX_AI_INSTRUCTION_CHARS:
             log_with_time(

--- a/data_service/templates/ui.js
+++ b/data_service/templates/ui.js
@@ -687,7 +687,23 @@ App.ui = {
       status.classList.add("error");
       return;
     }
+    const webhook = result.data && result.data.webhook;
     const telegram = result.data && result.data.telegram;
+    if (!webhook || !webhook.sent) {
+      const webhookDetail = String((webhook && webhook.error) || "unknown error").slice(0, 180);
+      if (telegram && telegram.sent) {
+        status.textContent = webhookDetail
+          ? `Webhook failed: ${webhookDetail}; Telegram sent`
+          : "Webhook failed; Telegram sent";
+      } else {
+        const telegramDetail = String((telegram && telegram.error) || "").slice(0, 180);
+        status.textContent = telegramDetail
+          ? `Webhook failed: ${webhookDetail}; Telegram failed: ${telegramDetail}`
+          : `Webhook failed: ${webhookDetail}`;
+      }
+      status.classList.add("error");
+      return;
+    }
     if (telegram && telegram.error) {
       const detail = String(telegram.error || "").slice(0, 180);
       status.textContent = detail ? `Webhook sent; Telegram failed: ${detail}` : "Webhook sent; Telegram failed";


### PR DESCRIPTION
## Summary

- 수동 얼럿 가격 트리거를 확정봉 갱신이 아닌 거래소 raw trade 흐름에서 판정하여 pre-run 부하 중에도 가격 터치를 감지합니다.
- 스트림 초기 배치와 중복 체결을 걸러내고, 트리거 설정 이후 수신된 거래만 순서대로 판정합니다.
- 웹훅 실패가 Telegram 알림을 중단하지 않도록 전송 결과를 분리하고, Telegram 메시지에 웹훅 성공 또는 실패 상태를 표시합니다.
- Manual Alert AI는 기존 안전 조건대로 웹훅 성공 후에만 실행하며, 직접 전송 UI와 README를 변경된 동작에 맞게 갱신합니다.