### PR TITLE
Account Center와 거래 이력 관리 기능 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Run your crypto trading strategy in real time without TradingView.
   signal to exchange in under a second after candle confirmation
 - 📊 Bitget, Hyperliquid, OKX, Binance, and Bybit supported
 - 🔔 Webhook, Telegram, and draggable manual price alerts on the chart
-- 💼 Exchange and account-level asset portfolios with reviewed internal transfers
+- 💼 **Account Center** — assets, live positions, trade history, net PnL,
+  CSV history import, and reviewed internal transfers
 - 📱 Full mobile dashboard
 
 ## 🤖 AI Copilot
@@ -142,7 +143,7 @@ pynereal/
 |   |   |-- sessions.json            Runtime session state saved by dashboard
 |   |   `-- providers.toml           Provider credentials, e.g. ccxt API keys
 |   |-- data/                        OHLCV files and per-symbol metadata
-|   |   `-- cache/                   SQLite OHLCV cache
+|   |   `-- cache/                   SQLite OHLCV and account-history caches
 |   `-- output/realtime/             Per-session logs, plots, script hashes
 |-- demo_webhook_server.py           Optional local webhook receiver
 `-- setup.sh                         Local environment setup helper
@@ -364,26 +365,60 @@ values:
 {"signal":"CLOSE TP3","ticker":"{{ticker}}","timeframe":"{{timeframe}}"}
 ```
 
-## Assets and Internal Transfers
+## Account Center
 
-Open the Hub menu beside the PyneReal Hub title and select **Assets** to view the
-combined value of every configured exchange account. The list shows totals by
-exchange and account; select an account to open a donut chart with its asset and
-account-type breakdown, including supported spot, futures, margin, funding, and
-earn balances.
+Open the Hub menu beside the PyneReal Hub title and expand **Account**. Account
+Center combines every exchange account configured in
+`workdir/config/providers.toml`:
 
-Select a non-zero account type to open **Internal transfer**. Available routes
-depend on the exchange and account configuration. PyneReal supports transfers
-between the exchange's internal wallets, flexible Earn redemption where
+- **Assets** shows totals by exchange and account. Select an account to open a
+  donut chart with its asset and account-type breakdown, including supported
+  spot, futures, margin, funding, and earn balances.
+- **Positions** shows current derivative positions with mark price, unrealized
+  and realized PnL, return, leverage, margin mode, and liquidation price. Live
+  exchange streams update supported values, with periodic REST reconciliation.
+- **PnL** groups account results by exchange for `7D`, `30D`, `90D`, `6M`, `1Y`,
+  or all locally available history. Net realized PnL includes available trading
+  fees and funding; the UI marks incomplete breakdowns when an exchange source
+  does not expose every component.
+- **History** provides exchange- and symbol-grouped Position History and Order
+  History with manual refresh and local pagination.
+
+Recent account history is collected in the background and stored locally in
+`workdir/data/cache/account_cache.sqlite`. The initial API backfill targets the
+latest 90 days where the exchange permits it. Subsequent collections resume
+from overlapping cursors so restarts do not require rebuilding the full cache.
+
+### Import History
+
+Use **Account > History > Import History** to merge older exchange exports into
+Position History, Order History, and PnL. Re-importing the same file is allowed,
+and imported CSV records take precedence when they provide a more complete
+canonical record. Recommended exports are:
+
+- **Binance:** Position History, Order History, Trade History, and Transaction
+  History
+- **Bitget:** Futures Position History and Futures Order History
+- **OKX:** Position History, Order History, and Trade Details
+- **Hyperliquid:** Trade History and Funding History; historical orders are
+  completed through the Hyperliquid API during import
+
+Bybit accounts remain available in Account Center through supported exchange
+APIs, but **Bybit CSV import is not supported yet**.
+
+### Internal Transfers
+
+From **Assets**, select a non-zero account type to open **Internal transfer**.
+Available routes depend on the exchange and account configuration. PyneReal
+supports transfers between internal wallets, flexible Earn redemption where
 available, and main/sub-account transfers where the exchange API permits them.
 Every transfer is shown on a review screen and requires explicit confirmation.
 This feature does not perform blockchain withdrawals.
 
-Asset access uses credentials from `workdir/config/providers.toml`. Keep API
-keys read-only when only portfolio viewing is needed. If internal transfers are
-required, grant only the minimum account and transfer permissions for the
-intended routes; withdrawal permission is not required and should remain
-disabled.
+Keep API keys read-only when only portfolio viewing is needed. If internal
+transfers are required, grant only the minimum account and transfer permissions
+for the intended routes; withdrawal permission is not required and should
+remain disabled.
 
 ## Session Calendar
 

--- a/account_service/__init__.py
+++ b/account_service/__init__.py
@@ -1,0 +1,1 @@
+"""Account data collectors isolated from the strategy runtime."""

--- a/account_service/backfill.py
+++ b/account_service/backfill.py
@@ -1,0 +1,1446 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import math
+import sys
+import time
+import tomllib
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Iterator
+
+import ccxt
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_AI_SCRIPTS = _PROJECT_ROOT / "ai" / "scripts"
+if str(_AI_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_AI_SCRIPTS))
+
+from asset import redact_error, secret_values, utc_now  # noqa: E402
+
+from account_service.history import (  # noqa: E402
+    bitget_history_item_matches_scope,
+    bitget_position_matches_scope,
+    normalize_fill,
+    normalize_order,
+)
+from data_service.schedule_utils import (  # noqa: E402
+    seconds_until_manual_refresh_guard_end,
+    seconds_until_post_bar_task_window,
+)
+
+
+INITIAL_HISTORY_DAYS = 90
+CURSOR_OVERLAP_SECONDS = 24 * 60 * 60
+BACKFILL_INTERVAL_SECONDS = 30 * 60
+MAX_PAGINATION_CALLS = 5
+MAX_HISTORY_RECORDS = 1000
+BITGET_SPOT_ORDER_PAGE_LIMIT = 100
+BINANCE_HISTORY_WINDOW_SAFETY_MS = 5 * 60 * 1000
+BINANCE_ORDER_CURSOR_STREAM = "orders_90d"
+OKX_ARCHIVE_PAGINATION_CALLS = 10
+OKX_ORDER_CURSOR_STREAM = "orders_archive"
+POSITION_PAGE_LIMIT = 100
+POSITION_MIN_WINDOW_MS = 60 * 60 * 1000
+_MANUAL_REFRESH_TIMING: ContextVar[bool] = ContextVar(
+    "account_manual_refresh_timing",
+    default=False,
+)
+
+
+@contextmanager
+def manual_history_refresh_timing() -> Iterator[None]:
+    token = _MANUAL_REFRESH_TIMING.set(True)
+    try:
+        yield
+    finally:
+        _MANUAL_REFRESH_TIMING.reset(token)
+
+
+@dataclass(frozen=True)
+class HistoryScope:
+    name: str
+    params: dict[str, Any]
+    position_params: dict[str, Any] | None = None
+    requires_symbols: bool = False
+
+
+def _history_scopes(exchange_id: str, config: dict[str, Any]) -> list[HistoryScope]:
+    if exchange_id == "binance":
+        return [
+            HistoryScope("spot", {"type": "spot"}, requires_symbols=True),
+            HistoryScope(
+                "usd_m",
+                {"type": "future", "subType": "linear"},
+                requires_symbols=True,
+            ),
+            HistoryScope(
+                "coin_m",
+                {"type": "delivery", "subType": "inverse"},
+                requires_symbols=True,
+            ),
+        ]
+    if exchange_id == "bitget":
+        options = config.get("options")
+        options = options if isinstance(options, dict) else {}
+        uta = bool(config.get("uta") or options.get("uta"))
+        if uta:
+            return [HistoryScope("uta", {"uta": True}, {"uta": True})]
+        return [
+            HistoryScope("spot", {"type": "spot"}),
+            HistoryScope(
+                "USDT-FUTURES",
+                {
+                    "type": "swap",
+                    "subType": "linear",
+                    "productType": "USDT-FUTURES",
+                },
+                {"productType": "USDT-FUTURES"},
+            ),
+            HistoryScope(
+                "USDC-FUTURES",
+                {
+                    "type": "swap",
+                    "subType": "linear",
+                    "productType": "USDC-FUTURES",
+                },
+                {"productType": "USDC-FUTURES"},
+            ),
+            HistoryScope(
+                "COIN-FUTURES",
+                {
+                    "type": "swap",
+                    "subType": "inverse",
+                    "productType": "COIN-FUTURES",
+                },
+                {"productType": "COIN-FUTURES"},
+            ),
+        ]
+    if exchange_id == "okx":
+        return [
+            HistoryScope("spot", {"type": "spot"}),
+            HistoryScope(
+                "swap",
+                {"type": "swap"},
+                {"instType": "SWAP"},
+            ),
+            HistoryScope(
+                "futures",
+                {"type": "future"},
+                {"instType": "FUTURES"},
+            ),
+        ]
+    if exchange_id == "bybit":
+        return [
+            HistoryScope("spot", {"type": "spot"}),
+            HistoryScope(
+                "linear",
+                {"type": "swap", "subType": "linear"},
+                {"subType": "linear"},
+            ),
+            HistoryScope(
+                "inverse",
+                {"type": "swap", "subType": "inverse"},
+                {"subType": "inverse"},
+            ),
+        ]
+    if exchange_id == "hyperliquid":
+        return [HistoryScope("default", {})]
+    return [HistoryScope("default", {})]
+
+
+def _hyperliquid_dex(symbol: str) -> str | None:
+    base = symbol.split("/", 1)[0].strip()
+    if "-" not in base:
+        return None
+    prefix = base.split("-", 1)[0].strip().lower()
+    return prefix or None
+
+
+def hyperliquid_dexes(symbols: set[str]) -> list[str]:
+    return sorted({dex for symbol in symbols if (dex := _hyperliquid_dex(symbol))})
+
+
+def configured_session_symbols(config_path: str, exchange_id: str) -> set[str]:
+    config_dir = Path(config_path).resolve().parent
+    symbols: set[str] = set()
+
+    def add_sessions(sessions: Any) -> None:
+        if not isinstance(sessions, list):
+            return
+        for session in sessions:
+            if not isinstance(session, dict):
+                continue
+            if str(session.get("exchange") or "").lower() != exchange_id:
+                continue
+            symbol = str(session.get("symbol") or "").strip().upper()
+            if symbol:
+                symbols.add(symbol)
+
+    sessions_path = config_dir / "sessions.json"
+    try:
+        payload = json.loads(sessions_path.read_text(encoding="utf-8"))
+        add_sessions(payload.get("sessions", []) if isinstance(payload, dict) else [])
+    except (FileNotFoundError, OSError, ValueError, json.JSONDecodeError):
+        pass
+    if symbols:
+        return symbols
+
+    realtime_path = config_dir / "realtime_trade.toml"
+    try:
+        with realtime_path.open("rb") as handle:
+            payload = tomllib.load(handle)
+        add_sessions(payload.get("session", []))
+        realtime = payload.get("realtime")
+        if isinstance(realtime, dict):
+            add_sessions([realtime])
+    except (FileNotFoundError, OSError, ValueError, tomllib.TOMLDecodeError):
+        pass
+    return symbols
+
+
+def account_history_symbols(
+    config_path: str,
+    exchange_id: str,
+    current_positions: list[dict[str, Any]],
+    cached_symbols: set[str],
+) -> set[str]:
+    symbols = configured_session_symbols(config_path, exchange_id)
+    symbols.update(str(symbol).upper() for symbol in cached_symbols if symbol)
+    symbols.update(
+        str(position.get("symbol") or "").strip().upper()
+        for position in current_positions
+        if isinstance(position, dict) and position.get("symbol")
+    )
+    return {symbol for symbol in symbols if symbol}
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _integer(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _iso_timestamp(value: int | None) -> str | None:
+    if value is None:
+        return None
+    try:
+        return datetime.fromtimestamp(value / 1000.0, UTC).isoformat().replace(
+            "+00:00",
+            "Z",
+        )
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
+def _first_integer(source: dict[str, Any], keys: tuple[str, ...]) -> int | None:
+    for key in keys:
+        value = _integer(source.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _first_number(source: dict[str, Any], keys: tuple[str, ...]) -> float | None:
+    for key in keys:
+        value = _number(source.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _position_pnl_breakdown(
+    exchange_id: str,
+    position: dict[str, Any],
+) -> tuple[float | None, dict[str, Any] | None]:
+    info = position.get("info")
+    info = info if isinstance(info, dict) else {}
+    net = _number(position.get("realizedPnl"))
+    gross = None
+    if exchange_id == "bitget":
+        gross = _first_number(info, ("pnl", "cumRealisedPnl"))
+        native_net = _first_number(info, ("netProfit",))
+        if native_net is not None:
+            net = native_net
+    elif exchange_id == "okx":
+        gross = _first_number(info, ("pnl",))
+        native_net = _first_number(info, ("realizedPnl",))
+        if native_net is not None:
+            net = native_net
+    elif exchange_id == "bybit":
+        native_net = _first_number(info, ("closedPnl",))
+        if native_net is not None:
+            net = native_net
+    if net is None:
+        return None, None
+    if gross is None:
+        return net, {
+            "gross_pnl": None,
+            "fees": None,
+            "net_pnl": net,
+            "currency": None,
+            "complete": False,
+        }
+    return net, {
+        "gross_pnl": gross,
+        "fees": gross - net,
+        "net_pnl": net,
+        "currency": None,
+        "complete": True,
+    }
+
+
+def normalize_historical_position(
+    account_name: str,
+    exchange_id: str,
+    market_scope: str,
+    position: dict[str, Any],
+) -> dict[str, Any] | None:
+    info = position.get("info")
+    info = info if isinstance(info, dict) else {}
+    symbol = str(position.get("symbol") or "").strip()
+    side = str(position.get("side") or "").strip().lower()
+    if not symbol:
+        return None
+
+    opened_ms = _integer(position.get("timestamp"))
+    closed_ms = _integer(position.get("lastUpdateTimestamp"))
+    if closed_ms is None:
+        closed_ms = _first_integer(
+            info,
+            ("updatedTime", "updatedAt", "utime", "uTime", "closeTime"),
+        )
+    opened_known = exchange_id != "bybit" and opened_ms is not None
+    if closed_ms is None:
+        return None
+    if opened_ms is None or not opened_known:
+        opened_ms = closed_ms
+    opened_at = _iso_timestamp(opened_ms)
+    closed_at = _iso_timestamp(closed_ms)
+    if opened_at is None or closed_at is None:
+        return None
+
+    contracts = _number(position.get("contracts"))
+    contract_size = _number(position.get("contractSize"))
+    quantity = contracts
+    if contracts is not None and contract_size is not None:
+        quantity = contracts * contract_size
+    realized_pnl, realized_breakdown = _position_pnl_breakdown(
+        exchange_id,
+        position,
+    )
+    native_id = str(position.get("id") or "").strip()
+    if not native_id:
+        native_id = str(
+            _first_integer(
+                info,
+                ("positionId", "posId", "orderId"),
+            )
+            or ""
+        )
+    identity = [
+        account_name,
+        exchange_id,
+        market_scope,
+        native_id,
+        symbol,
+        side,
+        opened_at,
+        closed_at,
+        position.get("entryPrice"),
+        position.get("lastPrice"),
+        contracts,
+    ]
+    digest = hashlib.sha256(
+        json.dumps(identity, ensure_ascii=True, default=str).encode("utf-8")
+    ).hexdigest()[:24]
+    payload = {
+        "symbol": symbol,
+        "side": side,
+        "quantity": quantity,
+        "contracts": contracts,
+        "contract_size": contract_size,
+        "entry_price": _number(position.get("entryPrice")),
+        "exit_price": _number(position.get("lastPrice")),
+        "realized_pnl": realized_pnl,
+        "realized_pnl_breakdown": realized_breakdown,
+        "leverage": _number(position.get("leverage")),
+        "margin_mode": position.get("marginMode"),
+        "opened_at_known": opened_known,
+        "native_id": native_id or None,
+    }
+    return {
+        "account": account_name,
+        "exchange": exchange_id,
+        "market_scope": market_scope,
+        "position_key": f"native:{digest}",
+        "opened_at": opened_at,
+        "closed_at": closed_at,
+        "source": "native",
+        "payload": payload,
+    }
+
+
+def _cursor_key(
+    account_name: str,
+    exchange_id: str,
+    stream: str,
+    scope_name: str,
+) -> tuple[str, str, str, str]:
+    return account_name, exchange_id, stream, scope_name
+
+
+def _cursor_since(
+    cursors: dict[tuple[str, str, str, str], str],
+    key: tuple[str, str, str, str],
+    now_ms: int,
+) -> int:
+    initial = now_ms - INITIAL_HISTORY_DAYS * 86_400_000
+    try:
+        previous = int(cursors.get(key, ""))
+    except (TypeError, ValueError):
+        return initial
+    return max(initial, previous - CURSOR_OVERLAP_SECONDS * 1000)
+
+
+def _initial_history_since(exchange_id: str, now_ms: int) -> int:
+    since = now_ms - INITIAL_HISTORY_DAYS * 86_400_000
+    if exchange_id == "binance":
+        since += BINANCE_HISTORY_WINDOW_SAFETY_MS
+    return since
+
+
+def _history_since(
+    exchange_id: str,
+    cursors: dict[tuple[str, str, str, str], str],
+    key: tuple[str, str, str, str],
+    now_ms: int,
+) -> int:
+    return max(
+        _cursor_since(cursors, key, now_ms),
+        _initial_history_since(exchange_id, now_ms),
+    )
+
+
+def _cursor_record(
+    account_name: str,
+    exchange_id: str,
+    stream: str,
+    scope_name: str,
+    cursor: int,
+) -> dict[str, Any]:
+    return {
+        "account": account_name,
+        "exchange": exchange_id,
+        "stream": stream,
+        "market_scope": scope_name,
+        "cursor": str(cursor),
+        "updated_at": utc_now(),
+    }
+
+
+def _scope_symbols(
+    exchange: Any,
+    exchange_id: str,
+    scope: HistoryScope,
+    known_symbols: set[str],
+    target_symbol: str | None = None,
+) -> list[str | None]:
+    if target_symbol:
+        market = exchange.markets.get(target_symbol)
+        if not isinstance(market, dict):
+            return []
+        if scope.name == "spot":
+            matches = bool(market.get("spot"))
+        elif scope.name == "usd_m":
+            matches = bool(market.get("contract") and market.get("linear"))
+        elif scope.name == "coin_m":
+            matches = bool(market.get("contract") and market.get("inverse"))
+        elif scope.name == "USDT-FUTURES":
+            matches = bool(
+                market.get("swap")
+                and market.get("linear")
+                and str(market.get("settle") or "").upper() == "USDT"
+            )
+        elif scope.name == "USDC-FUTURES":
+            matches = bool(
+                market.get("swap")
+                and market.get("linear")
+                and str(market.get("settle") or "").upper() == "USDC"
+            )
+        elif scope.name == "COIN-FUTURES":
+            matches = bool(market.get("swap") and market.get("inverse"))
+        elif scope.name == "swap":
+            matches = bool(market.get("swap"))
+        elif scope.name == "futures":
+            matches = bool(market.get("future"))
+        elif scope.name == "linear":
+            matches = bool(market.get("contract") and market.get("linear"))
+        elif scope.name == "inverse":
+            matches = bool(market.get("contract") and market.get("inverse"))
+        else:
+            matches = True
+        return [target_symbol] if matches else []
+
+    if exchange_id == "hyperliquid":
+        if scope.name == "default":
+            return [None]
+        matches = [
+            symbol for symbol in known_symbols if _hyperliquid_dex(symbol) == scope.name
+        ]
+        return [matches[0]] if matches else []
+    if not scope.requires_symbols:
+        return [None]
+    matched: list[str] = []
+    for symbol in sorted(known_symbols):
+        market = exchange.markets.get(symbol)
+        if not isinstance(market, dict):
+            continue
+        if scope.name == "spot" and market.get("spot"):
+            matched.append(symbol)
+        elif scope.name == "usd_m" and market.get("linear") and market.get("contract"):
+            matched.append(symbol)
+        elif scope.name == "coin_m" and market.get("inverse") and market.get("contract"):
+            matched.append(symbol)
+    return matched
+
+
+async def _wait_for_history_slot(stop: asyncio.Event) -> None:
+    delay = (
+        seconds_until_manual_refresh_guard_end()
+        if _MANUAL_REFRESH_TIMING.get()
+        else seconds_until_post_bar_task_window()
+    )
+    if delay <= 0.0:
+        return
+    try:
+        await asyncio.wait_for(stop.wait(), timeout=delay)
+    except TimeoutError:
+        return
+    raise asyncio.CancelledError
+
+
+async def _fetch_with_retry(
+    exchange: Any,
+    account: Any,
+    label: str,
+    callback: Any,
+    stop: asyncio.Event,
+) -> list[dict[str, Any]]:
+    for attempt in range(1, 3):
+        await _wait_for_history_slot(stop)
+        try:
+            result = await callback()
+            if not isinstance(result, list):
+                raise TypeError(f"{label} returned a non-list result")
+            return [item for item in result if isinstance(item, dict)]
+        except asyncio.CancelledError:
+            raise
+        except (
+            ccxt.ArgumentsRequired,
+            ccxt.AuthenticationError,
+            ccxt.BadRequest,
+            ccxt.NotSupported,
+            ccxt.PermissionDenied,
+        ):
+            raise
+        except Exception:
+            if attempt >= 2:
+                raise
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=1.0)
+                raise asyncio.CancelledError
+            except TimeoutError:
+                pass
+    raise RuntimeError(f"{label} retry loop ended unexpectedly")
+
+
+def _rest_record(
+    account: Any,
+    market_scope: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "account": account.name,
+        "exchange": account.exchange_id,
+        "market_scope": market_scope,
+        "source": "rest",
+        "payload": payload,
+    }
+
+
+def _binance_unified_symbol(
+    exchange: Any,
+    raw_symbol: str,
+    market_scope: str,
+) -> str | None:
+    candidates = exchange.markets_by_id.get(raw_symbol.upper())
+    if isinstance(candidates, dict):
+        candidates = [candidates]
+    if not isinstance(candidates, list):
+        return None
+    for market in candidates:
+        if not isinstance(market, dict) or not market.get("contract"):
+            continue
+        if market_scope == "usd_m" and not market.get("linear"):
+            continue
+        if market_scope == "coin_m" and not market.get("inverse"):
+            continue
+        symbol = str(market.get("symbol") or "").strip()
+        if symbol:
+            return symbol
+    return None
+
+
+def _oldest_numeric_id(rows: list[dict[str, Any]]) -> str | None:
+    identifiers: list[tuple[int, str]] = []
+    for row in rows:
+        value = str(row.get("id") or "").strip()
+        if not value:
+            continue
+        try:
+            identifiers.append((int(value), value))
+        except ValueError:
+            continue
+    return min(identifiers)[1] if identifiers else None
+
+
+async def _fetch_bitget_spot_orders(
+    exchange: Any,
+    account: Any,
+    symbol: str | None,
+    since: int,
+    stop: asyncio.Event,
+) -> list[dict[str, Any]]:
+    method = getattr(exchange, "fetch_canceled_and_closed_orders", None)
+    if not callable(method):
+        raise ccxt.NotSupported("bitget does not expose spot order history")
+
+    orders: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    cursor: str | None = None
+    for page_number in range(1, MAX_PAGINATION_CALLS + 1):
+        params: dict[str, Any] = {
+            "type": "spot",
+            "paginate": False,
+        }
+        if cursor is not None:
+            params["idLessThan"] = cursor
+        page = await _fetch_with_retry(
+            exchange,
+            account,
+            f"spot orders page {page_number}",
+            lambda params=params: method(
+                symbol,
+                since,
+                BITGET_SPOT_ORDER_PAGE_LIMIT,
+                dict(params),
+            ),
+            stop,
+        )
+        if not page:
+            break
+        for order in page:
+            order_id = str(order.get("id") or "").strip()
+            if order_id and order_id in seen_ids:
+                continue
+            if order_id:
+                seen_ids.add(order_id)
+            orders.append(order)
+
+        next_cursor = _oldest_numeric_id(page)
+        if (
+            len(page) < BITGET_SPOT_ORDER_PAGE_LIMIT
+            or next_cursor is None
+            or next_cursor == cursor
+        ):
+            break
+        cursor = next_cursor
+    return orders
+
+
+async def _discover_binance_history_symbols(
+    exchange: Any,
+    account: Any,
+    market_scope: str,
+    since: int,
+    now_ms: int,
+    stop: asyncio.Event,
+) -> set[str]:
+    if market_scope == "coin_m":
+        method = exchange.dapiPrivateGetIncome
+    else:
+        method = exchange.fapiPrivateGetIncome
+    raw_symbols: set[str] = set()
+    window_start = since
+    for _ in range(MAX_PAGINATION_CALLS):
+        rows = await _fetch_with_retry(
+            exchange,
+            account,
+            f"{market_scope} realized PnL symbols",
+            lambda window_start=window_start: method({
+                "incomeType": "REALIZED_PNL",
+                "startTime": window_start,
+                "endTime": now_ms,
+                "limit": 1000,
+            }),
+            stop,
+        )
+        timestamps: list[int] = []
+        for row in rows:
+            raw_symbol = str(row.get("symbol") or "").strip().upper()
+            if raw_symbol:
+                raw_symbols.add(raw_symbol)
+            timestamp = _integer(row.get("time"))
+            if timestamp is not None:
+                timestamps.append(timestamp)
+        if len(rows) < 1000 or not timestamps:
+            break
+        next_start = max(timestamps) + 1
+        if next_start <= window_start:
+            break
+        window_start = next_start
+    return {
+        symbol
+        for raw_symbol in raw_symbols
+        if (
+            symbol := _binance_unified_symbol(
+                exchange,
+                raw_symbol,
+                market_scope,
+            )
+        )
+    }
+
+
+async def _fetch_orders(
+    exchange: Any,
+    account: Any,
+    scope: HistoryScope,
+    symbols: list[str | None],
+    since: int,
+    stop: asyncio.Event,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    historical_supported = False
+    params = {
+        **scope.params,
+        "paginate": True,
+        "paginationCalls": (
+            OKX_ARCHIVE_PAGINATION_CALLS
+            if account.exchange_id == "okx"
+            else MAX_PAGINATION_CALLS
+        ),
+    }
+    if account.exchange_id == "okx":
+        params["method"] = "privateGetTradeOrdersHistoryArchive"
+    for symbol in symbols:
+        raw_orders: list[dict[str, Any]] = []
+        if account.exchange_id == "bitget" and scope.name == "spot":
+            historical_supported = True
+            raw_orders.extend(await _fetch_bitget_spot_orders(
+                exchange,
+                account,
+                symbol,
+                since,
+                stop,
+            ))
+        elif exchange.has.get("fetchOrders"):
+            historical_supported = True
+            raw_orders.extend(await _fetch_with_retry(
+                exchange,
+                account,
+                f"{scope.name} orders",
+                lambda symbol=symbol: exchange.fetch_orders(
+                    symbol,
+                    since,
+                    MAX_HISTORY_RECORDS,
+                    dict(params),
+                ),
+                stop,
+            ))
+        else:
+            for capability, method_name in (
+                ("fetchClosedOrders", "fetch_closed_orders"),
+            ):
+                if not exchange.has.get(capability):
+                    continue
+                historical_supported = True
+                method = getattr(exchange, method_name)
+                raw_orders.extend(await _fetch_with_retry(
+                    exchange,
+                    account,
+                    f"{scope.name} {method_name}",
+                    lambda method=method, symbol=symbol: method(
+                        symbol,
+                        since,
+                        MAX_HISTORY_RECORDS,
+                        dict(params),
+                    ),
+                    stop,
+                ))
+            if (
+                account.exchange_id in {"bitget", "bybit", "okx"}
+                and exchange.has.get("fetchCanceledOrders")
+            ):
+                try:
+                    raw_orders.extend(await _fetch_with_retry(
+                        exchange,
+                        account,
+                        f"{scope.name} fetch_canceled_orders",
+                        lambda symbol=symbol: exchange.fetch_canceled_orders(
+                            symbol,
+                            since,
+                            MAX_HISTORY_RECORDS,
+                            dict(params),
+                        ),
+                        stop,
+                    ))
+                except (
+                    ccxt.ArgumentsRequired,
+                    ccxt.BadRequest,
+                    ccxt.NotSupported,
+                ):
+                    pass
+        for order in raw_orders:
+            normalized = normalize_order(order)
+            if (
+                account.exchange_id == "bitget"
+                and not bitget_history_item_matches_scope(
+                    normalized,
+                    scope.name,
+                )
+            ):
+                continue
+            records.append(_rest_record(account, scope.name, normalized))
+    if not historical_supported:
+        raise ccxt.NotSupported(
+            f"{account.exchange_id} does not expose order history"
+        )
+    return records
+
+
+def _stream_windows(
+    exchange_id: str,
+    since: int,
+    now_ms: int,
+) -> list[tuple[int, int | None]]:
+    if exchange_id not in {"binance", "bybit"}:
+        return [(since, None)]
+    windows: list[tuple[int, int | None]] = []
+    window_start = since
+    window_size = 7 * 86_400_000
+    while window_start < now_ms:
+        window_end = min(window_start + window_size, now_ms)
+        windows.append((window_start, window_end))
+        window_start = window_end + 1
+    return windows
+
+
+def _scope_until(scope: HistoryScope, until: int | None) -> HistoryScope:
+    if until is None:
+        return scope
+    return HistoryScope(
+        scope.name,
+        {**scope.params, "until": until},
+        scope.position_params,
+        scope.requires_symbols,
+    )
+
+
+async def _fetch_orders_since(
+    exchange: Any,
+    account: Any,
+    scope: HistoryScope,
+    symbols: list[str | None],
+    since: int,
+    now_ms: int,
+    stop: asyncio.Event,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for window_start, window_end in _stream_windows(
+        account.exchange_id,
+        since,
+        now_ms,
+    ):
+        records.extend(await _fetch_orders(
+            exchange,
+            account,
+            _scope_until(scope, window_end),
+            symbols,
+            window_start,
+            stop,
+        ))
+    return records
+
+
+async def _fetch_fills_since(
+    exchange: Any,
+    account: Any,
+    scope: HistoryScope,
+    symbols: list[str | None],
+    since: int,
+    now_ms: int,
+    stop: asyncio.Event,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for window_start, window_end in _stream_windows(
+        account.exchange_id,
+        since,
+        now_ms,
+    ):
+        records.extend(await _fetch_fills(
+            exchange,
+            account,
+            _scope_until(scope, window_end),
+            symbols,
+            window_start,
+            stop,
+        ))
+    return records
+
+
+async def _fetch_fills(
+    exchange: Any,
+    account: Any,
+    scope: HistoryScope,
+    symbols: list[str | None],
+    since: int,
+    stop: asyncio.Event,
+) -> list[dict[str, Any]]:
+    if not exchange.has.get("fetchMyTrades"):
+        raise ccxt.NotSupported(
+            f"{account.exchange_id} does not expose trade history"
+        )
+    params = {
+        **scope.params,
+        "paginate": True,
+        "paginationCalls": MAX_PAGINATION_CALLS,
+    }
+    records: list[dict[str, Any]] = []
+    for symbol in symbols:
+        trades = await _fetch_with_retry(
+            exchange,
+            account,
+            f"{scope.name} fills",
+            lambda symbol=symbol: exchange.fetch_my_trades(
+                symbol,
+                since,
+                MAX_HISTORY_RECORDS,
+                dict(params),
+            ),
+            stop,
+        )
+        for trade in trades:
+            normalized = normalize_fill(trade)
+            if (
+                account.exchange_id == "bitget"
+                and not bitget_history_item_matches_scope(
+                    normalized,
+                    scope.name,
+                )
+            ):
+                continue
+            records.append(_rest_record(account, scope.name, normalized))
+    return records
+
+
+def _position_closed_ms(position: dict[str, Any]) -> int | None:
+    value = _integer(position.get("lastUpdateTimestamp"))
+    if value is not None:
+        return value
+    info = position.get("info")
+    info = info if isinstance(info, dict) else {}
+    return _first_integer(
+        info,
+        ("updatedTime", "updatedAt", "utime", "uTime", "closeTime"),
+    )
+
+
+async def _fetch_position_window(
+    exchange: Any,
+    account: Any,
+    scope: HistoryScope,
+    since: int,
+    until: int,
+    stop: asyncio.Event,
+    symbol: str | None = None,
+) -> list[dict[str, Any]]:
+    params = {**(scope.position_params or {}), "until": until}
+    rows = await _fetch_with_retry(
+        exchange,
+        account,
+        f"{scope.name} position history",
+        lambda: exchange.fetch_positions_history(
+            symbol,
+            since,
+            POSITION_PAGE_LIMIT,
+            params,
+        ),
+        stop,
+    )
+    if len(rows) < POSITION_PAGE_LIMIT or until - since <= POSITION_MIN_WINDOW_MS:
+        return rows
+    midpoint = since + (until - since) // 2
+    left = await _fetch_position_window(
+        exchange,
+        account,
+        scope,
+        since,
+        midpoint,
+        stop,
+        symbol,
+    )
+    right = await _fetch_position_window(
+        exchange,
+        account,
+        scope,
+        midpoint + 1,
+        until,
+        stop,
+        symbol,
+    )
+    return [*left, *right]
+
+
+async def _fetch_okx_position_pages(
+    exchange: Any,
+    account: Any,
+    scope: HistoryScope,
+    since: int,
+    stop: asyncio.Event,
+    symbol: str | None = None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    after: int | None = None
+    for _ in range(MAX_PAGINATION_CALLS):
+        params = dict(scope.position_params or {})
+        if after is not None:
+            params["after"] = str(after)
+        page = await _fetch_with_retry(
+            exchange,
+            account,
+            f"{scope.name} position history",
+            lambda params=params: exchange.fetch_positions_history(
+                symbol,
+                None,
+                POSITION_PAGE_LIMIT,
+                params,
+            ),
+            stop,
+        )
+        rows.extend(page)
+        timestamps = [
+            timestamp
+            for position in page
+            if (timestamp := _position_closed_ms(position)) is not None
+        ]
+        if len(page) < POSITION_PAGE_LIMIT or not timestamps:
+            break
+        oldest = min(timestamps)
+        if oldest <= since or oldest == after:
+            break
+        after = oldest
+    return [
+        position
+        for position in rows
+        if (_position_closed_ms(position) or 0) >= since
+    ]
+
+
+async def _fetch_positions(
+    exchange: Any,
+    account: Any,
+    scope: HistoryScope,
+    since: int,
+    now_ms: int,
+    stop: asyncio.Event,
+    symbol: str | None = None,
+) -> list[dict[str, Any]]:
+    if scope.position_params is None or not exchange.has.get("fetchPositionsHistory"):
+        return []
+    if account.exchange_id == "okx":
+        raw_positions = await _fetch_okx_position_pages(
+            exchange,
+            account,
+            scope,
+            since,
+            stop,
+            symbol,
+        )
+    else:
+        max_window = 7 * 86_400_000 if account.exchange_id == "bybit" else 90 * 86_400_000
+        raw_positions = []
+        window_start = since
+        while window_start < now_ms:
+            window_end = min(window_start + max_window, now_ms)
+            raw_positions.extend(await _fetch_position_window(
+                exchange,
+                account,
+                scope,
+                window_start,
+                window_end,
+                stop,
+                symbol,
+            ))
+            window_start = window_end + 1
+    records = [
+        normalized
+        for position in raw_positions
+        if (
+            account.exchange_id != "bitget"
+            or bitget_position_matches_scope(position, scope.name)
+        )
+        if (
+            normalized := normalize_historical_position(
+                account.name,
+                account.exchange_id,
+                scope.name,
+                position,
+            )
+        ) is not None
+    ]
+    return list({record["position_key"]: record for record in records}.values())
+
+
+async def backfill_account_once(
+    exchange: Any,
+    account: Any,
+    known_symbols: set[str],
+    cursors: dict[tuple[str, str, str, str], str],
+    stop: asyncio.Event,
+    *,
+    include_orders: bool = True,
+    include_fills: bool = True,
+    include_positions: bool = True,
+    target_symbol: str | None = None,
+    discover_symbols: bool = True,
+) -> dict[str, list[dict[str, Any]]]:
+    now_ms = int(time.time() * 1000)
+    orders: list[dict[str, Any]] = []
+    fills: list[dict[str, Any]] = []
+    positions: list[dict[str, Any]] = []
+    cursor_records: list[dict[str, Any]] = []
+    scopes = _history_scopes(account.exchange_id, account.config)
+    discovered_symbols: dict[str, set[str]] = {}
+    full_history_scopes: set[str] = set()
+    pending_discovery_keys: dict[str, tuple[str, str, str, str]] = {}
+    if account.exchange_id == "binance" and discover_symbols:
+        for market_scope in ("usd_m", "coin_m"):
+            discovery_key = _cursor_key(
+                account.name,
+                account.exchange_id,
+                "symbols",
+                market_scope,
+            )
+            initial_discovery = discovery_key not in cursors
+            discovery_since = _history_since(
+                account.exchange_id,
+                cursors,
+                discovery_key,
+                now_ms,
+            )
+            try:
+                discovered_symbols[market_scope] = (
+                    await _discover_binance_history_symbols(
+                        exchange,
+                        account,
+                        market_scope,
+                        discovery_since,
+                        now_ms,
+                        stop,
+                    )
+                )
+                if initial_discovery:
+                    full_history_scopes.add(market_scope)
+                pending_discovery_keys[market_scope] = discovery_key
+            except (ccxt.ArgumentsRequired, ccxt.BadRequest, ccxt.NotSupported):
+                pass
+            except Exception as exc:
+                print(
+                    f"[account] {account.name} {market_scope} symbol discovery "
+                    f"failed: {type(exc).__name__}: "
+                    f"{redact_error(exc, secret_values(account.config))}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+    secrets = secret_values(account.config)
+    for scope in scopes:
+        scope_symbols = set(known_symbols)
+        scope_symbols.update(discovered_symbols.get(scope.name, set()))
+        symbols = _scope_symbols(
+            exchange,
+            account.exchange_id,
+            scope,
+            scope_symbols,
+            target_symbol,
+        )
+        if not symbols:
+            if scope.name in pending_discovery_keys:
+                discovery_key = pending_discovery_keys[scope.name]
+                cursors[discovery_key] = str(now_ms)
+                cursor_records.append(_cursor_record(
+                    account.name,
+                    account.exchange_id,
+                    "symbols",
+                    scope.name,
+                    now_ms,
+                ))
+            continue
+        scope_key = scope.name
+        if scope.requires_symbols:
+            symbol_targets = symbols
+        else:
+            symbol_targets = symbols[:1]
+
+        order_stream = (
+            OKX_ORDER_CURSOR_STREAM
+            if account.exchange_id == "okx"
+            else (
+                BINANCE_ORDER_CURSOR_STREAM
+                if account.exchange_id == "binance"
+                else "orders"
+            )
+        )
+        order_key = _cursor_key(
+            account.name,
+            account.exchange_id,
+            order_stream,
+            scope_key,
+        )
+        order_since = (
+            _initial_history_since(account.exchange_id, now_ms)
+            if scope.name in full_history_scopes
+            else _history_since(
+                account.exchange_id,
+                cursors,
+                order_key,
+                now_ms,
+            )
+        )
+        order_history_complete = not include_orders
+        if include_orders:
+            try:
+                orders.extend(await _fetch_orders_since(
+                    exchange,
+                    account,
+                    scope,
+                    symbol_targets,
+                    order_since,
+                    now_ms,
+                    stop,
+                ))
+                cursors[order_key] = str(now_ms)
+                cursor_records.append(_cursor_record(
+                    account.name,
+                    account.exchange_id,
+                    order_stream,
+                    scope_key,
+                    now_ms,
+                ))
+                order_history_complete = True
+            except (ccxt.ArgumentsRequired, ccxt.BadRequest, ccxt.NotSupported):
+                pass
+            except Exception as exc:
+                print(
+                    f"[account] {account.name} {scope.name} order backfill failed: "
+                    f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+        fill_key = _cursor_key(
+            account.name,
+            account.exchange_id,
+            "fills",
+            scope_key,
+        )
+        fill_since = (
+            _initial_history_since(account.exchange_id, now_ms)
+            if scope.name in full_history_scopes
+            else _history_since(
+                account.exchange_id,
+                cursors,
+                fill_key,
+                now_ms,
+            )
+        )
+        fill_history_complete = not include_fills
+        if include_fills:
+            try:
+                fills.extend(await _fetch_fills_since(
+                    exchange,
+                    account,
+                    scope,
+                    symbol_targets,
+                    fill_since,
+                    now_ms,
+                    stop,
+                ))
+                cursors[fill_key] = str(now_ms)
+                cursor_records.append(_cursor_record(
+                    account.name,
+                    account.exchange_id,
+                    "fills",
+                    scope_key,
+                    now_ms,
+                ))
+                fill_history_complete = True
+            except (ccxt.ArgumentsRequired, ccxt.BadRequest, ccxt.NotSupported):
+                pass
+            except Exception as exc:
+                print(
+                    f"[account] {account.name} {scope.name} fill backfill failed: "
+                    f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
+        if (
+            order_history_complete
+            and fill_history_complete
+            and scope.name in pending_discovery_keys
+        ):
+            discovery_key = pending_discovery_keys[scope.name]
+            cursors[discovery_key] = str(now_ms)
+            cursor_records.append(_cursor_record(
+                account.name,
+                account.exchange_id,
+                "symbols",
+                scope.name,
+                now_ms,
+            ))
+
+        if not include_positions or scope.position_params is None:
+            continue
+        position_key = _cursor_key(
+            account.name,
+            account.exchange_id,
+            "positions",
+            scope_key,
+        )
+        position_since = _cursor_since(cursors, position_key, now_ms)
+        try:
+            positions.extend(await _fetch_positions(
+                exchange,
+                account,
+                scope,
+                position_since,
+                now_ms,
+                stop,
+                target_symbol,
+            ))
+            cursors[position_key] = str(now_ms)
+            cursor_records.append(_cursor_record(
+                account.name,
+                account.exchange_id,
+                "positions",
+                scope_key,
+                now_ms,
+            ))
+        except (ccxt.ArgumentsRequired, ccxt.BadRequest, ccxt.NotSupported):
+            pass
+        except Exception as exc:
+            print(
+                f"[account] {account.name} {scope.name} position backfill failed: "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+    return {
+        "orders": orders,
+        "fills": fills,
+        "positions": positions,
+        "cursors": cursor_records,
+    }
+
+
+async def account_history_backfill_loop(
+    exchange: Any,
+    account: Any,
+    config_path: str,
+    current_positions: Any,
+    cached_symbols: set[str],
+    history: Any,
+    cursors: dict[tuple[str, str, str, str], str],
+    semaphore: asyncio.Semaphore,
+    account_lock: asyncio.Lock,
+    stop: asyncio.Event,
+) -> None:
+    while not stop.is_set():
+        await _wait_for_history_slot(stop)
+        known_symbols = account_history_symbols(
+            config_path,
+            account.exchange_id,
+            current_positions(),
+            cached_symbols,
+        )
+        try:
+            async with semaphore:
+                async with account_lock:
+                    incremental = any(
+                        key[0] == account.name and key[1] == account.exchange_id
+                        for key in cursors
+                    )
+                    range_label = (
+                        "cursor-24h-overlap"
+                        if incremental
+                        else f"{INITIAL_HISTORY_DAYS}d"
+                    )
+                    started_at = time.monotonic()
+                    print(
+                        f"[account] history backfill started | "
+                        f"account={account.name} exchange={account.exchange_id} "
+                        f"range={range_label}",
+                        flush=True,
+                    )
+                    batch = await backfill_account_once(
+                        exchange,
+                        account,
+                        known_symbols,
+                        cursors,
+                        stop,
+                    )
+            history.add_backfill(**batch)
+            elapsed = time.monotonic() - started_at
+            print(
+                f"[account] history backfill completed | "
+                f"account={account.name} exchange={account.exchange_id} "
+                f"orders={len(batch['orders'])} fills={len(batch['fills'])} "
+                f"positions={len(batch['positions'])} elapsed={elapsed:.1f}s",
+                flush=True,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            print(
+                f"[account] {account.name} history backfill failed: "
+                f"{type(exc).__name__}: "
+                f"{redact_error(exc, secret_values(account.config))}",
+                file=sys.stderr,
+                flush=True,
+            )
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=BACKFILL_INTERVAL_SECONDS)
+        except TimeoutError:
+            pass

--- a/account_service/backfill.py
+++ b/account_service/backfill.py
@@ -11,6 +11,7 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any, Iterator
 
@@ -41,6 +42,8 @@ CURSOR_OVERLAP_SECONDS = 24 * 60 * 60
 BACKFILL_INTERVAL_SECONDS = 30 * 60
 MAX_PAGINATION_CALLS = 5
 MAX_HISTORY_RECORDS = 1000
+MAX_FUNDING_RECORDS = 1000
+MAX_FUNDING_PAGINATION_CALLS = 10
 BITGET_SPOT_ORDER_PAGE_LIMIT = 100
 BINANCE_HISTORY_WINDOW_SAFETY_MS = 5 * 60 * 1000
 BINANCE_ORDER_CURSOR_STREAM = "orders_90d"
@@ -281,11 +284,41 @@ def _position_pnl_breakdown(
         native_net = _first_number(info, ("netProfit",))
         if native_net is not None:
             net = native_net
+        funding = _first_number(info, ("totalFunding", "totalFundingFee"))
+        if gross is not None and funding is not None and net is not None:
+            fees = gross + funding - net
+            return net, {
+                "gross_pnl": gross,
+                "fees": fees,
+                "funding": funding,
+                "funding_source": "position",
+                "net_pnl": net,
+                "currency": str(info.get("marginCoin") or "").upper() or None,
+                "complete": True,
+            }
     elif exchange_id == "okx":
-        gross = _first_number(info, ("pnl",))
+        position_pnl = _first_number(info, ("pnl",))
+        settled_pnl = _first_number(info, ("settledPnl",)) or 0.0
+        gross = (
+            position_pnl + settled_pnl
+            if position_pnl is not None
+            else None
+        )
         native_net = _first_number(info, ("realizedPnl",))
         if native_net is not None:
             net = native_net
+        funding = _first_number(info, ("fundingFee",))
+        if gross is not None and funding is not None and net is not None:
+            fees = gross + funding - net
+            return net, {
+                "gross_pnl": gross,
+                "fees": fees,
+                "funding": funding,
+                "funding_source": "position",
+                "net_pnl": net,
+                "currency": str(info.get("ccy") or "").upper() or None,
+                "complete": True,
+            }
     elif exchange_id == "bybit":
         native_net = _first_number(info, ("closedPnl",))
         if native_net is not None:
@@ -586,6 +619,161 @@ def _rest_record(
         "source": "rest",
         "payload": payload,
     }
+
+
+def _decimal_text(value: Any) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return format(parsed, "f") if parsed.is_finite() else None
+
+
+def _funding_amount_text(exchange_id: str, funding: dict[str, Any]) -> str | None:
+    info = funding.get("info")
+    info = info if isinstance(info, dict) else {}
+    if exchange_id == "binance":
+        raw = info.get("income")
+    elif exchange_id == "hyperliquid":
+        delta = info.get("delta")
+        delta = delta if isinstance(delta, dict) else {}
+        raw = delta.get("usdc")
+    else:
+        raw = None
+    return _decimal_text(raw if raw is not None else funding.get("amount"))
+
+
+def _normalize_funding_event(
+    account: Any,
+    market_scope: str,
+    funding: dict[str, Any],
+) -> dict[str, Any] | None:
+    timestamp = _integer(funding.get("timestamp"))
+    amount = _funding_amount_text(account.exchange_id, funding)
+    if timestamp is None or amount is None:
+        return None
+    occurred_at = _iso_timestamp(timestamp)
+    if occurred_at is None:
+        return None
+    symbol = str(funding.get("symbol") or "").strip()
+    currency = str(funding.get("code") or "").strip().upper()
+    if not currency:
+        currency = "USDC" if account.exchange_id == "hyperliquid" else "USDT"
+
+    info = funding.get("info")
+    info = info if isinstance(info, dict) else {}
+    event_id = str(funding.get("id") or "").strip()
+    if account.exchange_id == "hyperliquid":
+        delta = info.get("delta")
+        delta = delta if isinstance(delta, dict) else {}
+        identity = [
+            account.name,
+            occurred_at,
+            symbol,
+            amount,
+            delta.get("fundingRate") or funding.get("rate"),
+            delta.get("szi"),
+        ]
+        event_id = "hyperliquid-funding:" + hashlib.sha256(
+            json.dumps(identity, ensure_ascii=True, default=str).encode("utf-8")
+        ).hexdigest()[:24]
+    elif not event_id:
+        identity = [account.name, market_scope, occurred_at, symbol, amount]
+        event_id = "rest-funding:" + hashlib.sha256(
+            json.dumps(identity, ensure_ascii=True, default=str).encode("utf-8")
+        ).hexdigest()[:24]
+
+    payload: dict[str, Any] = {
+        "amount": amount,
+        "currency": currency,
+        "component": "funding",
+        "count_in_pnl": True,
+        "canonical_source": f"rest:{account.exchange_id}",
+    }
+    if account.exchange_id == "hyperliquid":
+        delta = info.get("delta")
+        delta = delta if isinstance(delta, dict) else {}
+        size = _decimal_text(delta.get("szi"))
+        payload.update({
+            "side": "long" if size is not None and not size.startswith("-") else "short",
+            "size": size,
+            "rate": _decimal_text(delta.get("fundingRate") or funding.get("rate")),
+        })
+    return {
+        "account": account.name,
+        "exchange": account.exchange_id,
+        "event_id": event_id,
+        "event_type": "funding",
+        "market_scope": market_scope,
+        "symbol": symbol,
+        "occurred_at": occurred_at,
+        "source": "rest",
+        "payload": payload,
+    }
+
+
+async def _fetch_funding_events(
+    exchange: Any,
+    account: Any,
+    scope: HistoryScope,
+    since: int,
+    now_ms: int,
+    stop: asyncio.Event,
+    symbol: str | None = None,
+) -> list[dict[str, Any]]:
+    if account.exchange_id not in {"binance", "hyperliquid"}:
+        return []
+    if not exchange.has.get("fetchFundingHistory"):
+        raise ccxt.NotSupported(
+            f"{account.exchange_id} does not expose funding history"
+        )
+
+    params = dict(scope.params)
+    records: dict[str, dict[str, Any]] = {}
+    page_limit = 500 if account.exchange_id == "hyperliquid" else MAX_FUNDING_RECORDS
+    for window_start, window_end in _stream_windows(
+        account.exchange_id,
+        since,
+        now_ms,
+    ):
+        cursor = window_start
+        effective_end = window_end if window_end is not None else now_ms
+        for _ in range(MAX_FUNDING_PAGINATION_CALLS):
+            request_params = {**params, "until": effective_end}
+            page = await _fetch_with_retry(
+                exchange,
+                account,
+                f"{scope.name} funding history",
+                lambda cursor=cursor, request_params=request_params: (
+                    exchange.fetch_funding_history(
+                        symbol,
+                        cursor,
+                        page_limit,
+                        dict(request_params),
+                    )
+                ),
+                stop,
+            )
+            page_timestamps: list[int] = []
+            for item in page:
+                timestamp = _integer(item.get("timestamp"))
+                if timestamp is None or timestamp < since or timestamp > now_ms:
+                    continue
+                page_timestamps.append(timestamp)
+                normalized = _normalize_funding_event(account, scope.name, item)
+                if normalized is not None:
+                    records[normalized["event_id"]] = normalized
+            if not page_timestamps:
+                break
+            next_cursor = max(page_timestamps) + 1
+            if next_cursor <= cursor or next_cursor > effective_end:
+                break
+            cursor = next_cursor
+            if len(page) < page_limit:
+                break
+    return list(records.values())
 
 
 def _binance_unified_symbol(
@@ -1132,6 +1320,7 @@ async def backfill_account_once(
     include_orders: bool = True,
     include_fills: bool = True,
     include_positions: bool = True,
+    include_pnl_events: bool = True,
     target_symbol: str | None = None,
     discover_symbols: bool = True,
 ) -> dict[str, list[dict[str, Any]]]:
@@ -1139,6 +1328,7 @@ async def backfill_account_once(
     orders: list[dict[str, Any]] = []
     fills: list[dict[str, Any]] = []
     positions: list[dict[str, Any]] = []
+    pnl_events: list[dict[str, Any]] = []
     cursor_records: list[dict[str, Any]] = []
     scopes = _history_scopes(account.exchange_id, account.config)
     discovered_symbols: dict[str, set[str]] = {}
@@ -1211,6 +1401,55 @@ async def backfill_account_once(
             symbol_targets = symbols
         else:
             symbol_targets = symbols[:1]
+
+        collects_funding = (
+            account.exchange_id == "hyperliquid"
+            or (
+                account.exchange_id == "binance"
+                and scope.name in {"usd_m", "coin_m"}
+            )
+        )
+        if include_pnl_events and collects_funding:
+            funding_key = _cursor_key(
+                account.name,
+                account.exchange_id,
+                "funding",
+                scope.name,
+            )
+            funding_since = _history_since(
+                account.exchange_id,
+                cursors,
+                funding_key,
+                now_ms,
+            )
+            try:
+                pnl_events.extend(await _fetch_funding_events(
+                    exchange,
+                    account,
+                    scope,
+                    funding_since,
+                    now_ms,
+                    stop,
+                    target_symbol,
+                ))
+                cursors[funding_key] = str(now_ms)
+                cursor_records.append(_cursor_record(
+                    account.name,
+                    account.exchange_id,
+                    "funding",
+                    scope.name,
+                    now_ms,
+                ))
+            except (ccxt.ArgumentsRequired, ccxt.BadRequest, ccxt.NotSupported):
+                pass
+            except Exception as exc:
+                print(
+                    f"[account] {account.name} {scope.name} funding backfill "
+                    f"failed: {type(exc).__name__}: "
+                    f"{redact_error(exc, secrets)}",
+                    file=sys.stderr,
+                    flush=True,
+                )
 
         order_stream = (
             OKX_ORDER_CURSOR_STREAM
@@ -1371,6 +1610,7 @@ async def backfill_account_once(
         "orders": orders,
         "fills": fills,
         "positions": positions,
+        "pnl_events": pnl_events,
         "cursors": cursor_records,
     }
 
@@ -1427,7 +1667,9 @@ async def account_history_backfill_loop(
                 f"[account] history backfill completed | "
                 f"account={account.name} exchange={account.exchange_id} "
                 f"orders={len(batch['orders'])} fills={len(batch['fills'])} "
-                f"positions={len(batch['positions'])} elapsed={elapsed:.1f}s",
+                f"positions={len(batch['positions'])} "
+                f"pnl_events={len(batch['pnl_events'])} "
+                f"elapsed={elapsed:.1f}s",
                 flush=True,
             )
         except asyncio.CancelledError:

--- a/account_service/cache.py
+++ b/account_service/cache.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+_BUSY_TIMEOUT_SECONDS = 30.0
+_BUSY_TIMEOUT_MS = int(_BUSY_TIMEOUT_SECONDS * 1000)
+
+
+def _json(value: Any) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        sort_keys=True,
+        default=str,
+    )
+
+
+def _position_key(position: dict[str, Any]) -> str:
+    return _json([
+        str(position.get("market_scope") or ""),
+        str(position.get("dex") or ""),
+        str(position.get("symbol") or ""),
+        str(position.get("side") or ""),
+    ])
+
+
+def _timestamp(value: Any, fallback: str) -> str:
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        seconds = float(value)
+        if seconds > 10_000_000_000:
+            seconds /= 1000.0
+        try:
+            return datetime.fromtimestamp(seconds, UTC).isoformat().replace("+00:00", "Z")
+        except (OverflowError, OSError, ValueError):
+            pass
+    return fallback
+
+
+class AccountCache:
+    """Single-writer storage owned by the account-service process."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path.resolve()
+        self._connection: sqlite3.Connection | None = None
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._connection is not None:
+            return self._connection
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(self.path, timeout=_BUSY_TIMEOUT_SECONDS)
+        connection.row_factory = sqlite3.Row
+        connection.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+        connection.execute("PRAGMA journal_mode = WAL")
+        connection.execute("PRAGMA synchronous = NORMAL")
+        connection.execute("PRAGMA foreign_keys = ON")
+        self._connection = connection
+        self._create_schema(connection)
+        return connection
+
+    @staticmethod
+    def _create_schema(connection: sqlite3.Connection) -> None:
+        connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS current_positions (
+                account TEXT NOT NULL,
+                exchange TEXT NOT NULL,
+                position_key TEXT NOT NULL,
+                market_scope TEXT NOT NULL DEFAULT '',
+                dex TEXT NOT NULL DEFAULT '',
+                symbol TEXT NOT NULL,
+                side TEXT NOT NULL,
+                opened_at TEXT NOT NULL,
+                first_seen_at TEXT NOT NULL,
+                last_seen_at TEXT NOT NULL,
+                source TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                PRIMARY KEY (account, position_key)
+            );
+
+            CREATE TABLE IF NOT EXISTS position_history (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                account TEXT NOT NULL,
+                exchange TEXT NOT NULL,
+                position_key TEXT NOT NULL,
+                market_scope TEXT NOT NULL DEFAULT '',
+                dex TEXT NOT NULL DEFAULT '',
+                symbol TEXT NOT NULL,
+                side TEXT NOT NULL,
+                opened_at TEXT NOT NULL,
+                closed_at TEXT NOT NULL,
+                source TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                UNIQUE (account, position_key, opened_at, closed_at)
+            );
+
+            CREATE TABLE IF NOT EXISTS orders (
+                account TEXT NOT NULL,
+                exchange TEXT NOT NULL,
+                order_id TEXT NOT NULL,
+                client_order_id TEXT,
+                market_scope TEXT NOT NULL DEFAULT '',
+                symbol TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT '',
+                side TEXT NOT NULL DEFAULT '',
+                order_type TEXT NOT NULL DEFAULT '',
+                created_at TEXT,
+                updated_at TEXT,
+                payload_json TEXT NOT NULL,
+                PRIMARY KEY (
+                    account, exchange, market_scope, symbol, order_id
+                )
+            );
+
+            CREATE TABLE IF NOT EXISTS fills (
+                account TEXT NOT NULL,
+                exchange TEXT NOT NULL,
+                trade_id TEXT NOT NULL,
+                order_id TEXT,
+                market_scope TEXT NOT NULL DEFAULT '',
+                symbol TEXT NOT NULL DEFAULT '',
+                side TEXT NOT NULL DEFAULT '',
+                occurred_at TEXT,
+                payload_json TEXT NOT NULL,
+                PRIMARY KEY (
+                    account, exchange, market_scope, symbol, trade_id
+                )
+            );
+
+            CREATE TABLE IF NOT EXISTS pnl_events (
+                account TEXT NOT NULL,
+                exchange TEXT NOT NULL,
+                event_id TEXT NOT NULL,
+                event_type TEXT NOT NULL,
+                symbol TEXT NOT NULL DEFAULT '',
+                occurred_at TEXT,
+                payload_json TEXT NOT NULL,
+                PRIMARY KEY (account, exchange, event_id, event_type)
+            );
+
+            CREATE TABLE IF NOT EXISTS account_sync_status (
+                account TEXT PRIMARY KEY,
+                exchange TEXT NOT NULL,
+                stream_status TEXT NOT NULL,
+                last_snapshot_at TEXT,
+                last_success_at TEXT,
+                last_error TEXT,
+                updated_at TEXT NOT NULL
+            );
+
+            CREATE TABLE IF NOT EXISTS sync_cursors (
+                account TEXT NOT NULL,
+                exchange TEXT NOT NULL,
+                stream TEXT NOT NULL,
+                market_scope TEXT NOT NULL DEFAULT '',
+                cursor TEXT,
+                updated_at TEXT NOT NULL,
+                PRIMARY KEY (account, exchange, stream, market_scope)
+            );
+
+            CREATE INDEX IF NOT EXISTS idx_current_positions_symbol
+                ON current_positions (exchange, symbol);
+            CREATE INDEX IF NOT EXISTS idx_position_history_closed
+                ON position_history (closed_at DESC, account);
+            CREATE INDEX IF NOT EXISTS idx_orders_updated
+                ON orders (updated_at DESC, account);
+            CREATE INDEX IF NOT EXISTS idx_fills_occurred
+                ON fills (occurred_at DESC, account);
+            CREATE INDEX IF NOT EXISTS idx_pnl_events_occurred
+                ON pnl_events (occurred_at DESC, account);
+            """
+        )
+        connection.commit()
+
+    def apply_positions_snapshot(self, payload: dict[str, Any]) -> None:
+        connection = self._connect()
+        observed_at = str(payload.get("collected_at") or "")
+        if not observed_at:
+            observed_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        source = str(payload.get("source") or "exchange.positions")
+        results = payload.get("results")
+        if not isinstance(results, list):
+            return
+
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            for result in results:
+                if not isinstance(result, dict):
+                    continue
+                account = str(result.get("account") or "").strip()
+                exchange = str(result.get("exchange") or "").strip()
+                if not account or not exchange:
+                    continue
+                status = str(result.get("status") or "error")
+                stream_status = str(result.get("stream_status") or status)
+                error = result.get("error")
+                error_message = None
+                if isinstance(error, dict) and error.get("message"):
+                    error_message = str(error["message"])[:500]
+                connection.execute(
+                    """
+                    INSERT INTO account_sync_status (
+                        account, exchange, stream_status, last_snapshot_at,
+                        last_success_at, last_error, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account) DO UPDATE SET
+                        exchange = excluded.exchange,
+                        stream_status = excluded.stream_status,
+                        last_snapshot_at = excluded.last_snapshot_at,
+                        last_success_at = CASE
+                            WHEN excluded.last_success_at IS NOT NULL
+                            THEN excluded.last_success_at
+                            ELSE account_sync_status.last_success_at
+                        END,
+                        last_error = excluded.last_error,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        account,
+                        exchange,
+                        stream_status,
+                        observed_at,
+                        observed_at if status == "ok" else None,
+                        error_message,
+                        observed_at,
+                    ),
+                )
+                if status != "ok":
+                    continue
+
+                existing = {
+                    str(row["position_key"]): row
+                    for row in connection.execute(
+                        "SELECT * FROM current_positions WHERE account = ?",
+                        (account,),
+                    )
+                }
+                positions = result.get("positions")
+                positions = positions if isinstance(positions, list) else []
+                active_keys: set[str] = set()
+                for position in positions:
+                    if not isinstance(position, dict):
+                        continue
+                    key = _position_key(position)
+                    active_keys.add(key)
+                    symbol = str(position.get("symbol") or "")
+                    side = str(position.get("side") or "")
+                    market_scope = str(position.get("market_scope") or "")
+                    dex = str(position.get("dex") or "")
+                    opened_at = _timestamp(
+                        position.get("datetime") or position.get("timestamp"),
+                        observed_at,
+                    )
+                    connection.execute(
+                        """
+                        INSERT INTO current_positions (
+                            account, exchange, position_key, market_scope, dex,
+                            symbol, side, opened_at, first_seen_at, last_seen_at,
+                            source, payload_json
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        ON CONFLICT(account, position_key) DO UPDATE SET
+                            exchange = excluded.exchange,
+                            market_scope = excluded.market_scope,
+                            dex = excluded.dex,
+                            symbol = excluded.symbol,
+                            side = excluded.side,
+                            last_seen_at = excluded.last_seen_at,
+                            source = excluded.source,
+                            payload_json = excluded.payload_json
+                        """,
+                        (
+                            account,
+                            exchange,
+                            key,
+                            market_scope,
+                            dex,
+                            symbol,
+                            side,
+                            opened_at,
+                            observed_at,
+                            observed_at,
+                            source,
+                            _json(position),
+                        ),
+                    )
+
+                for key, row in existing.items():
+                    if key in active_keys:
+                        continue
+                    connection.execute(
+                        """
+                        INSERT OR IGNORE INTO position_history (
+                            account, exchange, position_key, market_scope, dex,
+                            symbol, side, opened_at, closed_at, source, payload_json
+                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'derived', ?)
+                        """,
+                        (
+                            row["account"],
+                            row["exchange"],
+                            row["position_key"],
+                            row["market_scope"],
+                            row["dex"],
+                            row["symbol"],
+                            row["side"],
+                            row["opened_at"],
+                            observed_at,
+                            row["payload_json"],
+                        ),
+                    )
+                    connection.execute(
+                        "DELETE FROM current_positions WHERE account = ? AND position_key = ?",
+                        (account, key),
+                    )
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+
+    def apply_history_batch(
+        self,
+        orders: list[dict[str, Any]],
+        fills: list[dict[str, Any]],
+    ) -> None:
+        if not orders and not fills:
+            return
+        connection = self._connect()
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            for record in orders:
+                payload = record.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                account = str(record.get("account") or "").strip()
+                exchange = str(record.get("exchange") or "").strip()
+                order_id = str(payload.get("id") or "").strip()
+                symbol = str(payload.get("symbol") or "")
+                market_scope = str(record.get("market_scope") or "")
+                if not account or not exchange or not order_id:
+                    continue
+                created_at = _timestamp(
+                    payload.get("datetime") or payload.get("timestamp"),
+                    "",
+                ) or None
+                updated_at = _timestamp(
+                    payload.get("updated_timestamp"),
+                    created_at or "",
+                ) or None
+                connection.execute(
+                    """
+                    INSERT INTO orders (
+                        account, exchange, order_id, client_order_id,
+                        market_scope, symbol, status, side, order_type,
+                        created_at, updated_at, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(
+                        account, exchange, market_scope, symbol, order_id
+                    ) DO UPDATE SET
+                        client_order_id = excluded.client_order_id,
+                        status = excluded.status,
+                        side = excluded.side,
+                        order_type = excluded.order_type,
+                        created_at = COALESCE(orders.created_at, excluded.created_at),
+                        updated_at = excluded.updated_at,
+                        payload_json = excluded.payload_json
+                    WHERE orders.updated_at IS NULL
+                        OR excluded.updated_at IS NULL
+                        OR excluded.updated_at >= orders.updated_at
+                    """,
+                    (
+                        account,
+                        exchange,
+                        order_id,
+                        str(payload.get("client_order_id") or "") or None,
+                        market_scope,
+                        symbol,
+                        str(payload.get("status") or ""),
+                        str(payload.get("side") or ""),
+                        str(payload.get("type") or ""),
+                        created_at,
+                        updated_at,
+                        _json(payload),
+                    ),
+                )
+
+            for record in fills:
+                payload = record.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                account = str(record.get("account") or "").strip()
+                exchange = str(record.get("exchange") or "").strip()
+                trade_id = str(payload.get("id") or "").strip()
+                symbol = str(payload.get("symbol") or "")
+                market_scope = str(record.get("market_scope") or "")
+                if not account or not exchange or not trade_id:
+                    continue
+                occurred_at = _timestamp(
+                    payload.get("datetime") or payload.get("timestamp"),
+                    "",
+                ) or None
+                connection.execute(
+                    """
+                    INSERT INTO fills (
+                        account, exchange, trade_id, order_id, market_scope,
+                        symbol, side, occurred_at, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(
+                        account, exchange, market_scope, symbol, trade_id
+                    ) DO UPDATE SET
+                        order_id = excluded.order_id,
+                        side = excluded.side,
+                        occurred_at = excluded.occurred_at,
+                        payload_json = excluded.payload_json
+                    """,
+                    (
+                        account,
+                        exchange,
+                        trade_id,
+                        str(payload.get("order_id") or "") or None,
+                        market_scope,
+                        symbol,
+                        str(payload.get("side") or ""),
+                        occurred_at,
+                        _json(payload),
+                    ),
+                )
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+
+    def rows(self, table: str) -> list[dict[str, Any]]:
+        if table not in {
+            "current_positions",
+            "position_history",
+            "orders",
+            "fills",
+            "account_sync_status",
+        }:
+            raise ValueError(f"unsupported account cache table: {table}")
+        connection = self._connect()
+        return [dict(row) for row in connection.execute(f"SELECT * FROM {table}")]
+
+    def close(self) -> None:
+        connection = self._connection
+        self._connection = None
+        if connection is not None:
+            connection.close()

--- a/account_service/cache.py
+++ b/account_service/cache.py
@@ -130,11 +130,15 @@ def _new_pnl_bucket(
         "unrealized_pnl": Decimal(0),
         "gross_realized_pnl": Decimal(0),
         "fees": Decimal(0),
+        "funding": Decimal(0),
+        "borrow_interest": Decimal(0),
         "closed_positions": 0,
         "open_positions": 0,
         "realized_complete": True,
         "unrealized_complete": True,
         "fee_breakdown_complete": True,
+        "funding_available": False,
+        "borrow_interest_available": False,
     }
 
 
@@ -165,8 +169,16 @@ def _serialize_pnl_bucket(bucket: dict[str, Any]) -> dict[str, Any]:
             and bucket["unrealized_complete"]
         ),
         "fee_breakdown_complete": bucket["fee_breakdown_complete"],
-        "funding": None,
-        "borrow_interest": None,
+        "funding": (
+            float(bucket["funding"])
+            if bucket["funding_available"]
+            else None
+        ),
+        "borrow_interest": (
+            float(bucket["borrow_interest"])
+            if bucket["borrow_interest_available"]
+            else None
+        ),
     }
 
 
@@ -197,6 +209,8 @@ class AccountCache:
         self._rebuild_hyperliquid_position_history(connection)
         self._repair_replaced_derived_position_history(connection)
         self._repair_okx_intermediate_position_history(connection)
+        self._repair_okx_csv_position_pnl(connection)
+        self._repair_csv_position_history(connection)
         connection.commit()
         return connection
 
@@ -315,6 +329,25 @@ class AccountCache:
                 PRIMARY KEY (account, exchange, stream, market_scope)
             );
 
+            CREATE TABLE IF NOT EXISTS csv_imports (
+                import_id TEXT PRIMARY KEY,
+                batch_id TEXT NOT NULL,
+                file_hash TEXT NOT NULL,
+                original_name TEXT NOT NULL,
+                account TEXT NOT NULL,
+                exchange TEXT NOT NULL,
+                file_type TEXT NOT NULL,
+                market_scope TEXT NOT NULL DEFAULT '',
+                source_timezone TEXT NOT NULL,
+                row_count INTEGER NOT NULL,
+                first_occurred_at TEXT,
+                last_occurred_at TEXT,
+                status TEXT NOT NULL,
+                warnings_json TEXT NOT NULL DEFAULT '[]',
+                imported_at TEXT NOT NULL,
+                UNIQUE (account, exchange, file_type, file_hash)
+            );
+
             CREATE INDEX IF NOT EXISTS idx_current_positions_symbol
                 ON current_positions (exchange, symbol);
             CREATE INDEX IF NOT EXISTS idx_position_history_closed
@@ -331,6 +364,8 @@ class AccountCache:
                 ON fills (occurred_at DESC, account);
             CREATE INDEX IF NOT EXISTS idx_pnl_events_occurred
                 ON pnl_events (occurred_at DESC, account);
+            CREATE INDEX IF NOT EXISTS idx_csv_imports_imported
+                ON csv_imports (imported_at DESC);
             """
         )
         AccountCache._ensure_column(
@@ -602,6 +637,88 @@ class AccountCache:
         )
 
     @staticmethod
+    def _repair_csv_position_history(connection: sqlite3.Connection) -> None:
+        connection.execute(
+            """
+            DELETE FROM position_history
+            WHERE source NOT LIKE 'csv:%'
+              AND EXISTS (
+                  SELECT 1
+                  FROM position_history AS csv_row
+                  WHERE csv_row.source LIKE 'csv:%'
+                    AND csv_row.account = position_history.account
+                    AND csv_row.exchange = position_history.exchange
+                    AND csv_row.market_scope = position_history.market_scope
+                    AND csv_row.symbol = position_history.symbol
+                    AND (
+                        LOWER(csv_row.side) = LOWER(position_history.side)
+                        OR (
+                            position_history.exchange = 'okx'
+                            AND (
+                                LOWER(csv_row.side) IN ('', 'net')
+                                OR LOWER(position_history.side) IN ('', 'net')
+                            )
+                        )
+                    )
+                    AND ABS(
+                        (julianday(csv_row.opened_at)
+                         - julianday(position_history.opened_at)) * 86400.0
+                    ) <= 2.0
+                    AND ABS(
+                        (julianday(csv_row.closed_at)
+                         - julianday(position_history.closed_at)) * 86400.0
+                    ) <= 2.0
+              )
+            """
+        )
+
+    @staticmethod
+    def _repair_okx_csv_position_pnl(connection: sqlite3.Connection) -> None:
+        rows = connection.execute(
+            """
+            SELECT id, payload_json
+            FROM position_history
+            WHERE exchange = 'okx' AND source = 'csv:okx'
+            """
+        ).fetchall()
+        for row in rows:
+            payload = _payload_object(row["payload_json"])
+            breakdown = payload.get("realized_pnl_breakdown")
+            if not isinstance(breakdown, dict):
+                continue
+            gross = _decimal(breakdown.get("gross_pnl"))
+            trading_fee = _decimal(breakdown.get("trading_fee"))
+            funding = _decimal(breakdown.get("funding"))
+            liquidation_fee = _decimal(breakdown.get("liquidation_fee"))
+            if any(
+                value is None
+                for value in (gross, trading_fee, funding, liquidation_fee)
+            ):
+                continue
+            net = gross + trading_fee + funding + liquidation_fee
+            fees = gross - net
+            net_text = format(net, "f")
+            fees_text = format(fees, "f")
+            if (
+                payload.get("realized_pnl") == net_text
+                and breakdown.get("fees") == fees_text
+                and breakdown.get("net_pnl") == net_text
+                and breakdown.get("complete") is True
+            ):
+                continue
+            payload["realized_pnl"] = net_text
+            breakdown.update({
+                "gross_pnl": format(gross, "f"),
+                "fees": fees_text,
+                "net_pnl": net_text,
+                "complete": True,
+            })
+            connection.execute(
+                "UPDATE position_history SET payload_json = ? WHERE id = ?",
+                (_json(payload), row["id"]),
+            )
+
+    @staticmethod
     def _rebuild_fill_position_history(
         connection: sqlite3.Connection,
         exchange: str,
@@ -740,6 +857,20 @@ class AccountCache:
         connection: sqlite3.Connection,
         groups: set[tuple[str, str, str]] | None = None,
     ) -> None:
+        if groups is None:
+            groups = {
+                (str(row["account"]), str(row["market_scope"]), str(row["symbol"]))
+                for row in connection.execute(
+                    """
+                    SELECT DISTINCT account, market_scope, symbol
+                    FROM fills
+                    WHERE exchange = 'hyperliquid'
+                      AND market_scope != 'spot' AND symbol != ''
+                    """
+                )
+            }
+        else:
+            groups = {group for group in groups if group[1] != "spot"}
         AccountCache._rebuild_fill_position_history(
             connection,
             "hyperliquid",
@@ -916,17 +1047,73 @@ class AccountCache:
         fills: list[dict[str, Any]],
         positions: list[dict[str, Any]] | None = None,
         cursors: list[dict[str, Any]] | None = None,
-    ) -> None:
+        pnl_events: list[dict[str, Any]] | None = None,
+        imports: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any] | None:
         positions = positions or []
         cursors = cursors or []
-        if not orders and not fills and not positions and not cursors:
-            return
+        pnl_events = pnl_events or []
+        imports = imports or []
+        if not orders and not fills and not positions and not cursors and not pnl_events and not imports:
+            return None
         connection = self._connect()
         connection.execute("BEGIN IMMEDIATE")
         touched_binance_fills: set[tuple[str, str, str]] = set()
         touched_hyperliquid_fills: set[tuple[str, str, str]] = set()
         try:
+            accepted_imports: set[str] = set()
+            import_results: list[dict[str, Any]] = []
+            pending_import_keys: dict[tuple[str, str, str, str], str] = {}
+            for manifest in imports:
+                import_id = str(manifest.get("import_id") or "").strip()
+                account = str(manifest.get("account") or "").strip()
+                exchange = str(manifest.get("exchange") or "").strip()
+                file_type = str(manifest.get("file_type") or "").strip()
+                file_hash = str(manifest.get("file_hash") or "").strip()
+                if not all((import_id, account, exchange, file_type, file_hash)):
+                    continue
+                import_key = (account, exchange, file_type, file_hash)
+                pending_import_id = pending_import_keys.get(import_key)
+                if pending_import_id is not None:
+                    import_results.append({
+                        "import_id": import_id,
+                        "status": "already_imported",
+                        "existing_import_id": pending_import_id,
+                        "name": str(manifest.get("original_name") or ""),
+                    })
+                    continue
+                existing = connection.execute(
+                    """
+                    SELECT import_id
+                    FROM csv_imports
+                    WHERE account = ? AND exchange = ?
+                      AND file_type = ? AND file_hash = ?
+                    """,
+                    (account, exchange, file_type, file_hash),
+                ).fetchone()
+                if existing is not None:
+                    import_results.append({
+                        "import_id": import_id,
+                        "status": "already_imported",
+                        "existing_import_id": str(existing["import_id"]),
+                        "name": str(manifest.get("original_name") or ""),
+                    })
+                    continue
+                accepted_imports.add(import_id)
+                pending_import_keys[import_key] = import_id
+                import_results.append({
+                    "import_id": import_id,
+                    "status": "imported",
+                    "name": str(manifest.get("original_name") or ""),
+                })
+
+            def record_allowed(record: dict[str, Any]) -> bool:
+                import_id = str(record.get("import_id") or "").strip()
+                return not imports or not import_id or import_id in accepted_imports
+
             for record in orders:
+                if not record_allowed(record):
+                    continue
                 payload = record.get("payload")
                 if not isinstance(payload, dict):
                     continue
@@ -1005,6 +1192,8 @@ class AccountCache:
                     ),
                 )
             for record in fills:
+                if not record_allowed(record):
+                    continue
                 payload = record.get("payload")
                 if not isinstance(payload, dict):
                     continue
@@ -1066,12 +1255,14 @@ class AccountCache:
                 )
                 if exchange == "binance":
                     touched_binance_fills.add((account, market_scope, symbol))
-                elif exchange == "hyperliquid":
+                elif exchange == "hyperliquid" and market_scope != "spot":
                     touched_hyperliquid_fills.add(
                         (account, market_scope, symbol),
                     )
 
             for record in positions:
+                if not record_allowed(record):
+                    continue
                 payload = record.get("payload")
                 if not isinstance(payload, dict):
                     continue
@@ -1146,6 +1337,40 @@ class AccountCache:
                         updated_at,
                     ),
                 )
+            for record in pnl_events:
+                if not record_allowed(record):
+                    continue
+                payload = record.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                account = str(record.get("account") or "").strip()
+                exchange = str(record.get("exchange") or "").strip()
+                event_id = str(record.get("event_id") or "").strip()
+                event_type = str(record.get("event_type") or "").strip()
+                if not all((account, exchange, event_id, event_type)):
+                    continue
+                connection.execute(
+                    """
+                    INSERT INTO pnl_events (
+                        account, exchange, event_id, event_type,
+                        symbol, occurred_at, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account, exchange, event_id, event_type)
+                    DO UPDATE SET
+                        symbol = excluded.symbol,
+                        occurred_at = excluded.occurred_at,
+                        payload_json = excluded.payload_json
+                    """,
+                    (
+                        account,
+                        exchange,
+                        event_id,
+                        event_type,
+                        str(record.get("symbol") or ""),
+                        str(record.get("occurred_at") or "") or None,
+                        _json(payload),
+                    ),
+                )
             if touched_binance_fills:
                 self._rebuild_binance_position_history(
                     connection,
@@ -1156,7 +1381,63 @@ class AccountCache:
                     connection,
                     touched_hyperliquid_fills,
                 )
+            if positions or touched_binance_fills or touched_hyperliquid_fills:
+                self._repair_csv_position_history(connection)
+
+            imported_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            for manifest in imports:
+                import_id = str(manifest.get("import_id") or "").strip()
+                if import_id not in accepted_imports:
+                    continue
+                warnings = manifest.get("warnings")
+                warnings = warnings if isinstance(warnings, list) else []
+                connection.execute(
+                    """
+                    INSERT INTO csv_imports (
+                        import_id, batch_id, file_hash, original_name,
+                        account, exchange, file_type, market_scope,
+                        source_timezone, row_count, first_occurred_at,
+                        last_occurred_at, status, warnings_json, imported_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        import_id,
+                        str(manifest.get("batch_id") or import_id),
+                        str(manifest.get("file_hash") or ""),
+                        str(manifest.get("original_name") or ""),
+                        str(manifest.get("account") or ""),
+                        str(manifest.get("exchange") or ""),
+                        str(manifest.get("file_type") or ""),
+                        str(manifest.get("market_scope") or ""),
+                        str(manifest.get("source_timezone") or ""),
+                        int(manifest.get("row_count") or 0),
+                        manifest.get("first_occurred_at"),
+                        manifest.get("last_occurred_at"),
+                        (
+                            "partial"
+                            if str(manifest.get("status") or "") == "partial"
+                            else "imported"
+                        ),
+                        _json(warnings),
+                        imported_at,
+                    ),
+                )
             connection.commit()
+            return {
+                "status": "ok",
+                "imports": import_results,
+                "summary": {
+                    "imported": sum(item["status"] == "imported" for item in import_results),
+                    "already_imported": sum(
+                        item["status"] == "already_imported"
+                        for item in import_results
+                    ),
+                    "orders": sum(record_allowed(record) for record in orders),
+                    "fills": sum(record_allowed(record) for record in fills),
+                    "positions": sum(record_allowed(record) for record in positions),
+                    "pnl_events": sum(record_allowed(record) for record in pnl_events),
+                },
+            }
         except BaseException:
             connection.rollback()
             raise
@@ -1167,7 +1448,9 @@ class AccountCache:
             "position_history",
             "orders",
             "fills",
+            "pnl_events",
             "account_sync_status",
+            "csv_imports",
         }:
             raise ValueError(f"unsupported account cache table: {table}")
         connection = self._connect()
@@ -1198,16 +1481,21 @@ class AccountCache:
     def pnl_summary(
         self,
         *,
-        days: int = 90,
+        days: int | None = 90,
         account: str = "",
         exchange: str = "",
     ) -> dict[str, Any]:
-        if isinstance(days, bool) or not 1 <= days <= 365:
+        if days is not None and (
+            isinstance(days, bool) or not 1 <= days <= 365
+        ):
             raise ValueError("days must be between 1 and 365")
 
         now = datetime.now(UTC)
-        since = now - timedelta(days=days)
-        since_text = since.isoformat().replace("+00:00", "Z")
+        since_text = (
+            (now - timedelta(days=days)).isoformat().replace("+00:00", "Z")
+            if days is not None
+            else None
+        )
         filters: list[str] = []
         params: list[str] = []
         for column, value in (("account", account), ("exchange", exchange)):
@@ -1227,14 +1515,40 @@ class AccountCache:
                 "totals": [],
             }
         try:
-            history_rows = connection.execute(
-                f"""
-                SELECT account, exchange, symbol, payload_json
-                FROM position_history
-                WHERE closed_at >= ?{common_filter}
-                """,
-                [since_text, *params],
-            ).fetchall()
+            if since_text is None:
+                history_rows = connection.execute(
+                    f"""
+                    SELECT account, exchange, symbol, payload_json
+                    FROM position_history
+                    WHERE 1 = 1{common_filter}
+                    """,
+                    params,
+                ).fetchall()
+                event_rows = connection.execute(
+                    f"""
+                    SELECT account, exchange, symbol, occurred_at, payload_json
+                    FROM pnl_events
+                    WHERE 1 = 1{common_filter}
+                    """,
+                    params,
+                ).fetchall()
+            else:
+                history_rows = connection.execute(
+                    f"""
+                    SELECT account, exchange, symbol, payload_json
+                    FROM position_history
+                    WHERE closed_at >= ?{common_filter}
+                    """,
+                    [since_text, *params],
+                ).fetchall()
+                event_rows = connection.execute(
+                    f"""
+                    SELECT account, exchange, symbol, occurred_at, payload_json
+                    FROM pnl_events
+                    WHERE occurred_at >= ?{common_filter}
+                    """,
+                    [since_text, *params],
+                ).fetchall()
             current_rows = connection.execute(
                 f"""
                 SELECT account, exchange, symbol, payload_json
@@ -1248,10 +1562,17 @@ class AccountCache:
 
         buckets: dict[tuple[str, str, str], dict[str, Any]] = {}
 
-        def bucket_for(row: sqlite3.Row, payload: dict[str, Any]) -> dict[str, Any]:
+        def bucket_for(
+            row: sqlite3.Row,
+            payload: dict[str, Any],
+            currency_override: str = "",
+        ) -> dict[str, Any]:
             account_name = str(row["account"])
             exchange_id = str(row["exchange"])
-            currency = _settlement_currency(str(row["symbol"]), payload)
+            currency = currency_override or _settlement_currency(
+                str(row["symbol"]),
+                payload,
+            )
             key = (account_name, exchange_id, currency)
             return buckets.setdefault(
                 key,
@@ -1278,6 +1599,26 @@ class AccountCache:
             else:
                 bucket["fee_breakdown_complete"] = False
 
+        for row in event_rows:
+            payload = _payload_object(row["payload_json"])
+            if payload.get("count_in_pnl") is not True:
+                continue
+            amount = _decimal(payload.get("amount"))
+            currency = str(payload.get("currency") or "").strip().upper()
+            component = str(payload.get("component") or "").strip().lower()
+            if amount is None or not currency:
+                continue
+            bucket = bucket_for(row, payload, currency)
+            bucket["realized_pnl"] += amount
+            if component == "funding":
+                bucket["funding"] += amount
+                bucket["funding_available"] = True
+            elif component == "borrow_interest":
+                bucket["borrow_interest"] += amount
+                bucket["borrow_interest_available"] = True
+            elif component == "trading_fee":
+                bucket["fees"] += -amount
+
         for row in current_rows:
             payload = _payload_object(row["payload_json"])
             bucket = bucket_for(row, payload)
@@ -1300,6 +1641,8 @@ class AccountCache:
                 "unrealized_pnl",
                 "gross_realized_pnl",
                 "fees",
+                "funding",
+                "borrow_interest",
             ):
                 total[field] += bucket[field]
             for field in ("closed_positions", "open_positions"):
@@ -1310,6 +1653,8 @@ class AccountCache:
                 "fee_breakdown_complete",
             ):
                 total[field] = total[field] and bucket[field]
+            for field in ("funding_available", "borrow_interest_available"):
+                total[field] = total[field] or bucket[field]
 
         ordered_buckets = sorted(
             buckets.values(),
@@ -1327,6 +1672,90 @@ class AccountCache:
             "results": [_serialize_pnl_bucket(item) for item in ordered_buckets],
             "totals": [_serialize_pnl_bucket(item) for item in ordered_totals],
         }
+
+    def csv_imports(self, *, limit: int = 100) -> dict[str, Any]:
+        if isinstance(limit, bool) or not 1 <= limit <= 500:
+            raise ValueError("limit must be between 1 and 500")
+        connection = self._read_connection()
+        if connection is None:
+            return {"results": [], "total": 0}
+        try:
+            total = int(connection.execute("SELECT COUNT(*) FROM csv_imports").fetchone()[0])
+            rows = connection.execute(
+                """
+                SELECT import_id, batch_id, original_name, account, exchange,
+                       file_type, market_scope, source_timezone, row_count,
+                       first_occurred_at, last_occurred_at, status,
+                       warnings_json, imported_at
+                FROM csv_imports
+                ORDER BY imported_at DESC, original_name
+                LIMIT ?
+                """,
+                (limit,),
+            ).fetchall()
+        finally:
+            connection.close()
+        results = []
+        for row in rows:
+            item = dict(row)
+            try:
+                warnings = json.loads(str(item.pop("warnings_json") or "[]"))
+            except json.JSONDecodeError:
+                warnings = []
+            item["warnings"] = warnings if isinstance(warnings, list) else []
+            results.append(item)
+        return {"results": results, "total": total}
+
+    def csv_import(self, import_id: str) -> dict[str, Any] | None:
+        normalized_id = import_id.strip()
+        if not normalized_id:
+            return None
+        connection = self._read_connection()
+        if connection is None:
+            return None
+        try:
+            row = connection.execute(
+                "SELECT * FROM csv_imports WHERE import_id = ?",
+                (normalized_id,),
+            ).fetchone()
+        finally:
+            connection.close()
+        if row is None:
+            return None
+        result = dict(row)
+        try:
+            warnings = json.loads(str(result.pop("warnings_json") or "[]"))
+        except json.JSONDecodeError:
+            warnings = []
+        result["warnings"] = warnings if isinstance(warnings, list) else []
+        return result
+
+    def update_csv_import_status(
+        self,
+        import_id: str,
+        *,
+        status: str,
+        warnings: list[str],
+    ) -> None:
+        if status not in {"imported", "partial"}:
+            raise ValueError("unsupported CSV import status")
+        connection = self._connect()
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            cursor = connection.execute(
+                """
+                UPDATE csv_imports
+                SET status = ?, warnings_json = ?
+                WHERE import_id = ?
+                """,
+                (status, _json(warnings), import_id),
+            )
+            if cursor.rowcount != 1:
+                raise ValueError("CSV import was not found")
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
 
     def _history_groups(
         self,

--- a/account_service/cache.py
+++ b/account_service/cache.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import base64
 import json
 import sqlite3
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
@@ -86,6 +87,87 @@ def _payload_object(value: Any) -> dict[str, Any]:
     except json.JSONDecodeError:
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return result if result.is_finite() else None
+
+
+def _settlement_currency(symbol: str, payload: dict[str, Any]) -> str:
+    breakdown = payload.get("realized_pnl_breakdown")
+    if isinstance(breakdown, dict):
+        currency = str(breakdown.get("currency") or "").strip().upper()
+        if currency:
+            return currency
+    normalized = symbol.strip().upper()
+    if ":" in normalized:
+        settlement = normalized.rsplit(":", 1)[1].split("-", 1)[0]
+        if settlement:
+            return settlement
+    if "/" in normalized:
+        quote = normalized.split("/", 1)[1].split(":", 1)[0].split("-", 1)[0]
+        if quote:
+            return quote
+    return "UNKNOWN"
+
+
+def _new_pnl_bucket(
+    account: str,
+    exchange: str,
+    currency: str,
+) -> dict[str, Any]:
+    return {
+        "account": account,
+        "exchange": exchange,
+        "currency": currency,
+        "realized_pnl": Decimal(0),
+        "unrealized_pnl": Decimal(0),
+        "gross_realized_pnl": Decimal(0),
+        "fees": Decimal(0),
+        "closed_positions": 0,
+        "open_positions": 0,
+        "realized_complete": True,
+        "unrealized_complete": True,
+        "fee_breakdown_complete": True,
+    }
+
+
+def _serialize_pnl_bucket(bucket: dict[str, Any]) -> dict[str, Any]:
+    realized = bucket["realized_pnl"]
+    unrealized = bucket["unrealized_pnl"]
+    return {
+        "account": bucket["account"],
+        "exchange": bucket["exchange"],
+        "currency": bucket["currency"],
+        "realized_pnl": float(realized),
+        "unrealized_pnl": float(unrealized),
+        "net_pnl": float(realized + unrealized),
+        "gross_realized_pnl": (
+            float(bucket["gross_realized_pnl"])
+            if bucket["fee_breakdown_complete"]
+            else None
+        ),
+        "fees": (
+            float(bucket["fees"])
+            if bucket["fee_breakdown_complete"]
+            else None
+        ),
+        "closed_positions": bucket["closed_positions"],
+        "open_positions": bucket["open_positions"],
+        "complete": (
+            bucket["realized_complete"]
+            and bucket["unrealized_complete"]
+        ),
+        "fee_breakdown_complete": bucket["fee_breakdown_complete"],
+        "funding": None,
+        "borrow_interest": None,
+    }
 
 
 class AccountCache:
@@ -1112,6 +1194,139 @@ class AccountCache:
             ):
                 symbols.setdefault(str(row["exchange"]), set()).add(str(row["symbol"]))
         return symbols
+
+    def pnl_summary(
+        self,
+        *,
+        days: int = 90,
+        account: str = "",
+        exchange: str = "",
+    ) -> dict[str, Any]:
+        if isinstance(days, bool) or not 1 <= days <= 365:
+            raise ValueError("days must be between 1 and 365")
+
+        now = datetime.now(UTC)
+        since = now - timedelta(days=days)
+        since_text = since.isoformat().replace("+00:00", "Z")
+        filters: list[str] = []
+        params: list[str] = []
+        for column, value in (("account", account), ("exchange", exchange)):
+            normalized = value.strip().lower()
+            if normalized:
+                filters.append(f"LOWER({column}) = ?")
+                params.append(normalized)
+        common_filter = f" AND {' AND '.join(filters)}" if filters else ""
+
+        connection = self._read_connection()
+        if connection is None:
+            return {
+                "from": since_text,
+                "to": now.isoformat().replace("+00:00", "Z"),
+                "days": days,
+                "results": [],
+                "totals": [],
+            }
+        try:
+            history_rows = connection.execute(
+                f"""
+                SELECT account, exchange, symbol, payload_json
+                FROM position_history
+                WHERE closed_at >= ?{common_filter}
+                """,
+                [since_text, *params],
+            ).fetchall()
+            current_rows = connection.execute(
+                f"""
+                SELECT account, exchange, symbol, payload_json
+                FROM current_positions
+                WHERE 1 = 1{common_filter}
+                """,
+                params,
+            ).fetchall()
+        finally:
+            connection.close()
+
+        buckets: dict[tuple[str, str, str], dict[str, Any]] = {}
+
+        def bucket_for(row: sqlite3.Row, payload: dict[str, Any]) -> dict[str, Any]:
+            account_name = str(row["account"])
+            exchange_id = str(row["exchange"])
+            currency = _settlement_currency(str(row["symbol"]), payload)
+            key = (account_name, exchange_id, currency)
+            return buckets.setdefault(
+                key,
+                _new_pnl_bucket(account_name, exchange_id, currency),
+            )
+
+        for row in history_rows:
+            payload = _payload_object(row["payload_json"])
+            bucket = bucket_for(row, payload)
+            bucket["closed_positions"] += 1
+            realized = _decimal(payload.get("realized_pnl"))
+            if realized is None:
+                bucket["realized_complete"] = False
+            else:
+                bucket["realized_pnl"] += realized
+
+            breakdown = payload.get("realized_pnl_breakdown")
+            breakdown = breakdown if isinstance(breakdown, dict) else {}
+            gross = _decimal(breakdown.get("gross_pnl"))
+            fees = _decimal(breakdown.get("fees"))
+            if breakdown.get("complete") is True and gross is not None and fees is not None:
+                bucket["gross_realized_pnl"] += gross
+                bucket["fees"] += fees
+            else:
+                bucket["fee_breakdown_complete"] = False
+
+        for row in current_rows:
+            payload = _payload_object(row["payload_json"])
+            bucket = bucket_for(row, payload)
+            bucket["open_positions"] += 1
+            unrealized = _decimal(payload.get("unrealized_pnl"))
+            if unrealized is None:
+                bucket["unrealized_complete"] = False
+            else:
+                bucket["unrealized_pnl"] += unrealized
+
+        totals: dict[str, dict[str, Any]] = {}
+        for bucket in buckets.values():
+            currency = str(bucket["currency"])
+            total = totals.setdefault(
+                currency,
+                _new_pnl_bucket("", "", currency),
+            )
+            for field in (
+                "realized_pnl",
+                "unrealized_pnl",
+                "gross_realized_pnl",
+                "fees",
+            ):
+                total[field] += bucket[field]
+            for field in ("closed_positions", "open_positions"):
+                total[field] += bucket[field]
+            for field in (
+                "realized_complete",
+                "unrealized_complete",
+                "fee_breakdown_complete",
+            ):
+                total[field] = total[field] and bucket[field]
+
+        ordered_buckets = sorted(
+            buckets.values(),
+            key=lambda item: (
+                item["exchange"].lower(),
+                item["account"].lower(),
+                item["currency"],
+            ),
+        )
+        ordered_totals = sorted(totals.values(), key=lambda item: item["currency"])
+        return {
+            "from": since_text,
+            "to": now.isoformat().replace("+00:00", "Z"),
+            "days": days,
+            "results": [_serialize_pnl_bucket(item) for item in ordered_buckets],
+            "totals": [_serialize_pnl_bucket(item) for item in ordered_totals],
+        }
 
     def _history_groups(
         self,

--- a/account_service/cache.py
+++ b/account_service/cache.py
@@ -99,6 +99,34 @@ def _decimal(value: Any) -> Decimal | None:
     return result if result.is_finite() else None
 
 
+def _iso_timestamp(value: Any) -> float | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).timestamp()
+    except ValueError:
+        return None
+
+
+def _fill_amount_and_cost(payload: dict[str, Any]) -> tuple[Decimal, Decimal] | None:
+    amount = _decimal(payload.get("amount"))
+    if amount is None:
+        return None
+    cost = _decimal(payload.get("cost"))
+    if cost is None:
+        price = _decimal(payload.get("price"))
+        if price is None:
+            return None
+        cost = price * amount
+    return amount, cost
+
+
+def _decimal_close(left: Decimal, right: Decimal, relative: Decimal) -> bool:
+    tolerance = max(Decimal("0.000000001"), abs(left) * relative)
+    return abs(left - right) <= tolerance
+
+
 def _settlement_currency(symbol: str, payload: dict[str, Any]) -> str:
     breakdown = payload.get("realized_pnl_breakdown")
     if isinstance(breakdown, dict):
@@ -205,12 +233,15 @@ class AccountCache:
         self._repair_bitget_position_history(connection)
         self._repair_okx_history_scopes(connection)
         self._repair_hyperliquid_history_scopes(connection)
+        self._repair_hyperliquid_csv_fill_overlaps(connection)
         self._rebuild_binance_position_history(connection)
         self._rebuild_hyperliquid_position_history(connection)
         self._repair_replaced_derived_position_history(connection)
         self._repair_okx_intermediate_position_history(connection)
         self._repair_okx_csv_position_pnl(connection)
+        self._repair_bitget_csv_position_pnl(connection)
         self._repair_csv_position_history(connection)
+        self._allocate_position_funding(connection)
         connection.commit()
         return connection
 
@@ -531,6 +562,147 @@ class AccountCache:
                     )
 
     @staticmethod
+    def _repair_hyperliquid_csv_fill_overlaps(
+        connection: sqlite3.Connection,
+    ) -> set[tuple[str, str, str]]:
+        rows = connection.execute(
+            """
+            SELECT rowid AS storage_id, account, market_scope, symbol,
+                   side, occurred_at, source, payload_json
+            FROM fills
+            WHERE exchange = 'hyperliquid'
+            ORDER BY occurred_at, rowid
+            """
+        ).fetchall()
+        csv_groups: dict[tuple[str, str, str, int], list[dict[str, Any]]] = {}
+        native_rows: list[dict[str, Any]] = []
+        for row in rows:
+            occurred = _iso_timestamp(row["occurred_at"])
+            payload = _payload_object(row["payload_json"])
+            totals = _fill_amount_and_cost(payload)
+            if occurred is None or totals is None:
+                continue
+            item = {
+                "storage_id": int(row["storage_id"]),
+                "account": str(row["account"]),
+                "market_scope": str(row["market_scope"]),
+                "symbol": str(row["symbol"]),
+                "side": str(row["side"]),
+                "occurred": occurred,
+                "payload": payload,
+                "amount": totals[0],
+                "cost": totals[1],
+            }
+            if str(row["source"]).startswith("csv:"):
+                key = (
+                    item["account"],
+                    item["symbol"],
+                    item["side"],
+                    int(occurred),
+                )
+                csv_groups.setdefault(key, []).append(item)
+            else:
+                native_rows.append(item)
+
+        consumed_native: set[int] = set()
+        aliases: dict[tuple[str, str], tuple[str, str]] = {}
+        deleted_native: list[int] = []
+        affected: set[tuple[str, str, str]] = set()
+        for (account, csv_symbol, side, occurred_second), csv_rows in csv_groups.items():
+            csv_amount = sum(
+                (item["amount"] for item in csv_rows),
+                Decimal(0),
+            )
+            csv_cost = sum(
+                (item["cost"] for item in csv_rows),
+                Decimal(0),
+            )
+            candidates: dict[str, list[dict[str, Any]]] = {}
+            for item in native_rows:
+                if (
+                    item["storage_id"] in consumed_native
+                    or item["account"] != account
+                    or item["side"] != side
+                    or abs(item["occurred"] - occurred_second) > 2.0
+                ):
+                    continue
+                candidates.setdefault(item["symbol"], []).append(item)
+
+            matches: list[tuple[str, list[dict[str, Any]]]] = []
+            for candidate_symbol, candidate_rows in candidates.items():
+                native_amount = sum(
+                    (item["amount"] for item in candidate_rows),
+                    Decimal(0),
+                )
+                native_cost = sum(
+                    (item["cost"] for item in candidate_rows),
+                    Decimal(0),
+                )
+                if (
+                    _decimal_close(csv_amount, native_amount, Decimal("0.00000001"))
+                    and _decimal_close(csv_cost, native_cost, Decimal("0.000002"))
+                ):
+                    matches.append((candidate_symbol, candidate_rows))
+            if len(matches) != 1:
+                continue
+
+            canonical_symbol, matched_rows = matches[0]
+            canonical_scope = hyperliquid_market_scope(canonical_symbol)
+            aliases[(account, csv_symbol)] = (
+                canonical_scope,
+                canonical_symbol,
+            )
+            affected.add((account, canonical_scope, canonical_symbol))
+            affected.update(
+                (account, item["market_scope"], item["symbol"])
+                for item in csv_rows
+            )
+            for item in matched_rows:
+                consumed_native.add(item["storage_id"])
+                deleted_native.append(item["storage_id"])
+
+        if deleted_native:
+            connection.executemany(
+                "DELETE FROM fills WHERE rowid = ?",
+                [(storage_id,) for storage_id in deleted_native],
+            )
+
+        for (account, source_symbol), (market_scope, symbol) in aliases.items():
+            matching = connection.execute(
+                """
+                SELECT rowid AS storage_id, market_scope, symbol, payload_json
+                FROM fills
+                WHERE account = ? AND exchange = 'hyperliquid'
+                  AND source LIKE 'csv:%' AND symbol = ?
+                """,
+                (account, source_symbol),
+            ).fetchall()
+            for row in matching:
+                payload = _payload_object(row["payload_json"])
+                payload["symbol"] = symbol
+                connection.execute(
+                    """
+                    UPDATE fills
+                    SET market_scope = ?, symbol = ?, payload_json = ?
+                    WHERE rowid = ?
+                    """,
+                    (market_scope, symbol, _json(payload), int(row["storage_id"])),
+                )
+                affected.add((account, str(row["market_scope"]), source_symbol))
+                affected.add((account, market_scope, symbol))
+
+        for account, _, symbol in affected:
+            connection.execute(
+                """
+                DELETE FROM position_history
+                WHERE account = ? AND exchange = 'hyperliquid'
+                  AND symbol = ? AND source = 'trades'
+                """,
+                (account, symbol),
+            )
+        return affected
+
+    @staticmethod
     def _repair_okx_history_scopes(connection: sqlite3.Connection) -> None:
         for table, identity_column in (
             ("orders", "order_id"),
@@ -696,13 +868,14 @@ class AccountCache:
             ):
                 continue
             net = gross + trading_fee + funding + liquidation_fee
-            fees = gross - net
+            fees = gross + funding - net
             net_text = format(net, "f")
             fees_text = format(fees, "f")
             if (
                 payload.get("realized_pnl") == net_text
                 and breakdown.get("fees") == fees_text
                 and breakdown.get("net_pnl") == net_text
+                and breakdown.get("funding_source") == "position"
                 and breakdown.get("complete") is True
             ):
                 continue
@@ -711,12 +884,189 @@ class AccountCache:
                 "gross_pnl": format(gross, "f"),
                 "fees": fees_text,
                 "net_pnl": net_text,
+                "funding_source": "position",
                 "complete": True,
             })
             connection.execute(
                 "UPDATE position_history SET payload_json = ? WHERE id = ?",
                 (_json(payload), row["id"]),
             )
+
+    @staticmethod
+    def _repair_bitget_csv_position_pnl(connection: sqlite3.Connection) -> None:
+        rows = connection.execute(
+            """
+            SELECT id, payload_json
+            FROM position_history
+            WHERE exchange = 'bitget' AND source = 'csv:bitget'
+            """
+        ).fetchall()
+        for row in rows:
+            payload = _payload_object(row["payload_json"])
+            breakdown = payload.get("realized_pnl_breakdown")
+            if not isinstance(breakdown, dict):
+                continue
+            gross = _decimal(breakdown.get("gross_pnl"))
+            net = _decimal(breakdown.get("net_pnl"))
+            funding = _decimal(breakdown.get("funding_or_other"))
+            if gross is None or net is None or funding is None:
+                continue
+            fees = gross + funding - net
+            payload["realized_pnl"] = format(net, "f")
+            breakdown.update({
+                "fees": format(fees, "f"),
+                "funding": format(funding, "f"),
+                "funding_source": "position",
+                "complete": True,
+            })
+            connection.execute(
+                "UPDATE position_history SET payload_json = ? WHERE id = ?",
+                (_json(payload), row["id"]),
+            )
+
+    @staticmethod
+    def _allocate_position_funding(connection: sqlite3.Connection) -> None:
+        position_rows = connection.execute(
+            """
+            SELECT id, account, exchange, symbol, side, opened_at, closed_at,
+                   payload_json
+            FROM position_history
+            WHERE exchange IN ('binance', 'hyperliquid')
+            """
+        ).fetchall()
+        event_rows = connection.execute(
+            """
+            SELECT account, exchange, symbol, occurred_at, payload_json
+            FROM pnl_events
+            WHERE exchange IN ('binance', 'hyperliquid')
+            """
+        ).fetchall()
+        if not position_rows or not event_rows:
+            return
+
+        positions: dict[tuple[str, str, str], list[dict[str, Any]]] = {}
+        for row in position_rows:
+            opened = _iso_timestamp(row["opened_at"])
+            closed = _iso_timestamp(row["closed_at"])
+            if opened is None or closed is None:
+                continue
+            payload = _payload_object(row["payload_json"])
+            quantity = _decimal(payload.get("quantity"))
+            if quantity is None or quantity <= 0:
+                quantity = _decimal(payload.get("contracts")) or Decimal(1)
+            item = {
+                "id": int(row["id"]),
+                "account": str(row["account"]),
+                "exchange": str(row["exchange"]),
+                "symbol": str(row["symbol"]),
+                "side": str(row["side"]).lower(),
+                "opened": opened,
+                "closed": closed,
+                "quantity": abs(quantity),
+                "payload": payload,
+            }
+            key = (item["account"], item["exchange"], item["symbol"])
+            positions.setdefault(key, []).append(item)
+
+        allocations: dict[int, Decimal] = {}
+        estimated: set[int] = set()
+        covered_groups: set[tuple[str, str, str]] = set()
+        for row in event_rows:
+            payload = _payload_object(row["payload_json"])
+            if str(payload.get("component") or "").lower() != "funding":
+                continue
+            amount = _decimal(payload.get("amount"))
+            occurred = _iso_timestamp(row["occurred_at"])
+            if amount is None or occurred is None:
+                continue
+            key = (
+                str(row["account"]),
+                str(row["exchange"]),
+                str(row["symbol"]),
+            )
+            candidates = positions.get(key, [])
+            if not candidates:
+                continue
+            covered_groups.add(key)
+            event_side = str(payload.get("side") or "").lower()
+            if event_side in {"long", "short"}:
+                candidates = [item for item in candidates if item["side"] == event_side]
+
+            event_time = datetime.fromtimestamp(occurred, UTC)
+            is_daily_hyperliquid = (
+                key[1] == "hyperliquid"
+                and event_time.hour == 0
+                and event_time.minute == 0
+                and event_time.second == 0
+            )
+            weighted: list[tuple[dict[str, Any], Decimal]] = []
+            if is_daily_hyperliquid:
+                window_end = occurred + 86400.0
+                for item in candidates:
+                    overlap = min(item["closed"], window_end) - max(
+                        item["opened"], occurred
+                    )
+                    if overlap > 0:
+                        weighted.append(
+                            (item, item["quantity"] * Decimal(str(overlap)))
+                        )
+            else:
+                weighted = [
+                    (item, item["quantity"])
+                    for item in candidates
+                    if item["opened"] <= occurred <= item["closed"]
+                ]
+            total_weight = sum((weight for _, weight in weighted), Decimal(0))
+            if total_weight <= 0:
+                continue
+            for item, weight in weighted:
+                position_id = int(item["id"])
+                allocations[position_id] = (
+                    allocations.get(position_id, Decimal(0))
+                    + amount * weight / total_weight
+                )
+                if is_daily_hyperliquid:
+                    estimated.add(position_id)
+
+        for key in covered_groups:
+            for item in positions.get(key, []):
+                payload = item["payload"]
+                breakdown = payload.get("realized_pnl_breakdown")
+                if not isinstance(breakdown, dict):
+                    continue
+                funding = allocations.get(int(item["id"]), Decimal(0))
+                gross = _decimal(breakdown.get("gross_pnl"))
+                fees = _decimal(breakdown.get("fees"))
+                trading_net = _decimal(breakdown.get("trading_net_pnl"))
+                if trading_net is None and gross is not None and fees is not None:
+                    trading_net = gross - fees
+                if trading_net is None:
+                    current_net = _decimal(payload.get("realized_pnl"))
+                    previous_funding = (
+                        _decimal(breakdown.get("funding"))
+                        if breakdown.get("funding_source") == "ledger"
+                        else Decimal(0)
+                    )
+                    if current_net is None or previous_funding is None:
+                        continue
+                    trading_net = current_net - previous_funding
+                net = trading_net + funding
+                funding_text = format(funding, "f")
+                net_text = format(net, "f")
+                payload["realized_pnl"] = net_text
+                breakdown.update({
+                    "funding": funding_text,
+                    "funding_source": "ledger",
+                    "funding_allocation": (
+                        "estimated" if int(item["id"]) in estimated else "exact"
+                    ),
+                    "trading_net_pnl": format(trading_net, "f"),
+                    "net_pnl": net_text,
+                })
+                connection.execute(
+                    "UPDATE position_history SET payload_json = ? WHERE id = ?",
+                    (_json(payload), int(item["id"])),
+                )
 
     @staticmethod
     def _rebuild_fill_position_history(
@@ -1060,6 +1410,7 @@ class AccountCache:
         connection.execute("BEGIN IMMEDIATE")
         touched_binance_fills: set[tuple[str, str, str]] = set()
         touched_hyperliquid_fills: set[tuple[str, str, str]] = set()
+        hyperliquid_fills_changed = False
         try:
             accepted_imports: set[str] = set()
             import_results: list[dict[str, Any]] = []
@@ -1091,19 +1442,19 @@ class AccountCache:
                     """,
                     (account, exchange, file_type, file_hash),
                 ).fetchone()
+                previous_import_id = ""
                 if existing is not None:
-                    import_results.append({
-                        "import_id": import_id,
-                        "status": "already_imported",
-                        "existing_import_id": str(existing["import_id"]),
-                        "name": str(manifest.get("original_name") or ""),
-                    })
-                    continue
+                    previous_import_id = str(existing["import_id"])
+                    connection.execute(
+                        "DELETE FROM csv_imports WHERE import_id = ?",
+                        (previous_import_id,),
+                    )
                 accepted_imports.add(import_id)
                 pending_import_keys[import_key] = import_id
                 import_results.append({
                     "import_id": import_id,
                     "status": "imported",
+                    "reprocessed": bool(previous_import_id),
                     "name": str(manifest.get("original_name") or ""),
                 })
 
@@ -1166,14 +1517,22 @@ class AccountCache:
                         END,
                         created_at = COALESCE(orders.created_at, excluded.created_at),
                         updated_at = excluded.updated_at,
-                        source = CASE
-                            WHEN excluded.source = 'live' THEN 'live'
-                            ELSE orders.source
-                        END,
+                        source = excluded.source,
                         payload_json = excluded.payload_json
-                    WHERE orders.updated_at IS NULL
-                        OR excluded.updated_at IS NULL
-                        OR excluded.updated_at >= orders.updated_at
+                    WHERE (
+                            orders.updated_at IS NULL
+                            AND excluded.updated_at IS NOT NULL
+                        )
+                        OR excluded.updated_at > orders.updated_at
+                        OR (
+                            excluded.updated_at = orders.updated_at
+                            AND excluded.source LIKE 'csv:%'
+                        )
+                        OR (
+                            orders.updated_at IS NULL
+                            AND excluded.updated_at IS NULL
+                            AND excluded.source LIKE 'csv:%'
+                        )
                     """,
                     (
                         account,
@@ -1234,11 +1593,10 @@ class AccountCache:
                         order_id = excluded.order_id,
                         side = excluded.side,
                         occurred_at = excluded.occurred_at,
-                        source = CASE
-                            WHEN excluded.source = 'live' THEN 'live'
-                            ELSE fills.source
-                        END,
+                        source = excluded.source,
                         payload_json = excluded.payload_json
+                    WHERE fills.source NOT LIKE 'csv:%'
+                       OR excluded.source LIKE 'csv:%'
                     """,
                     (
                         account,
@@ -1255,10 +1613,17 @@ class AccountCache:
                 )
                 if exchange == "binance":
                     touched_binance_fills.add((account, market_scope, symbol))
-                elif exchange == "hyperliquid" and market_scope != "spot":
-                    touched_hyperliquid_fills.add(
-                        (account, market_scope, symbol),
-                    )
+                elif exchange == "hyperliquid":
+                    hyperliquid_fills_changed = True
+                    if market_scope != "spot":
+                        touched_hyperliquid_fills.add(
+                            (account, market_scope, symbol),
+                        )
+
+            if hyperliquid_fills_changed:
+                touched_hyperliquid_fills.update(
+                    self._repair_hyperliquid_csv_fill_overlaps(connection),
+                )
 
             for record in positions:
                 if not record_allowed(record):
@@ -1290,6 +1655,8 @@ class AccountCache:
                         side = excluded.side,
                         source = excluded.source,
                         payload_json = excluded.payload_json
+                    WHERE position_history.source NOT LIKE 'csv:%'
+                       OR excluded.source LIKE 'csv:%'
                     """,
                     (
                         account,
@@ -1349,6 +1716,75 @@ class AccountCache:
                 event_type = str(record.get("event_type") or "").strip()
                 if not all((account, exchange, event_id, event_type)):
                     continue
+                symbol = str(record.get("symbol") or "")
+                occurred_at = str(record.get("occurred_at") or "") or None
+                amount = _decimal(payload.get("amount"))
+                duplicate_ids: list[str] = []
+                if amount is not None:
+                    if occurred_at is None:
+                        existing_events = connection.execute(
+                            """
+                            SELECT event_id, payload_json
+                            FROM pnl_events
+                            WHERE account = ? AND exchange = ? AND event_type = ?
+                              AND symbol = ? AND occurred_at IS NULL
+                            """,
+                            (account, exchange, event_type, symbol),
+                        ).fetchall()
+                    else:
+                        existing_events = connection.execute(
+                            """
+                            SELECT event_id, payload_json
+                            FROM pnl_events
+                            WHERE account = ? AND exchange = ? AND event_type = ?
+                              AND symbol = ?
+                              AND ABS(
+                                  (julianday(occurred_at) - julianday(?))
+                                  * 86400000.0
+                              ) <= 1.0
+                            """,
+                            (account, exchange, event_type, symbol, occurred_at),
+                        ).fetchall()
+                    duplicate_ids = [
+                        str(existing["event_id"])
+                        for existing in existing_events
+                        if str(existing["event_id"]) != event_id
+                        and _decimal(
+                            _payload_object(existing["payload_json"]).get("amount")
+                        ) == amount
+                    ]
+                canonical_source = str(payload.get("canonical_source") or "")
+                existing_event = connection.execute(
+                    """
+                    SELECT payload_json
+                    FROM pnl_events
+                    WHERE account = ? AND exchange = ?
+                      AND event_id = ? AND event_type = ?
+                    """,
+                    (account, exchange, event_id, event_type),
+                ).fetchone()
+                if existing_event is not None:
+                    existing_source = str(
+                        _payload_object(existing_event["payload_json"]).get(
+                            "canonical_source"
+                        ) or ""
+                    )
+                    if (
+                        existing_source.startswith("csv:")
+                        and not canonical_source.startswith("csv:")
+                    ):
+                        continue
+                if duplicate_ids and not canonical_source.startswith("csv:"):
+                    continue
+                for duplicate_id in duplicate_ids:
+                    connection.execute(
+                        """
+                        DELETE FROM pnl_events
+                        WHERE account = ? AND exchange = ?
+                          AND event_id = ? AND event_type = ?
+                        """,
+                        (account, exchange, duplicate_id, event_type),
+                    )
                 connection.execute(
                     """
                     INSERT INTO pnl_events (
@@ -1366,8 +1802,8 @@ class AccountCache:
                         exchange,
                         event_id,
                         event_type,
-                        str(record.get("symbol") or ""),
-                        str(record.get("occurred_at") or "") or None,
+                        symbol,
+                        occurred_at,
                         _json(payload),
                     ),
                 )
@@ -1383,6 +1819,10 @@ class AccountCache:
                 )
             if positions or touched_binance_fills or touched_hyperliquid_fills:
                 self._repair_csv_position_history(connection)
+            if imports or pnl_events:
+                self._repair_okx_csv_position_pnl(connection)
+                self._repair_bitget_csv_position_pnl(connection)
+                self._allocate_position_funding(connection)
 
             imported_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
             for manifest in imports:
@@ -1583,14 +2023,20 @@ class AccountCache:
             payload = _payload_object(row["payload_json"])
             bucket = bucket_for(row, payload)
             bucket["closed_positions"] += 1
+            breakdown = payload.get("realized_pnl_breakdown")
+            breakdown = breakdown if isinstance(breakdown, dict) else {}
             realized = _decimal(payload.get("realized_pnl"))
             if realized is None:
                 bucket["realized_complete"] = False
             else:
+                allocated_funding = _decimal(breakdown.get("funding"))
+                if (
+                    breakdown.get("funding_source") == "ledger"
+                    and allocated_funding is not None
+                ):
+                    realized -= allocated_funding
                 bucket["realized_pnl"] += realized
 
-            breakdown = payload.get("realized_pnl_breakdown")
-            breakdown = breakdown if isinstance(breakdown, dict) else {}
             gross = _decimal(breakdown.get("gross_pnl"))
             fees = _decimal(breakdown.get("fees"))
             if breakdown.get("complete") is True and gross is not None and fees is not None:
@@ -1598,6 +2044,13 @@ class AccountCache:
                 bucket["fees"] += fees
             else:
                 bucket["fee_breakdown_complete"] = False
+            position_funding = _decimal(breakdown.get("funding"))
+            if (
+                breakdown.get("funding_source") == "position"
+                and position_funding is not None
+            ):
+                bucket["funding"] += position_funding
+                bucket["funding_available"] = True
 
         for row in event_rows:
             payload = _payload_object(row["payload_json"])
@@ -1729,6 +2182,33 @@ class AccountCache:
             warnings = []
         result["warnings"] = warnings if isinstance(warnings, list) else []
         return result
+
+    def delete_csv_import(self, import_id: str) -> dict[str, Any]:
+        normalized_id = import_id.strip()
+        if not normalized_id:
+            raise ValueError("CSV import was not found")
+        connection = self._connect()
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            row = connection.execute(
+                "SELECT original_name FROM csv_imports WHERE import_id = ?",
+                (normalized_id,),
+            ).fetchone()
+            if row is None:
+                raise ValueError("CSV import was not found")
+            connection.execute(
+                "DELETE FROM csv_imports WHERE import_id = ?",
+                (normalized_id,),
+            )
+            connection.commit()
+        except BaseException:
+            connection.rollback()
+            raise
+        return {
+            "status": "deleted",
+            "import_id": normalized_id,
+            "original_name": str(row["original_name"] or ""),
+        }
 
     def update_csv_import_status(
         self,

--- a/account_service/cache.py
+++ b/account_service/cache.py
@@ -1,10 +1,19 @@
 from __future__ import annotations
 
+import base64
 import json
 import sqlite3
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+
+from account_service.history import (
+    bitget_history_item_matches_scope,
+    bitget_position_market_scope,
+    hyperliquid_market_scope,
+    okx_history_market_scope,
+    reconstruct_position_history_from_fills,
+)
 
 
 _BUSY_TIMEOUT_SECONDS = 30.0
@@ -44,6 +53,41 @@ def _timestamp(value: Any, fallback: str) -> str:
     return fallback
 
 
+def _encode_cursor(values: list[Any]) -> str:
+    encoded = base64.urlsafe_b64encode(_json(values).encode("utf-8")).decode("ascii")
+    return encoded.rstrip("=")
+
+
+def _decode_cursor(value: str | None, expected_size: int) -> list[Any] | None:
+    if not value:
+        return None
+    try:
+        padding = "=" * (-len(value) % 4)
+        decoded = base64.urlsafe_b64decode(f"{value}{padding}")
+        items = json.loads(decoded.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("invalid history cursor") from exc
+    if not isinstance(items, list) or len(items) != expected_size:
+        raise ValueError("invalid history cursor")
+    return items
+
+
+def _page_limit(value: int) -> int:
+    if isinstance(value, bool) or not 1 <= value <= 100:
+        raise ValueError("limit must be between 1 and 100")
+    return value
+
+
+def _payload_object(value: Any) -> dict[str, Any]:
+    if not isinstance(value, str):
+        return {}
+    try:
+        payload = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
 class AccountCache:
     """Single-writer storage owned by the account-service process."""
 
@@ -63,6 +107,28 @@ class AccountCache:
         connection.execute("PRAGMA foreign_keys = ON")
         self._connection = connection
         self._create_schema(connection)
+        self._repair_bitget_history_scopes(connection)
+        self._repair_bitget_position_history(connection)
+        self._repair_okx_history_scopes(connection)
+        self._repair_hyperliquid_history_scopes(connection)
+        self._rebuild_binance_position_history(connection)
+        self._rebuild_hyperliquid_position_history(connection)
+        self._repair_replaced_derived_position_history(connection)
+        self._repair_okx_intermediate_position_history(connection)
+        connection.commit()
+        return connection
+
+    def _read_connection(self) -> sqlite3.Connection | None:
+        if not self.path.exists():
+            return None
+        connection = sqlite3.connect(
+            f"{self.path.as_uri()}?mode=ro",
+            uri=True,
+            timeout=_BUSY_TIMEOUT_SECONDS,
+        )
+        connection.row_factory = sqlite3.Row
+        connection.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+        connection.execute("PRAGMA query_only = ON")
         return connection
 
     @staticmethod
@@ -113,6 +179,7 @@ class AccountCache:
                 order_type TEXT NOT NULL DEFAULT '',
                 created_at TEXT,
                 updated_at TEXT,
+                source TEXT NOT NULL DEFAULT 'live',
                 payload_json TEXT NOT NULL,
                 PRIMARY KEY (
                     account, exchange, market_scope, symbol, order_id
@@ -128,6 +195,7 @@ class AccountCache:
                 symbol TEXT NOT NULL DEFAULT '',
                 side TEXT NOT NULL DEFAULT '',
                 occurred_at TEXT,
+                source TEXT NOT NULL DEFAULT 'live',
                 payload_json TEXT NOT NULL,
                 PRIMARY KEY (
                     account, exchange, market_scope, symbol, trade_id
@@ -169,15 +237,432 @@ class AccountCache:
                 ON current_positions (exchange, symbol);
             CREATE INDEX IF NOT EXISTS idx_position_history_closed
                 ON position_history (closed_at DESC, account);
+            CREATE INDEX IF NOT EXISTS idx_position_history_exchange_symbol
+                ON position_history (exchange, symbol, closed_at DESC);
             CREATE INDEX IF NOT EXISTS idx_orders_updated
                 ON orders (updated_at DESC, account);
+            CREATE INDEX IF NOT EXISTS idx_orders_sort
+                ON orders (COALESCE(updated_at, created_at, '') DESC);
+            CREATE INDEX IF NOT EXISTS idx_orders_exchange_symbol
+                ON orders (exchange, symbol, updated_at DESC);
             CREATE INDEX IF NOT EXISTS idx_fills_occurred
                 ON fills (occurred_at DESC, account);
             CREATE INDEX IF NOT EXISTS idx_pnl_events_occurred
                 ON pnl_events (occurred_at DESC, account);
             """
         )
+        AccountCache._ensure_column(
+            connection,
+            "orders",
+            "source",
+            "TEXT NOT NULL DEFAULT 'live'",
+        )
+        AccountCache._ensure_column(
+            connection,
+            "fills",
+            "source",
+            "TEXT NOT NULL DEFAULT 'live'",
+        )
         connection.commit()
+
+    @staticmethod
+    def _ensure_column(
+        connection: sqlite3.Connection,
+        table: str,
+        column: str,
+        definition: str,
+    ) -> None:
+        columns = {
+            str(row[1])
+            for row in connection.execute(f"PRAGMA table_info({table})")
+        }
+        if column not in columns:
+            connection.execute(f"ALTER TABLE {table} ADD COLUMN {column} {definition}")
+
+    @staticmethod
+    def _repair_bitget_position_history(connection: sqlite3.Connection) -> None:
+        rows = connection.execute(
+            """
+            SELECT id, account, symbol, side, opened_at, closed_at,
+                   market_scope, payload_json
+            FROM position_history
+            WHERE exchange = 'bitget' AND source = 'native'
+            ORDER BY id
+            """
+        ).fetchall()
+        grouped: dict[tuple[str, str, str, str, str], list[sqlite3.Row]] = {}
+        for row in rows:
+            key = (
+                str(row["account"]),
+                str(row["symbol"]),
+                str(row["side"]),
+                str(row["opened_at"]),
+                str(row["closed_at"]),
+            )
+            grouped.setdefault(key, []).append(row)
+        for duplicates in grouped.values():
+            if len(duplicates) < 2:
+                continue
+            payload = _payload_object(duplicates[0]["payload_json"])
+            payload.setdefault("symbol", duplicates[0]["symbol"])
+            expected_scope = bitget_position_market_scope(payload)
+            if expected_scope is None:
+                continue
+            preferred = next(
+                (
+                    row
+                    for row in duplicates
+                    if str(row["market_scope"]) == expected_scope
+                ),
+                None,
+            )
+            if preferred is None:
+                continue
+            connection.executemany(
+                "DELETE FROM position_history WHERE id = ?",
+                [
+                    (int(row["id"]),)
+                    for row in duplicates
+                    if int(row["id"]) != int(preferred["id"])
+                ],
+            )
+
+    @staticmethod
+    def _repair_bitget_history_scopes(connection: sqlite3.Connection) -> None:
+        cursor_keys: list[tuple[str, str, str]] = []
+        for table, stream in (("orders", "orders"), ("fills", "fills")):
+            rows = connection.execute(
+                f"""
+                SELECT DISTINCT account
+                FROM {table}
+                WHERE exchange = 'bitget' AND market_scope = 'spot'
+                  AND instr(symbol, ':') > 0
+                """
+            ).fetchall()
+            if not rows:
+                continue
+            connection.execute(
+                f"""
+                DELETE FROM {table}
+                WHERE exchange = 'bitget' AND market_scope = 'spot'
+                  AND instr(symbol, ':') > 0
+                """
+            )
+            cursor_keys.extend(
+                (str(row["account"]), stream, "spot") for row in rows
+            )
+        connection.executemany(
+            """
+            DELETE FROM sync_cursors
+            WHERE account = ? AND exchange = 'bitget'
+              AND stream = ? AND market_scope = ?
+            """,
+            cursor_keys,
+        )
+
+    @staticmethod
+    def _repair_hyperliquid_history_scopes(
+        connection: sqlite3.Connection,
+    ) -> None:
+        for table, identity_column in (
+            ("orders", "order_id"),
+            ("fills", "trade_id"),
+        ):
+            rows = connection.execute(
+                f"""
+                SELECT rowid AS storage_id, account, symbol,
+                       {identity_column} AS identity, market_scope, source
+                FROM {table}
+                WHERE exchange = 'hyperliquid'
+                ORDER BY rowid
+                """
+            ).fetchall()
+            grouped: dict[tuple[str, str, str], list[sqlite3.Row]] = {}
+            for row in rows:
+                key = (
+                    str(row["account"]),
+                    str(row["symbol"]),
+                    str(row["identity"]),
+                )
+                grouped.setdefault(key, []).append(row)
+
+            for duplicates in grouped.values():
+                canonical_scope = hyperliquid_market_scope(
+                    str(duplicates[0]["symbol"]),
+                )
+                preferred = min(
+                    duplicates,
+                    key=lambda row: (
+                        str(row["source"]) != "live",
+                        str(row["market_scope"]) != canonical_scope,
+                        -int(row["storage_id"]),
+                    ),
+                )
+                connection.executemany(
+                    f"DELETE FROM {table} WHERE rowid = ?",
+                    [
+                        (int(row["storage_id"]),)
+                        for row in duplicates
+                        if int(row["storage_id"])
+                        != int(preferred["storage_id"])
+                    ],
+                )
+                if str(preferred["market_scope"]) != canonical_scope:
+                    connection.execute(
+                        f"UPDATE {table} SET market_scope = ? WHERE rowid = ?",
+                        (canonical_scope, int(preferred["storage_id"])),
+                    )
+
+    @staticmethod
+    def _repair_okx_history_scopes(connection: sqlite3.Connection) -> None:
+        for table, identity_column in (
+            ("orders", "order_id"),
+            ("fills", "trade_id"),
+        ):
+            rows = connection.execute(
+                f"""
+                SELECT rowid AS storage_id, account, symbol,
+                       {identity_column} AS identity, market_scope, source
+                FROM {table}
+                WHERE exchange = 'okx'
+                ORDER BY rowid
+                """
+            ).fetchall()
+            grouped: dict[tuple[str, str, str], list[sqlite3.Row]] = {}
+            for row in rows:
+                key = (
+                    str(row["account"]),
+                    str(row["symbol"]),
+                    str(row["identity"]),
+                )
+                grouped.setdefault(key, []).append(row)
+
+            for duplicates in grouped.values():
+                canonical_scope = okx_history_market_scope({
+                    "symbol": duplicates[0]["symbol"],
+                })
+                if canonical_scope is None:
+                    continue
+                preferred = min(
+                    duplicates,
+                    key=lambda row: (
+                        str(row["source"]) != "live",
+                        str(row["market_scope"]) != canonical_scope,
+                        -int(row["storage_id"]),
+                    ),
+                )
+                connection.executemany(
+                    f"DELETE FROM {table} WHERE rowid = ?",
+                    [
+                        (int(row["storage_id"]),)
+                        for row in duplicates
+                        if int(row["storage_id"])
+                        != int(preferred["storage_id"])
+                    ],
+                )
+                if str(preferred["market_scope"]) != canonical_scope:
+                    connection.execute(
+                        f"UPDATE {table} SET market_scope = ? WHERE rowid = ?",
+                        (canonical_scope, int(preferred["storage_id"])),
+                    )
+
+    @staticmethod
+    def _repair_replaced_derived_position_history(
+        connection: sqlite3.Connection,
+    ) -> None:
+        connection.execute(
+            """
+            DELETE FROM position_history
+            WHERE source = 'derived'
+              AND EXISTS (
+                  SELECT 1
+                  FROM position_history AS authoritative
+                  WHERE authoritative.id != position_history.id
+                    AND authoritative.source IN ('native', 'trades')
+                    AND authoritative.account = position_history.account
+                    AND authoritative.exchange = position_history.exchange
+                    AND authoritative.symbol = position_history.symbol
+                    AND (
+                        LOWER(authoritative.side) = LOWER(position_history.side)
+                        OR LOWER(authoritative.side) IN ('', 'net')
+                        OR LOWER(position_history.side) IN ('', 'net')
+                    )
+                    AND ABS(
+                        (julianday(authoritative.opened_at)
+                         - julianday(position_history.opened_at)) * 86400.0
+                    ) <= 1.0
+              )
+            """
+        )
+
+    @staticmethod
+    def _repair_okx_intermediate_position_history(
+        connection: sqlite3.Connection,
+    ) -> None:
+        connection.execute(
+            """
+            DELETE FROM position_history
+            WHERE exchange = 'okx' AND source = 'native'
+              AND EXISTS (
+                  SELECT 1
+                  FROM position_history AS final
+                  WHERE final.id != position_history.id
+                    AND final.exchange = 'okx'
+                    AND final.source = 'native'
+                    AND final.account = position_history.account
+                    AND final.market_scope = position_history.market_scope
+                    AND final.symbol = position_history.symbol
+                    AND LOWER(final.side) = LOWER(position_history.side)
+                    AND final.opened_at = position_history.opened_at
+                    AND final.closed_at > position_history.closed_at
+              )
+            """
+        )
+
+    @staticmethod
+    def _rebuild_fill_position_history(
+        connection: sqlite3.Connection,
+        exchange: str,
+        groups: set[tuple[str, str, str]] | None = None,
+    ) -> None:
+        if groups is None:
+            groups = {
+                (str(row["account"]), str(row["market_scope"]), str(row["symbol"]))
+                for row in connection.execute(
+                    """
+                    SELECT DISTINCT account, market_scope, symbol
+                    FROM fills
+                    WHERE exchange = ? AND symbol != ''
+                    """,
+                    (exchange,),
+                )
+            }
+        for account, market_scope, symbol in groups:
+            rows = []
+            for row in connection.execute(
+                """
+                SELECT trade_id, occurred_at, payload_json
+                FROM fills
+                WHERE account = ? AND exchange = ?
+                  AND market_scope = ? AND symbol = ?
+                ORDER BY occurred_at, trade_id
+                """,
+                (account, exchange, market_scope, symbol),
+            ):
+                rows.append({
+                    "trade_id": str(row["trade_id"]),
+                    "occurred_at": str(row["occurred_at"] or ""),
+                    "payload": _payload_object(row["payload_json"]),
+                })
+            rebuilt = reconstruct_position_history_from_fills(
+                account,
+                exchange,
+                market_scope,
+                symbol,
+                rows,
+                infer_linear_pnl=(
+                    exchange == "hyperliquid"
+                    or (exchange == "binance" and market_scope == "usd_m")
+                ),
+            )
+            if exchange == "hyperliquid":
+                connection.execute(
+                    """
+                    DELETE FROM position_history
+                    WHERE account = ? AND exchange = 'hyperliquid'
+                      AND symbol = ? AND source = 'trades'
+                    """,
+                    (account, symbol),
+                )
+            else:
+                connection.execute(
+                    """
+                    DELETE FROM position_history
+                    WHERE account = ? AND exchange = ?
+                      AND market_scope = ? AND symbol = ? AND source = 'trades'
+                    """,
+                    (account, exchange, market_scope, symbol),
+                )
+            for record in rebuilt:
+                payload = record["payload"]
+                connection.execute(
+                    """
+                    INSERT INTO position_history (
+                        account, exchange, position_key, market_scope, dex,
+                        symbol, side, opened_at, closed_at, source, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'trades', ?)
+                    ON CONFLICT(account, position_key, opened_at, closed_at)
+                    DO UPDATE SET payload_json = excluded.payload_json,
+                                  source = excluded.source
+                    """,
+                    (
+                        account,
+                        exchange,
+                        record["position_key"],
+                        market_scope,
+                        market_scope if exchange == "hyperliquid" else "",
+                        symbol,
+                        str(payload.get("side") or ""),
+                        record["opened_at"],
+                        record["closed_at"],
+                        _json(payload),
+                    ),
+                )
+                if exchange == "hyperliquid":
+                    connection.execute(
+                        """
+                        DELETE FROM position_history
+                        WHERE account = ? AND exchange = 'hyperliquid'
+                          AND symbol = ? AND source = 'derived'
+                          AND opened_at <= ? AND closed_at >= ?
+                        """,
+                        (
+                            account,
+                            symbol,
+                            record["closed_at"],
+                            record["opened_at"],
+                        ),
+                    )
+                else:
+                    connection.execute(
+                        """
+                        DELETE FROM position_history
+                        WHERE account = ? AND exchange = ?
+                          AND market_scope = ? AND symbol = ?
+                          AND source = 'derived'
+                          AND opened_at <= ? AND closed_at >= ?
+                        """,
+                        (
+                            account,
+                            exchange,
+                            market_scope,
+                            symbol,
+                            record["closed_at"],
+                            record["opened_at"],
+                        ),
+                    )
+
+    @staticmethod
+    def _rebuild_binance_position_history(
+        connection: sqlite3.Connection,
+        groups: set[tuple[str, str, str]] | None = None,
+    ) -> None:
+        AccountCache._rebuild_fill_position_history(
+            connection,
+            "binance",
+            groups,
+        )
+
+    @staticmethod
+    def _rebuild_hyperliquid_position_history(
+        connection: sqlite3.Connection,
+        groups: set[tuple[str, str, str]] | None = None,
+    ) -> None:
+        AccountCache._rebuild_fill_position_history(
+            connection,
+            "hyperliquid",
+            groups,
+        )
 
     def apply_positions_snapshot(self, payload: dict[str, Any]) -> None:
         connection = self._connect()
@@ -294,26 +779,46 @@ class AccountCache:
                 for key, row in existing.items():
                     if key in active_keys:
                         continue
-                    connection.execute(
+                    completed_from_fills = connection.execute(
                         """
-                        INSERT OR IGNORE INTO position_history (
-                            account, exchange, position_key, market_scope, dex,
-                            symbol, side, opened_at, closed_at, source, payload_json
-                        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'derived', ?)
+                        SELECT 1 FROM position_history
+                        WHERE account = ? AND exchange = ?
+                          AND (? = 'hyperliquid' OR market_scope = ?)
+                          AND symbol = ? AND source = 'trades'
+                          AND opened_at <= ? AND closed_at >= ?
+                        LIMIT 1
                         """,
                         (
                             row["account"],
                             row["exchange"],
-                            row["position_key"],
+                            row["exchange"],
                             row["market_scope"],
-                            row["dex"],
                             row["symbol"],
-                            row["side"],
-                            row["opened_at"],
                             observed_at,
-                            row["payload_json"],
+                            row["opened_at"],
                         ),
-                    )
+                    ).fetchone()
+                    if completed_from_fills is None:
+                        connection.execute(
+                            """
+                            INSERT OR IGNORE INTO position_history (
+                                account, exchange, position_key, market_scope, dex,
+                                symbol, side, opened_at, closed_at, source, payload_json
+                            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'derived', ?)
+                            """,
+                            (
+                                row["account"],
+                                row["exchange"],
+                                row["position_key"],
+                                row["market_scope"],
+                                row["dex"],
+                                row["symbol"],
+                                row["side"],
+                                row["opened_at"],
+                                observed_at,
+                                row["payload_json"],
+                            ),
+                        )
                     connection.execute(
                         "DELETE FROM current_positions WHERE account = ? AND position_key = ?",
                         (account, key),
@@ -327,11 +832,17 @@ class AccountCache:
         self,
         orders: list[dict[str, Any]],
         fills: list[dict[str, Any]],
+        positions: list[dict[str, Any]] | None = None,
+        cursors: list[dict[str, Any]] | None = None,
     ) -> None:
-        if not orders and not fills:
+        positions = positions or []
+        cursors = cursors or []
+        if not orders and not fills and not positions and not cursors:
             return
         connection = self._connect()
         connection.execute("BEGIN IMMEDIATE")
+        touched_binance_fills: set[tuple[str, str, str]] = set()
+        touched_hyperliquid_fills: set[tuple[str, str, str]] = set()
         try:
             for record in orders:
                 payload = record.get("payload")
@@ -342,6 +853,20 @@ class AccountCache:
                 order_id = str(payload.get("id") or "").strip()
                 symbol = str(payload.get("symbol") or "")
                 market_scope = str(record.get("market_scope") or "")
+                if exchange == "hyperliquid":
+                    market_scope = hyperliquid_market_scope(symbol)
+                elif exchange == "okx":
+                    market_scope = (
+                        okx_history_market_scope(payload) or market_scope
+                    )
+                elif (
+                    exchange == "bitget"
+                    and not bitget_history_item_matches_scope(
+                        payload,
+                        market_scope,
+                    )
+                ):
+                    continue
                 if not account or not exchange or not order_id:
                     continue
                 created_at = _timestamp(
@@ -357,17 +882,25 @@ class AccountCache:
                     INSERT INTO orders (
                         account, exchange, order_id, client_order_id,
                         market_scope, symbol, status, side, order_type,
-                        created_at, updated_at, payload_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        created_at, updated_at, source, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(
                         account, exchange, market_scope, symbol, order_id
                     ) DO UPDATE SET
                         client_order_id = excluded.client_order_id,
                         status = excluded.status,
                         side = excluded.side,
-                        order_type = excluded.order_type,
+                        order_type = CASE
+                            WHEN excluded.order_type != ''
+                            THEN excluded.order_type
+                            ELSE orders.order_type
+                        END,
                         created_at = COALESCE(orders.created_at, excluded.created_at),
                         updated_at = excluded.updated_at,
+                        source = CASE
+                            WHEN excluded.source = 'live' THEN 'live'
+                            ELSE orders.source
+                        END,
                         payload_json = excluded.payload_json
                     WHERE orders.updated_at IS NULL
                         OR excluded.updated_at IS NULL
@@ -385,10 +918,10 @@ class AccountCache:
                         str(payload.get("type") or ""),
                         created_at,
                         updated_at,
+                        str(record.get("source") or "live"),
                         _json(payload),
                     ),
                 )
-
             for record in fills:
                 payload = record.get("payload")
                 if not isinstance(payload, dict):
@@ -398,6 +931,20 @@ class AccountCache:
                 trade_id = str(payload.get("id") or "").strip()
                 symbol = str(payload.get("symbol") or "")
                 market_scope = str(record.get("market_scope") or "")
+                if exchange == "hyperliquid":
+                    market_scope = hyperliquid_market_scope(symbol)
+                elif exchange == "okx":
+                    market_scope = (
+                        okx_history_market_scope(payload) or market_scope
+                    )
+                elif (
+                    exchange == "bitget"
+                    and not bitget_history_item_matches_scope(
+                        payload,
+                        market_scope,
+                    )
+                ):
+                    continue
                 if not account or not exchange or not trade_id:
                     continue
                 occurred_at = _timestamp(
@@ -408,14 +955,18 @@ class AccountCache:
                     """
                     INSERT INTO fills (
                         account, exchange, trade_id, order_id, market_scope,
-                        symbol, side, occurred_at, payload_json
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        symbol, side, occurred_at, source, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     ON CONFLICT(
                         account, exchange, market_scope, symbol, trade_id
                     ) DO UPDATE SET
                         order_id = excluded.order_id,
                         side = excluded.side,
                         occurred_at = excluded.occurred_at,
+                        source = CASE
+                            WHEN excluded.source = 'live' THEN 'live'
+                            ELSE fills.source
+                        END,
                         payload_json = excluded.payload_json
                     """,
                     (
@@ -427,8 +978,101 @@ class AccountCache:
                         symbol,
                         str(payload.get("side") or ""),
                         occurred_at,
+                        str(record.get("source") or "live"),
                         _json(payload),
                     ),
+                )
+                if exchange == "binance":
+                    touched_binance_fills.add((account, market_scope, symbol))
+                elif exchange == "hyperliquid":
+                    touched_hyperliquid_fills.add(
+                        (account, market_scope, symbol),
+                    )
+
+            for record in positions:
+                payload = record.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                account = str(record.get("account") or "").strip()
+                exchange = str(record.get("exchange") or "").strip()
+                position_key = str(record.get("position_key") or "").strip()
+                opened_at = str(record.get("opened_at") or "").strip()
+                closed_at = str(record.get("closed_at") or "").strip()
+                symbol = str(payload.get("symbol") or "")
+                side = str(payload.get("side") or "")
+                if not all((account, exchange, position_key, opened_at, closed_at, symbol)):
+                    continue
+                connection.execute(
+                    """
+                    INSERT INTO position_history (
+                        account, exchange, position_key, market_scope, dex,
+                        symbol, side, opened_at, closed_at, source, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account, position_key, opened_at, closed_at)
+                    DO UPDATE SET
+                        exchange = excluded.exchange,
+                        market_scope = excluded.market_scope,
+                        dex = excluded.dex,
+                        symbol = excluded.symbol,
+                        side = excluded.side,
+                        source = excluded.source,
+                        payload_json = excluded.payload_json
+                    """,
+                    (
+                        account,
+                        exchange,
+                        position_key,
+                        str(record.get("market_scope") or ""),
+                        str(record.get("dex") or ""),
+                        symbol,
+                        side,
+                        opened_at,
+                        closed_at,
+                        str(record.get("source") or "native"),
+                        _json(payload),
+                    ),
+                )
+
+            if positions:
+                self._repair_replaced_derived_position_history(connection)
+                self._repair_okx_intermediate_position_history(connection)
+
+            for record in cursors:
+                account = str(record.get("account") or "").strip()
+                exchange = str(record.get("exchange") or "").strip()
+                stream = str(record.get("stream") or "").strip()
+                market_scope = str(record.get("market_scope") or "")
+                updated_at = str(record.get("updated_at") or "").strip()
+                if not all((account, exchange, stream, updated_at)):
+                    continue
+                connection.execute(
+                    """
+                    INSERT INTO sync_cursors (
+                        account, exchange, stream, market_scope, cursor, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account, exchange, stream, market_scope)
+                    DO UPDATE SET
+                        cursor = excluded.cursor,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        account,
+                        exchange,
+                        stream,
+                        market_scope,
+                        str(record.get("cursor") or ""),
+                        updated_at,
+                    ),
+                )
+            if touched_binance_fills:
+                self._rebuild_binance_position_history(
+                    connection,
+                    touched_binance_fills,
+                )
+            if touched_hyperliquid_fills:
+                self._rebuild_hyperliquid_position_history(
+                    connection,
+                    touched_hyperliquid_fills,
                 )
             connection.commit()
         except BaseException:
@@ -446,6 +1090,340 @@ class AccountCache:
             raise ValueError(f"unsupported account cache table: {table}")
         connection = self._connect()
         return [dict(row) for row in connection.execute(f"SELECT * FROM {table}")]
+
+    def sync_cursors(self) -> dict[tuple[str, str, str, str], str]:
+        connection = self._connect()
+        return {
+            (
+                str(row["account"]),
+                str(row["exchange"]),
+                str(row["stream"]),
+                str(row["market_scope"]),
+            ): str(row["cursor"] or "")
+            for row in connection.execute("SELECT * FROM sync_cursors")
+        }
+
+    def known_history_symbols(self) -> dict[str, set[str]]:
+        connection = self._connect()
+        symbols: dict[str, set[str]] = {}
+        for table in ("current_positions", "position_history", "orders", "fills"):
+            for row in connection.execute(
+                f"SELECT DISTINCT exchange, symbol FROM {table} WHERE symbol != ''"
+            ):
+                symbols.setdefault(str(row["exchange"]), set()).add(str(row["symbol"]))
+        return symbols
+
+    def _history_groups(
+        self,
+        *,
+        table: str,
+        timestamp_expression: str,
+        exchange: str = "",
+    ) -> dict[str, Any]:
+        if table not in {"position_history", "orders"}:
+            raise ValueError(f"unsupported history table: {table}")
+
+        normalized_exchange = exchange.strip().lower()
+        connection = self._read_connection()
+        if connection is None:
+            return {"results": [], "total": 0}
+        try:
+            if normalized_exchange:
+                rows = connection.execute(
+                    f"""
+                    SELECT MIN(exchange) AS exchange, MIN(symbol) AS symbol,
+                           COUNT(*) AS record_count,
+                           COUNT(DISTINCT account) AS account_count,
+                           MAX({timestamp_expression}) AS latest_at
+                    FROM {table}
+                    WHERE LOWER(exchange) = ? AND symbol != ''
+                    GROUP BY LOWER(symbol)
+                    ORDER BY latest_at DESC, LOWER(symbol)
+                    """,
+                    (normalized_exchange,),
+                ).fetchall()
+            else:
+                rows = connection.execute(
+                    f"""
+                    SELECT MIN(exchange) AS exchange, '' AS symbol,
+                           COUNT(*) AS record_count,
+                           COUNT(DISTINCT account) AS account_count,
+                           MAX({timestamp_expression}) AS latest_at
+                    FROM {table}
+                    WHERE exchange != ''
+                    GROUP BY LOWER(exchange)
+                    ORDER BY latest_at DESC, LOWER(exchange)
+                    """
+                ).fetchall()
+        finally:
+            connection.close()
+
+        results = [dict(row) for row in rows]
+        return {
+            "results": results,
+            "total": sum(int(row["record_count"] or 0) for row in rows),
+        }
+
+    def position_history_groups(self, *, exchange: str = "") -> dict[str, Any]:
+        return self._history_groups(
+            table="position_history",
+            timestamp_expression="closed_at",
+            exchange=exchange,
+        )
+
+    def order_history_groups(self, *, exchange: str = "") -> dict[str, Any]:
+        return self._history_groups(
+            table="orders",
+            timestamp_expression="COALESCE(updated_at, created_at, '')",
+            exchange=exchange,
+        )
+
+    def history_accounts(
+        self,
+        *,
+        kind: str,
+        exchange: str = "",
+        symbol: str = "",
+    ) -> list[str]:
+        table = {
+            "order": "orders",
+            "position": "position_history",
+        }.get(kind)
+        if table is None:
+            raise ValueError(f"unsupported history kind: {kind}")
+
+        filters: list[str] = []
+        params: list[str] = []
+        for column, value in (("exchange", exchange), ("symbol", symbol)):
+            normalized = value.strip().lower()
+            if normalized:
+                filters.append(f"LOWER({column}) = ?")
+                params.append(normalized)
+        where = f"WHERE {' AND '.join(filters)}" if filters else ""
+
+        connection = self._read_connection()
+        if connection is None:
+            return []
+        try:
+            rows = connection.execute(
+                f"""
+                SELECT DISTINCT account
+                FROM {table}
+                {where}
+                ORDER BY LOWER(account)
+                """,
+                params,
+            ).fetchall()
+        finally:
+            connection.close()
+        return [str(row["account"]) for row in rows if row["account"]]
+
+    def position_history_page(
+        self,
+        *,
+        cursor: str | None = None,
+        limit: int = 50,
+        account: str = "",
+        exchange: str = "",
+        symbol: str = "",
+        exact_market: bool = False,
+    ) -> dict[str, Any]:
+        page_size = _page_limit(limit)
+        decoded_cursor = _decode_cursor(cursor, 2)
+        filters: list[str] = []
+        filter_params: list[Any] = []
+        for column, value in (
+            ("account", account),
+            ("exchange", exchange),
+            ("symbol", symbol),
+        ):
+            normalized = value.strip().lower()
+            if normalized:
+                if exact_market and column in {"exchange", "symbol"}:
+                    filters.append(f"LOWER({column}) = ?")
+                    filter_params.append(normalized)
+                else:
+                    filters.append(f"LOWER({column}) LIKE ?")
+                    filter_params.append(f"%{normalized}%")
+
+        connection = self._read_connection()
+        if connection is None:
+            return {"results": [], "next_cursor": None, "total": 0}
+        try:
+            filter_sql = f" WHERE {' AND '.join(filters)}" if filters else ""
+            total = int(connection.execute(
+                f"SELECT COUNT(*) FROM position_history{filter_sql}",
+                filter_params,
+            ).fetchone()[0])
+
+            conditions = list(filters)
+            params = list(filter_params)
+            if decoded_cursor is not None:
+                closed_at, row_id = decoded_cursor
+                if not isinstance(closed_at, str) or not isinstance(row_id, int):
+                    raise ValueError("invalid history cursor")
+                conditions.append("(closed_at < ? OR (closed_at = ? AND id < ?))")
+                params.extend((closed_at, closed_at, row_id))
+            where_sql = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+            rows = connection.execute(
+                f"""
+                SELECT id, account, exchange, market_scope, dex, symbol, side,
+                       opened_at, closed_at, source, payload_json,
+                       EXISTS (
+                           SELECT 1
+                           FROM current_positions AS active
+                           WHERE active.account = position_history.account
+                             AND active.exchange = position_history.exchange
+                             AND (
+                                 active.market_scope = position_history.market_scope
+                                 OR active.market_scope = ''
+                                 OR position_history.market_scope = ''
+                             )
+                             AND active.symbol = position_history.symbol
+                             AND ABS(
+                                 (julianday(active.opened_at)
+                                  - julianday(position_history.opened_at)) * 86400.0
+                             ) <= 2.0
+                       ) AS remains_open
+                FROM position_history
+                {where_sql}
+                ORDER BY closed_at DESC, id DESC
+                LIMIT ?
+                """,
+                [*params, page_size + 1],
+            ).fetchall()
+        finally:
+            connection.close()
+
+        has_more = len(rows) > page_size
+        page_rows = rows[:page_size]
+        results = []
+        for row in page_rows:
+            position = _payload_object(row["payload_json"])
+            opened_at = (
+                None
+                if position.get("opened_at_known") is False
+                else row["opened_at"]
+            )
+            results.append({
+                "id": int(row["id"]),
+                "account": row["account"],
+                "exchange": row["exchange"],
+                "market_scope": row["market_scope"],
+                "dex": row["dex"],
+                "symbol": row["symbol"],
+                "side": row["side"],
+                "opened_at": opened_at,
+                "closed_at": row["closed_at"],
+                "close_status": (
+                    "partially_closed" if row["remains_open"] else "fully_closed"
+                ),
+                "source": row["source"],
+                "position": position,
+            })
+        next_cursor = None
+        if has_more and page_rows:
+            last = page_rows[-1]
+            next_cursor = _encode_cursor([last["closed_at"], int(last["id"])])
+        return {"results": results, "next_cursor": next_cursor, "total": total}
+
+    def order_history_page(
+        self,
+        *,
+        cursor: str | None = None,
+        limit: int = 50,
+        account: str = "",
+        exchange: str = "",
+        symbol: str = "",
+        status: str = "",
+        exact_market: bool = False,
+    ) -> dict[str, Any]:
+        page_size = _page_limit(limit)
+        decoded_cursor = _decode_cursor(cursor, 2)
+        filters: list[str] = []
+        filter_params: list[Any] = []
+        for column, value in (
+            ("account", account),
+            ("exchange", exchange),
+            ("symbol", symbol),
+        ):
+            normalized = value.strip().lower()
+            if normalized:
+                if exact_market and column in {"exchange", "symbol"}:
+                    filters.append(f"LOWER({column}) = ?")
+                    filter_params.append(normalized)
+                else:
+                    filters.append(f"LOWER({column}) LIKE ?")
+                    filter_params.append(f"%{normalized}%")
+        normalized_status = status.strip().lower()
+        if normalized_status:
+            filters.append("LOWER(status) = ?")
+            filter_params.append(normalized_status)
+
+        connection = self._read_connection()
+        if connection is None:
+            return {"results": [], "next_cursor": None, "total": 0}
+        sort_expression = "COALESCE(updated_at, created_at, '')"
+        try:
+            filter_sql = f" WHERE {' AND '.join(filters)}" if filters else ""
+            total = int(connection.execute(
+                f"SELECT COUNT(*) FROM orders{filter_sql}",
+                filter_params,
+            ).fetchone()[0])
+
+            conditions = list(filters)
+            params = list(filter_params)
+            if decoded_cursor is not None:
+                sort_at, row_id = decoded_cursor
+                if not isinstance(sort_at, str) or not isinstance(row_id, int):
+                    raise ValueError("invalid history cursor")
+                conditions.append(
+                    f"({sort_expression} < ? OR "
+                    f"({sort_expression} = ? AND rowid < ?))"
+                )
+                params.extend((sort_at, sort_at, row_id))
+            where_sql = f" WHERE {' AND '.join(conditions)}" if conditions else ""
+            rows = connection.execute(
+                f"""
+                SELECT rowid AS row_id, account, exchange, order_id,
+                       client_order_id, market_scope, symbol, status, side,
+                       order_type, created_at, updated_at, source,
+                       {sort_expression} AS sort_at, payload_json
+                FROM orders
+                {where_sql}
+                ORDER BY sort_at DESC, row_id DESC
+                LIMIT ?
+                """,
+                [*params, page_size + 1],
+            ).fetchall()
+        finally:
+            connection.close()
+
+        has_more = len(rows) > page_size
+        page_rows = rows[:page_size]
+        results = [
+            {
+                "account": row["account"],
+                "exchange": row["exchange"],
+                "order_id": row["order_id"],
+                "client_order_id": row["client_order_id"],
+                "market_scope": row["market_scope"],
+                "symbol": row["symbol"],
+                "status": row["status"],
+                "side": row["side"],
+                "order_type": row["order_type"],
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+                "source": row["source"],
+                "order": _payload_object(row["payload_json"]),
+            }
+            for row in page_rows
+        ]
+        next_cursor = None
+        if has_more and page_rows:
+            last = page_rows[-1]
+            next_cursor = _encode_cursor([last["sort_at"], int(last["row_id"])])
+        return {"results": results, "next_cursor": next_cursor, "total": total}
 
     def close(self) -> None:
         connection = self._connection

--- a/account_service/csv_import.py
+++ b/account_service/csv_import.py
@@ -5,11 +5,17 @@ import hashlib
 import io
 import json
 import re
+import ssl
 import urllib.request
 from datetime import UTC, datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
+
+try:
+    import certifi
+except ModuleNotFoundError:  # pragma: no cover - provider extras install certifi
+    certifi = None
 
 from account_service.history import reconstruct_position_history_from_fills
 
@@ -186,6 +192,11 @@ def _hyperliquid_symbol(value: Any) -> tuple[str, str]:
     raw = _clean(value)
     if not raw:
         return "", "default"
+    display_match = re.fullmatch(r"(.+?)\s*\(([^()]+)\)", raw)
+    if display_match is not None:
+        coin = display_match.group(1).strip().upper()
+        dex_name = display_match.group(2).strip().lower() or "default"
+        return f"{dex_name.upper()}-{coin}/USDC:USDC", dex_name
     if "/" in raw:
         return raw.upper(), "spot"
     if ":" in raw:
@@ -193,6 +204,70 @@ def _hyperliquid_symbol(value: Any) -> tuple[str, str]:
         dex_name = dex.strip().lower() or "default"
         return f"{dex_name.upper()}-{coin.strip().upper()}/USDC:USDC", dex_name
     return f"{raw.upper()}/USDC:USDC", "default"
+
+
+def canonicalize_hyperliquid_symbol(
+    symbol: str,
+    aliases: dict[tuple[str, str], tuple[str, str]],
+) -> tuple[str, str]:
+    normalized = _clean(symbol).upper()
+    if not normalized:
+        return "", "default"
+    if "/" in normalized and ":" not in normalized:
+        return normalized, "spot"
+    base = normalized.split("/", 1)[0]
+    if "-" not in base:
+        return normalized, "default"
+    dex_name, coin = base.split("-", 1)
+    return aliases.get(
+        (dex_name.lower(), coin),
+        (normalized, dex_name.lower()),
+    )
+
+
+def canonicalize_hyperliquid_import_batch(
+    batch: dict[str, Any],
+    account: str,
+    aliases: dict[tuple[str, str], tuple[str, str]],
+) -> None:
+    for category in ("orders", "fills", "positions"):
+        records = batch.get(category)
+        if not isinstance(records, list):
+            continue
+        for record in records:
+            if (
+                not isinstance(record, dict)
+                or record.get("account") != account
+                or record.get("exchange") != "hyperliquid"
+            ):
+                continue
+            payload = record.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            symbol, scope = canonicalize_hyperliquid_symbol(
+                str(payload.get("symbol") or ""),
+                aliases,
+            )
+            payload["symbol"] = symbol
+            record["market_scope"] = scope
+            if category == "positions":
+                record["dex"] = scope
+
+    events = batch.get("pnl_events")
+    if not isinstance(events, list):
+        return
+    for record in events:
+        if (
+            not isinstance(record, dict)
+            or record.get("account") != account
+            or record.get("exchange") != "hyperliquid"
+        ):
+            continue
+        symbol, _ = canonicalize_hyperliquid_symbol(
+            str(record.get("symbol") or ""),
+            aliases,
+        )
+        record["symbol"] = symbol
 
 
 def _rows_from_bytes(content: bytes) -> tuple[list[list[str]], str]:
@@ -496,7 +571,12 @@ def _parse_bitget(
             symbol, side, margin_mode = _bitget_future_parts(row.get("Futures"))
             gross = _decimal(row.get("Realized PnL"))
             net = _decimal(row.get("Position Pnl"))
-            fees = gross - net if gross is not None and net is not None else None
+            funding = _decimal(row.get("Fees"))
+            fees = (
+                gross + funding - net
+                if gross is not None and funding is not None and net is not None
+                else None
+            )
             currency_match = re.search(r"([A-Za-z]+)$", _clean(row.get("Position Pnl")))
             currency = currency_match.group(1).upper() if currency_match else "USDT"
             result["positions"].append(_position_record(
@@ -517,7 +597,14 @@ def _parse_bitget(
                         "fees": format(fees, "f") if fees is not None else None,
                         "net_pnl": format(net, "f") if net is not None else None,
                         "currency": currency,
-                        "complete": gross is not None and net is not None,
+                        "complete": all(
+                            value is not None
+                            for value in (gross, net, funding, fees)
+                        ),
+                        "funding": (
+                            format(funding, "f") if funding is not None else None
+                        ),
+                        "funding_source": "position",
                         "funding_or_other": _number_text(row.get("Fees")),
                         "opening_fee": _number_text(row.get("Opening fee")),
                         "closing_fee": _number_text(row.get("Closing fee")),
@@ -593,7 +680,11 @@ def _parse_okx(
             funding = _decimal(row.get("Funding Fee"))
             liquidation = _decimal(row.get("Liquidation Clearance Fee"))
             net = _sum_decimal(gross, fee, funding, liquidation)
-            fee_cost = gross - net if gross is not None and net is not None else None
+            fee_cost = (
+                gross + funding - net
+                if gross is not None and funding is not None and net is not None
+                else None
+            )
             currency = _clean(row.get("Margin Currency")).upper() or "USDT"
             result["positions"].append(_position_record(
                 exchange="okx",
@@ -614,6 +705,7 @@ def _parse_okx(
                         "net_pnl": format(net, "f") if net is not None else None,
                         "currency": currency,
                         "complete": net is not None,
+                        "funding_source": "position",
                         "trading_fee": format(fee, "f") if fee is not None else None,
                         "funding": format(funding, "f") if funding is not None else None,
                         "liquidation_fee": (
@@ -711,7 +803,7 @@ def _parse_hyperliquid(
                 row.get("payment"),
                 row.get("rate"),
             )
-            result["pnl_events"].append(_event_record(
+            event = _event_record(
                 "hyperliquid",
                 event_id,
                 "funding",
@@ -720,7 +812,13 @@ def _parse_hyperliquid(
                 _number_text(row.get("payment"), "0") or "0",
                 "USDC",
                 "funding",
-            ))
+            )
+            event["payload"].update({
+                "side": _clean(row.get("side")).lower(),
+                "size": _number_text(row.get("sz")),
+                "rate": _number_text(row.get("rate")),
+            })
+            result["pnl_events"].append(event)
             continue
 
         direction = _clean(row.get("dir"))
@@ -1031,6 +1129,62 @@ def build_history_import_batch(specs: list[dict[str, Any]]) -> dict[str, Any]:
     return batch
 
 
+def _hyperliquid_info_request(
+    body: dict[str, Any],
+    *,
+    timeout: float,
+) -> Any:
+    request = urllib.request.Request(
+        "https://api.hyperliquid.xyz/info",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json", "User-Agent": "PyneReal/1"},
+        method="POST",
+    )
+    context = ssl.create_default_context(
+        cafile=certifi.where() if certifi is not None else None,
+    )
+    with urllib.request.urlopen(  # noqa: S310
+        request,
+        timeout=timeout,
+        context=context,
+    ) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def fetch_hyperliquid_symbol_aliases(
+    *,
+    timeout: float = 30.0,
+) -> dict[tuple[str, str], tuple[str, str]]:
+    payload = _hyperliquid_info_request(
+        {"type": "perpConciseAnnotations"},
+        timeout=timeout,
+    )
+    if not isinstance(payload, list):
+        raise HistoryCsvError(
+            "Hyperliquid perpConciseAnnotations returned an invalid response"
+        )
+    aliases: dict[tuple[str, str], tuple[str, str]] = {}
+    for item in payload:
+        if not isinstance(item, list) or len(item) != 2:
+            continue
+        raw_coin, annotation = item
+        if not isinstance(annotation, dict):
+            continue
+        coin_name = _clean(raw_coin)
+        if ":" not in coin_name:
+            continue
+        dex_name, coin = coin_name.split(":", 1)
+        dex_name = dex_name.strip().lower()
+        coin = coin.strip().upper()
+        display_name = _clean(annotation.get("displayName")).upper()
+        if not dex_name or not coin or not display_name:
+            continue
+        canonical = (f"{dex_name.upper()}-{coin}/USDC:USDC", dex_name)
+        aliases[(dex_name, display_name)] = canonical
+        aliases[(dex_name, coin)] = canonical
+    return aliases
+
+
 def fetch_hyperliquid_historical_orders(
     wallet_address: str,
     account: str,
@@ -1041,15 +1195,10 @@ def fetch_hyperliquid_historical_orders(
     address = _clean(wallet_address)
     if not re.fullmatch(r"0x[0-9a-fA-F]{40}", address):
         raise HistoryCsvError("Hyperliquid account requires a valid walletAddress")
-    body = json.dumps({"type": "historicalOrders", "user": address}).encode("utf-8")
-    request = urllib.request.Request(
-        "https://api.hyperliquid.xyz/info",
-        data=body,
-        headers={"Content-Type": "application/json", "User-Agent": "PyneReal/1"},
-        method="POST",
+    payload = _hyperliquid_info_request(
+        {"type": "historicalOrders", "user": address},
+        timeout=timeout,
     )
-    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
-        payload = json.loads(response.read().decode("utf-8"))
     if not isinstance(payload, list):
         raise HistoryCsvError("Hyperliquid historicalOrders returned an invalid response")
     orders: list[dict[str, Any]] = []

--- a/account_service/csv_import.py
+++ b/account_service/csv_import.py
@@ -1,0 +1,1118 @@
+from __future__ import annotations
+
+import csv
+import hashlib
+import io
+import json
+import re
+import urllib.request
+from datetime import UTC, datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+from account_service.history import reconstruct_position_history_from_fills
+
+
+MAX_IMPORT_FILES = 32
+MAX_IMPORT_FILE_BYTES = 32 * 1024 * 1024
+MAX_IMPORT_TOTAL_BYTES = 96 * 1024 * 1024
+DEFAULT_TIMEZONE = "UTC+09:00"
+TIMEZONE_CONFIRMATION_WARNING = "Confirm the source timezone before importing."
+
+
+class HistoryCsvError(ValueError):
+    pass
+
+
+def _clean(value: Any) -> str:
+    return str("" if value is None else value).replace("\ufeff", "").strip()
+
+
+def _decimal(value: Any) -> Decimal | None:
+    text = _clean(value).replace(",", "")
+    if not text:
+        return None
+    match = re.match(r"^[\t ]*([+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[eE][+-]?\d+)?)", text)
+    if match is None:
+        return None
+    try:
+        result = Decimal(match.group(1))
+    except InvalidOperation:
+        return None
+    return result if result.is_finite() else None
+
+
+def _number_text(value: Any, default: str | None = None) -> str | None:
+    parsed = _decimal(value)
+    if parsed is None:
+        return default
+    return format(parsed, "f")
+
+
+def _sum_decimal(*values: Any) -> Decimal | None:
+    parsed = [_decimal(value) for value in values]
+    if any(value is None for value in parsed):
+        return None
+    return sum((value for value in parsed if value is not None), Decimal(0))
+
+
+def _timezone_name(offset_minutes: int) -> str:
+    sign = "+" if offset_minutes >= 0 else "-"
+    total = abs(offset_minutes)
+    return f"UTC{sign}{total // 60:02d}:{total % 60:02d}"
+
+
+def timezone_options() -> list[str]:
+    return [_timezone_name(offset * 60) for offset in range(-12, 15)]
+
+
+def _timezone_offset(value: str) -> int:
+    match = re.fullmatch(r"UTC([+-])(\d{2}):(\d{2})", _clean(value).upper())
+    if match is None:
+        raise HistoryCsvError(f"invalid source timezone: {value}")
+    hours = int(match.group(2))
+    minutes = int(match.group(3))
+    if hours > 14 or minutes > 59:
+        raise HistoryCsvError(f"invalid source timezone: {value}")
+    total = hours * 60 + minutes
+    return total if match.group(1) == "+" else -total
+
+
+def _infer_timezone(
+    name: str,
+    metadata_rows: list[list[str]],
+    exchange: str,
+) -> tuple[str, bool]:
+    filename_match = re.search(
+        r"UTC\s*([+-])\s*(\d{1,2})(?::?(\d{2}))?",
+        name,
+        flags=re.IGNORECASE,
+    )
+    if filename_match is not None:
+        sign = 1 if filename_match.group(1) == "+" else -1
+        minutes = int(filename_match.group(2)) * 60 + int(filename_match.group(3) or 0)
+        return _timezone_name(sign * minutes), False
+
+    metadata = " ".join(",".join(row) for row in metadata_rows)
+    okx_match = re.search(r'"userTimeZone"\s*:\s*"?([+-]?\d{1,2})', metadata)
+    if okx_match is not None:
+        return _timezone_name(int(okx_match.group(1)) * 60), False
+
+    return DEFAULT_TIMEZONE, exchange in {"bitget", "hyperliquid"}
+
+
+def _infer_source_account_uid(
+    metadata_rows: list[list[str]],
+    exchange: str,
+) -> str:
+    if exchange != "okx":
+        return ""
+    for row in metadata_rows:
+        for value in row:
+            match = re.fullmatch(r"UID\s*:\s*(\d+)", _clean(value), flags=re.IGNORECASE)
+            if match is not None:
+                return match.group(1)
+    return ""
+
+
+def _parse_timestamp(value: Any, source_timezone: str) -> tuple[str, int]:
+    text = _clean(value)
+    if not text:
+        raise HistoryCsvError("timestamp is empty")
+    parsed: datetime | None = None
+    for pattern in (
+        "%Y-%m-%d %H:%M:%S",
+        "%Y-%m-%d %H:%M:%S.%f",
+        "%m/%d/%Y - %H:%M:%S",
+        "%m/%d/%Y - %H:%M:%S.%f",
+    ):
+        try:
+            parsed = datetime.strptime(text, pattern)
+            break
+        except ValueError:
+            continue
+    if parsed is None:
+        try:
+            parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+        except ValueError as exc:
+            raise HistoryCsvError(f"unsupported timestamp: {text}") from exc
+    if parsed.tzinfo is None:
+        offset = _timezone_offset(source_timezone)
+        parsed = parsed.replace(tzinfo=timezone(timedelta(minutes=offset)))
+    utc_value = parsed.astimezone(UTC)
+    iso = utc_value.isoformat().replace("+00:00", "Z")
+    return iso, int(utc_value.timestamp() * 1000)
+
+
+def _stable_id(prefix: str, *values: Any) -> str:
+    encoded = json.dumps(
+        values,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()[:24]}"
+
+
+def _linear_symbol(value: Any, settlement_hint: str = "") -> str:
+    raw = _clean(value).upper().replace(" ", "")
+    if not raw:
+        return ""
+    if "/" in raw:
+        return raw if ":" in raw else f"{raw}:{raw.rsplit('/', 1)[1]}"
+    for quote in tuple(filter(None, (settlement_hint.upper(), "USDT", "USDC", "BUSD", "USD"))):
+        if raw.endswith(quote) and len(raw) > len(quote):
+            return f"{raw[:-len(quote)]}/{quote}:{quote}"
+    return raw
+
+
+def _okx_symbol(value: Any, instrument: Any = "") -> str:
+    raw = _clean(value).upper()
+    parts = raw.split("-")
+    instrument_type = _clean(instrument).upper()
+    if len(parts) < 2:
+        return raw
+    base, quote = parts[0], parts[1]
+    if instrument_type in {"SWAP", "FUTURES"} or "SWAP" in parts:
+        suffix = [part for part in parts[2:] if part != "SWAP"]
+        settlement = quote
+        contract = settlement + (f"-{'-'.join(suffix)}" if suffix else "")
+        return f"{base}/{quote}:{contract}"
+    return f"{base}/{quote}"
+
+
+def _hyperliquid_symbol(value: Any) -> tuple[str, str]:
+    raw = _clean(value)
+    if not raw:
+        return "", "default"
+    if "/" in raw:
+        return raw.upper(), "spot"
+    if ":" in raw:
+        dex, coin = raw.split(":", 1)
+        dex_name = dex.strip().lower() or "default"
+        return f"{dex_name.upper()}-{coin.strip().upper()}/USDC:USDC", dex_name
+    return f"{raw.upper()}/USDC:USDC", "default"
+
+
+def _rows_from_bytes(content: bytes) -> tuple[list[list[str]], str]:
+    try:
+        text = content.decode("utf-8-sig")
+    except UnicodeDecodeError as exc:
+        raise HistoryCsvError("CSV must be UTF-8 or UTF-8 BOM") from exc
+    rows = [
+        [_clean(cell) for cell in row]
+        for row in csv.reader(io.StringIO(text, newline=""))
+        if any(_clean(cell) for cell in row)
+    ]
+    if not rows:
+        raise HistoryCsvError("CSV is empty")
+    return rows, text
+
+
+_SIGNATURES: list[tuple[str, str, set[str]]] = [
+    ("binance", "position_history", {"Symbol", "Position Side", "Closing PNL", "Opened", "Closed"}),
+    ("binance", "order_history", {"Uid", "Order No", "Update Time", "Executed Amount"}),
+    ("binance", "trade_history", {"Trade ID", "Order ID", "Realized Profit", "Quantity"}),
+    ("binance", "transaction_history", {"Transaction ID", "Type", "Amount", "Asset"}),
+    ("bitget", "position_history", {"Futures", "Opening time", "Position Pnl", "Closed time"}),
+    (
+        "bitget",
+        "order_history",
+        {"Order ID", "Direction", "Futures", "Transaction type", "NetProfits"},
+    ),
+    (
+        "okx",
+        "position_history",
+        {"Position Create Time", "Position Update Time", "Business Line", "Instrument Name"},
+    ),
+    ("okx", "order_history", {"Order ID", "Order Time", "Instrument", "Order Amount", "Bot ID"}),
+    (
+        "okx",
+        "trade_details",
+        {"Order ID", "Trade ID", "Trade Time", "Filled Amount", "taker/maker"},
+    ),
+    ("hyperliquid", "trade_history", {"time", "coin", "dir", "px", "sz", "closedPnl"}),
+    ("hyperliquid", "funding_history", {"time", "coin", "sz", "side", "payment", "rate"}),
+]
+
+
+def _detect_format(rows: list[list[str]]) -> tuple[str, str, int]:
+    for header_index, row in enumerate(rows[:4]):
+        fields = set(row)
+        for exchange, file_type, signature in _SIGNATURES:
+            if signature.issubset(fields):
+                return exchange, file_type, header_index
+    raise HistoryCsvError("unsupported account history CSV format")
+
+
+def _dict_rows(rows: list[list[str]], header_index: int) -> list[dict[str, str]]:
+    header = rows[header_index]
+    results: list[dict[str, str]] = []
+    for values in rows[header_index + 1:]:
+        if not any(values):
+            continue
+        padded = [*values, *([""] * max(0, len(header) - len(values)))]
+        results.append(dict(zip(header, padded, strict=False)))
+    return results
+
+
+def _position_record(
+    *,
+    exchange: str,
+    market_scope: str,
+    symbol: str,
+    side: str,
+    opened_at: str,
+    closed_at: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    position_key = _stable_id(
+        "csv-position",
+        exchange,
+        market_scope,
+        symbol,
+        side,
+        opened_at,
+        closed_at,
+    )
+    return {
+        "exchange": exchange,
+        "market_scope": market_scope,
+        "position_key": position_key,
+        "opened_at": opened_at,
+        "closed_at": closed_at,
+        "source": f"csv:{exchange}",
+        "payload": {"symbol": symbol, "side": side, **payload},
+    }
+
+
+def _order_record(
+    exchange: str,
+    market_scope: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "exchange": exchange,
+        "market_scope": market_scope,
+        "source": f"csv:{exchange}",
+        "payload": payload,
+    }
+
+
+def _fill_record(
+    exchange: str,
+    market_scope: str,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "exchange": exchange,
+        "market_scope": market_scope,
+        "source": f"csv:{exchange}",
+        "payload": payload,
+    }
+
+
+def _event_record(
+    exchange: str,
+    event_id: str,
+    event_type: str,
+    symbol: str,
+    occurred_at: str,
+    amount: str,
+    currency: str,
+    component: str,
+) -> dict[str, Any]:
+    return {
+        "exchange": exchange,
+        "event_id": event_id,
+        "event_type": event_type,
+        "symbol": symbol,
+        "occurred_at": occurred_at,
+        "payload": {
+            "amount": amount,
+            "currency": currency,
+            "component": component,
+            "count_in_pnl": True,
+            "canonical_source": f"csv:{exchange}",
+        },
+    }
+
+
+def _parse_binance(
+    file_type: str,
+    rows: list[dict[str, str]],
+    source_timezone: str,
+) -> dict[str, list[dict[str, Any]]]:
+    result = {"orders": [], "fills": [], "positions": [], "pnl_events": []}
+    for index, row in enumerate(rows, start=1):
+        if file_type == "position_history":
+            opened_at, _ = _parse_timestamp(row.get("Opened"), source_timezone)
+            closed_at, _ = _parse_timestamp(row.get("Closed"), source_timezone)
+            symbol = _linear_symbol(row.get("Symbol"), "USDT")
+            side = _clean(row.get("Position Side")).lower()
+            gross = _number_text(row.get("Closing PNL"))
+            payload = {
+                "quantity": _number_text(row.get("Closed Vol.")),
+                "contracts": _number_text(row.get("Closed Vol.")),
+                "entry_price": _number_text(row.get("Entry Price")),
+                "exit_price": _number_text(row.get("Avg. Close Price")),
+                "realized_pnl": gross,
+                "realized_pnl_breakdown": {
+                    "gross_pnl": gross,
+                    "fees": None,
+                    "net_pnl": gross,
+                    "currency": symbol.rsplit(":", 1)[-1],
+                    "complete": False,
+                },
+                "margin_mode": _clean(row.get("Margin Mode")).lower(),
+                "opened_at_known": True,
+                "native_id": None,
+                "source_row": index,
+            }
+            result["positions"].append(_position_record(
+                exchange="binance",
+                market_scope="usd_m",
+                symbol=symbol,
+                side=side,
+                opened_at=opened_at,
+                closed_at=closed_at,
+                payload=payload,
+            ))
+        elif file_type == "order_history":
+            created_at, created_ms = _parse_timestamp(row.get("Time"), source_timezone)
+            updated_at, updated_ms = _parse_timestamp(
+                row.get("Update Time") or row.get("Time"),
+                source_timezone,
+            )
+            symbol = _linear_symbol(row.get("Symbol"), "USDT")
+            amount = _number_text(row.get("Amount"))
+            filled = _number_text(row.get("Executed Amount"))
+            remaining = None
+            amount_decimal = _decimal(amount)
+            filled_decimal = _decimal(filled)
+            if amount_decimal is not None and filled_decimal is not None:
+                remaining = format(amount_decimal - filled_decimal, "f")
+            result["orders"].append(_order_record("binance", "usd_m", {
+                "id": _clean(row.get("Order No")),
+                "client_order_id": "",
+                "symbol": symbol,
+                "type": _clean(row.get("Type")).lower(),
+                "side": _clean(row.get("Side")).lower(),
+                "status": _clean(row.get("Status")).lower(),
+                "price": _number_text(row.get("Price")),
+                "average_price": _number_text(row.get("Average Price")),
+                "trigger_price": _number_text(row.get("Stop Price")),
+                "amount": amount,
+                "filled": filled,
+                "remaining": remaining,
+                "cost": _number_text(row.get("Executed Quote Amount")),
+                "timestamp": created_ms,
+                "datetime": created_at,
+                "updated_timestamp": updated_ms,
+                "source_row": index,
+            }))
+        elif file_type == "trade_history":
+            occurred_at, occurred_ms = _parse_timestamp(row.get("Time"), source_timezone)
+            symbol = _linear_symbol(row.get("Symbol"), "USDT")
+            fee_text = _number_text(row.get("Fee"), "0") or "0"
+            fee_currency_match = re.search(r"([A-Za-z]+)$", _clean(row.get("Fee")))
+            fee_currency = fee_currency_match.group(1).upper() if fee_currency_match else "USDT"
+            result["fills"].append(_fill_record("binance", "usd_m", {
+                "id": _clean(row.get("Trade ID")),
+                "order_id": _clean(row.get("Order ID")),
+                "symbol": symbol,
+                "side": _clean(row.get("Side")).lower(),
+                "price": _number_text(row.get("Price")),
+                "amount": _number_text(row.get("Quantity")),
+                "cost": _number_text(row.get("Amount")),
+                "timestamp": occurred_ms,
+                "datetime": occurred_at,
+                "fee": {"cost": fee_text, "currency": fee_currency},
+                "fees": [],
+                "position_side": "BOTH",
+                "realized_pnl": _number_text(row.get("Realized Profit"), "0"),
+                "source_row": index,
+            }))
+        elif file_type == "transaction_history":
+            event_type = _clean(row.get("Type")).upper()
+            if event_type != "FUNDING_FEE":
+                continue
+            occurred_at, _ = _parse_timestamp(row.get("Time"), source_timezone)
+            asset = _clean(row.get("Asset")).upper()
+            symbol = _linear_symbol(row.get("Symbol"), asset)
+            event_id = _clean(row.get("Transaction ID")) or _stable_id(
+                "binance-funding",
+                occurred_at,
+                symbol,
+                row.get("Amount"),
+            )
+            result["pnl_events"].append(_event_record(
+                "binance",
+                event_id,
+                "funding",
+                symbol,
+                occurred_at,
+                _number_text(row.get("Amount"), "0") or "0",
+                asset or "USDT",
+                "funding",
+            ))
+    return result
+
+
+def _bitget_future_parts(value: Any) -> tuple[str, str, str]:
+    text = _clean(value)
+    chunks = text.split(maxsplit=1)
+    symbol = _linear_symbol(chunks[0] if chunks else "", "USDT")
+    side = ""
+    margin_mode = ""
+    if len(chunks) > 1:
+        details = chunks[1].split("·")
+        side = _clean(details[0]).lower()
+        margin_mode = _clean(details[1] if len(details) > 1 else "").lower()
+    return symbol, side, margin_mode
+
+
+def _bitget_status(value: Any) -> str:
+    status = _clean(value).lower()
+    return {
+        "fully executed": "closed",
+        "partially executed": "open",
+        "cancelled": "canceled",
+        "canceled": "canceled",
+    }.get(status, status)
+
+
+def _parse_bitget(
+    file_type: str,
+    rows: list[dict[str, str]],
+    source_timezone: str,
+) -> dict[str, list[dict[str, Any]]]:
+    result = {"orders": [], "fills": [], "positions": [], "pnl_events": []}
+    for index, row in enumerate(rows, start=1):
+        if file_type == "position_history":
+            opened_at, _ = _parse_timestamp(row.get("Opening time"), source_timezone)
+            closed_at, _ = _parse_timestamp(row.get("Closed time"), source_timezone)
+            symbol, side, margin_mode = _bitget_future_parts(row.get("Futures"))
+            gross = _decimal(row.get("Realized PnL"))
+            net = _decimal(row.get("Position Pnl"))
+            fees = gross - net if gross is not None and net is not None else None
+            currency_match = re.search(r"([A-Za-z]+)$", _clean(row.get("Position Pnl")))
+            currency = currency_match.group(1).upper() if currency_match else "USDT"
+            result["positions"].append(_position_record(
+                exchange="bitget",
+                market_scope="USDT-FUTURES",
+                symbol=symbol,
+                side=side,
+                opened_at=opened_at,
+                closed_at=closed_at,
+                payload={
+                    "quantity": _number_text(row.get("Closed amount")),
+                    "contracts": _number_text(row.get("Closed amount")),
+                    "entry_price": _number_text(row.get("Average entry price")),
+                    "exit_price": _number_text(row.get("Average closing price")),
+                    "realized_pnl": format(net, "f") if net is not None else None,
+                    "realized_pnl_breakdown": {
+                        "gross_pnl": format(gross, "f") if gross is not None else None,
+                        "fees": format(fees, "f") if fees is not None else None,
+                        "net_pnl": format(net, "f") if net is not None else None,
+                        "currency": currency,
+                        "complete": gross is not None and net is not None,
+                        "funding_or_other": _number_text(row.get("Fees")),
+                        "opening_fee": _number_text(row.get("Opening fee")),
+                        "closing_fee": _number_text(row.get("Closing fee")),
+                    },
+                    "margin_mode": margin_mode,
+                    "opened_at_known": True,
+                    "native_id": None,
+                    "source_row": index,
+                },
+            ))
+        else:
+            created_at, created_ms = _parse_timestamp(row.get("Date"), source_timezone)
+            settlement = _clean(row.get("Coin")).upper() or "USDT"
+            symbol = _linear_symbol(row.get("Futures"), settlement)
+            amount = _number_text(row.get("Order amount"))
+            filled = _number_text(row.get("Executed"))
+            remaining = None
+            amount_decimal = _decimal(amount)
+            filled_decimal = _decimal(filled)
+            if amount_decimal is not None and filled_decimal is not None:
+                remaining = format(amount_decimal - filled_decimal, "f")
+            result["orders"].append(_order_record("bitget", "USDT-FUTURES", {
+                "id": _clean(row.get("Order ID")),
+                "client_order_id": "",
+                "symbol": symbol,
+                "type": _clean(row.get("Transaction type")).lower(),
+                "side": _clean(row.get("Direction")).lower(),
+                "status": _bitget_status(row.get("Status")),
+                "time_in_force": _clean(row.get("order source")),
+                "price": _number_text(row.get("Price")),
+                "average_price": _number_text(row.get("Average Price")),
+                "amount": amount,
+                "filled": filled,
+                "remaining": remaining,
+                "cost": _number_text(row.get("Trading volume")),
+                "timestamp": created_ms,
+                "datetime": created_at,
+                "updated_timestamp": created_ms,
+                "source_row": index,
+            }))
+    return result
+
+
+def _okx_scope(value: Any) -> str:
+    return {
+        "SWAP": "swap",
+        "FUTURES": "futures",
+        "SPOT": "spot",
+        "MARGIN": "spot",
+        "OPTION": "option",
+    }.get(_clean(value).upper(), _clean(value).lower())
+
+
+def _parse_okx(
+    file_type: str,
+    rows: list[dict[str, str]],
+    source_timezone: str,
+) -> dict[str, list[dict[str, Any]]]:
+    result = {"orders": [], "fills": [], "positions": [], "pnl_events": []}
+    duplicate_trade_ids: dict[tuple[str, str], int] = {}
+    if file_type == "trade_details":
+        for row in rows:
+            key = (_clean(row.get("Symbol")), _clean(row.get("Trade ID")))
+            duplicate_trade_ids[key] = duplicate_trade_ids.get(key, 0) + 1
+    for index, row in enumerate(rows, start=1):
+        if file_type == "position_history":
+            opened_at, _ = _parse_timestamp(row.get("Position Create Time"), source_timezone)
+            closed_at, _ = _parse_timestamp(row.get("Position Update Time"), source_timezone)
+            scope = _okx_scope(row.get("Business Line"))
+            symbol = _okx_symbol(row.get("Instrument Name"), row.get("Business Line"))
+            gross = _decimal(row.get("Pnl"))
+            fee = _decimal(row.get("Fee"))
+            funding = _decimal(row.get("Funding Fee"))
+            liquidation = _decimal(row.get("Liquidation Clearance Fee"))
+            net = _sum_decimal(gross, fee, funding, liquidation)
+            fee_cost = gross - net if gross is not None and net is not None else None
+            currency = _clean(row.get("Margin Currency")).upper() or "USDT"
+            result["positions"].append(_position_record(
+                exchange="okx",
+                market_scope=scope,
+                symbol=symbol,
+                side=_clean(row.get("Direction")).lower(),
+                opened_at=opened_at,
+                closed_at=closed_at,
+                payload={
+                    "quantity": _number_text(row.get("Total Close Quantity")),
+                    "contracts": _number_text(row.get("Total Close Quantity")),
+                    "entry_price": _number_text(row.get("Average Open Price")),
+                    "exit_price": _number_text(row.get("Average Close Price")),
+                    "realized_pnl": format(net, "f") if net is not None else None,
+                    "realized_pnl_breakdown": {
+                        "gross_pnl": format(gross, "f") if gross is not None else None,
+                        "fees": format(fee_cost, "f") if fee_cost is not None else None,
+                        "net_pnl": format(net, "f") if net is not None else None,
+                        "currency": currency,
+                        "complete": net is not None,
+                        "trading_fee": format(fee, "f") if fee is not None else None,
+                        "funding": format(funding, "f") if funding is not None else None,
+                        "liquidation_fee": (
+                            format(liquidation, "f") if liquidation is not None else None
+                        ),
+                    },
+                    "leverage": _number_text(row.get("Leverage")),
+                    "margin_mode": _clean(row.get("Margin Mode")).lower(),
+                    "opened_at_known": True,
+                    "native_id": None,
+                    "source_row": index,
+                },
+            ))
+        elif file_type == "order_history":
+            created_at, created_ms = _parse_timestamp(row.get("Order Time"), source_timezone)
+            scope = _okx_scope(row.get("Instrument"))
+            symbol = _okx_symbol(row.get("Symbol"), row.get("Instrument"))
+            amount = _number_text(row.get("Order Amount"))
+            filled = _number_text(row.get("Filled Amount"))
+            remaining = None
+            amount_decimal = _decimal(amount)
+            filled_decimal = _decimal(filled)
+            if amount_decimal is not None and filled_decimal is not None:
+                remaining = format(amount_decimal - filled_decimal, "f")
+            result["orders"].append(_order_record("okx", scope, {
+                "id": _clean(row.get("Order ID")),
+                "client_order_id": "",
+                "symbol": symbol,
+                "type": _clean(row.get("Order Type")).lower(),
+                "side": _clean(row.get("Side")).lower(),
+                "status": _clean(row.get("Status")).lower(),
+                "price": _number_text(row.get("Order Price")),
+                "average_price": _number_text(row.get("Avg. Filled Price")),
+                "amount": amount,
+                "filled": filled,
+                "remaining": remaining,
+                "timestamp": created_ms,
+                "datetime": created_at,
+                "updated_timestamp": created_ms,
+                "source_row": index,
+            }))
+        else:
+            occurred_at, occurred_ms = _parse_timestamp(row.get("Trade Time"), source_timezone)
+            scope = _okx_scope(row.get("Instrument"))
+            symbol = _okx_symbol(row.get("Symbol"), row.get("Instrument"))
+            raw_trade_id = _clean(row.get("Trade ID"))
+            duplicate_key = (_clean(row.get("Symbol")), raw_trade_id)
+            trade_id = raw_trade_id
+            if duplicate_trade_ids.get(duplicate_key, 0) > 1:
+                leg_id = _stable_id(
+                    "leg",
+                    row.get("Filled Amount"),
+                    row.get("Filled Amount Unit"),
+                    row.get("Filled Price"),
+                    row.get("Fee Unit"),
+                ).split(":", 1)[1]
+                trade_id = f"{raw_trade_id}:{leg_id}"
+            signed_fee = _decimal(row.get("Fee"))
+            fee_cost = -signed_fee if signed_fee is not None else Decimal(0)
+            result["fills"].append(_fill_record("okx", scope, {
+                "id": trade_id,
+                "order_id": _clean(row.get("Order ID")),
+                "symbol": symbol,
+                "side": None,
+                "price": _number_text(row.get("Filled Price")),
+                "amount": _number_text(row.get("Filled Amount")),
+                "cost": _number_text(row.get("Trading Volume")),
+                "timestamp": occurred_ms,
+                "datetime": occurred_at,
+                "fee": {
+                    "cost": format(fee_cost, "f"),
+                    "currency": _clean(row.get("Fee Unit")).upper(),
+                },
+                "fees": [],
+                "taker_or_maker": _clean(row.get("taker/maker")).lower(),
+                "source_row": index,
+            }))
+    return result
+
+
+def _parse_hyperliquid(
+    file_type: str,
+    rows: list[dict[str, str]],
+    source_timezone: str,
+) -> dict[str, list[dict[str, Any]]]:
+    result = {"orders": [], "fills": [], "positions": [], "pnl_events": []}
+    for index, row in enumerate(rows, start=1):
+        occurred_at, occurred_ms = _parse_timestamp(row.get("time"), source_timezone)
+        symbol, scope = _hyperliquid_symbol(row.get("coin"))
+        if file_type == "funding_history":
+            event_id = _stable_id(
+                "hyperliquid-funding",
+                occurred_at,
+                row.get("coin"),
+                row.get("payment"),
+                row.get("rate"),
+            )
+            result["pnl_events"].append(_event_record(
+                "hyperliquid",
+                event_id,
+                "funding",
+                symbol,
+                occurred_at,
+                _number_text(row.get("payment"), "0") or "0",
+                "USDC",
+                "funding",
+            ))
+            continue
+
+        direction = _clean(row.get("dir"))
+        side = {
+            "Open Long": "buy",
+            "Close Long": "sell",
+            "Open Short": "sell",
+            "Close Short": "buy",
+            "Buy": "buy",
+            "Sell": "sell",
+        }.get(direction, direction.lower())
+        position_side = (
+            "LONG" if "Long" in direction
+            else "SHORT" if "Short" in direction
+            else None
+        )
+        fee = _decimal(row.get("fee")) or Decimal(0)
+        closed_net = _decimal(row.get("closedPnl")) or Decimal(0)
+        gross = closed_net + fee
+        trade_id = _stable_id(
+            "hyperliquid-fill",
+            occurred_at,
+            row.get("coin"),
+            direction,
+            row.get("px"),
+            row.get("sz"),
+        )
+        result["fills"].append(_fill_record("hyperliquid", scope, {
+            "id": trade_id,
+            "order_id": "",
+            "symbol": symbol,
+            "side": side,
+            "price": _number_text(row.get("px")),
+            "amount": _number_text(row.get("sz")),
+            "cost": _number_text(row.get("ntl")),
+            "timestamp": occurred_ms,
+            "datetime": occurred_at,
+            "fee": {"cost": format(fee, "f"), "currency": "USDC"},
+            "fees": [],
+            "position_side": position_side,
+            "realized_pnl": format(gross, "f"),
+            "closed_pnl_net": format(closed_net, "f"),
+            "direction": direction,
+            "source_row": index,
+        }))
+    return result
+
+
+def _parse_file(spec: dict[str, Any]) -> dict[str, Any]:
+    path = Path(str(spec.get("path") or ""))
+    name = _clean(spec.get("name")) or path.name
+    try:
+        content = path.read_bytes()
+    except OSError as exc:
+        raise HistoryCsvError(f"cannot read upload: {name}") from exc
+    if len(content) > MAX_IMPORT_FILE_BYTES:
+        raise HistoryCsvError(f"CSV exceeds {MAX_IMPORT_FILE_BYTES // (1024 * 1024)} MB: {name}")
+    rows, _ = _rows_from_bytes(content)
+    exchange, file_type, header_index = _detect_format(rows)
+    inferred_timezone, timezone_required = _infer_timezone(
+        name,
+        rows[:header_index],
+        exchange,
+    )
+    source_account_uid = _infer_source_account_uid(rows[:header_index], exchange)
+    source_timezone = _clean(spec.get("source_timezone")) or inferred_timezone
+    _timezone_offset(source_timezone)
+    data_rows = _dict_rows(rows, header_index)
+    if not data_rows:
+        raise HistoryCsvError(f"CSV has no data rows: {name}")
+    if exchange == "binance":
+        records = _parse_binance(file_type, data_rows, source_timezone)
+    elif exchange == "bitget":
+        records = _parse_bitget(file_type, data_rows, source_timezone)
+    elif exchange == "okx":
+        records = _parse_okx(file_type, data_rows, source_timezone)
+    else:
+        records = _parse_hyperliquid(file_type, data_rows, source_timezone)
+
+    timestamps: list[str] = []
+    for record in records["orders"]:
+        value = record["payload"].get("datetime")
+        if value:
+            timestamps.append(str(value))
+    for record in records["fills"]:
+        value = record["payload"].get("datetime")
+        if value:
+            timestamps.append(str(value))
+    for record in records["positions"]:
+        timestamps.extend((record["opened_at"], record["closed_at"]))
+    for record in records["pnl_events"]:
+        if record.get("occurred_at"):
+            timestamps.append(str(record["occurred_at"]))
+
+    scopes = {
+        str(record.get("market_scope") or "")
+        for category in ("orders", "fills", "positions")
+        for record in records[category]
+        if record.get("market_scope")
+    }
+    warnings: list[str] = []
+    if timezone_required and spec.get("timezone_confirmed") is not True:
+        warnings.append(TIMEZONE_CONFIRMATION_WARNING)
+    return {
+        "file_id": _clean(spec.get("file_id")) or hashlib.sha256(content).hexdigest()[:16],
+        "name": name,
+        "file_hash": hashlib.sha256(content).hexdigest(),
+        "exchange": exchange,
+        "file_type": file_type,
+        "market_scope": next(iter(scopes)) if len(scopes) == 1 else "mixed" if scopes else "",
+        "source_timezone": source_timezone,
+        "source_account_uid": source_account_uid,
+        "timezone_requires_confirmation": timezone_required,
+        "row_count": len(data_rows),
+        "first_occurred_at": min(timestamps) if timestamps else None,
+        "last_occurred_at": max(timestamps) if timestamps else None,
+        "warnings": warnings,
+        "records": records,
+    }
+
+
+def _companion_warnings(files: list[dict[str, Any]]) -> None:
+    types_by_exchange: dict[str, set[str]] = {}
+    for item in files:
+        types_by_exchange.setdefault(item["exchange"], set()).add(item["file_type"])
+    for item in files:
+        available = types_by_exchange[item["exchange"]]
+        warning = None
+        if item["exchange"] == "binance" and "trade_history" not in available:
+            warning = "Binance Trade History is required for fee-complete PnL."
+        elif item["exchange"] == "hyperliquid" and "funding_history" not in available:
+            warning = "Hyperliquid Funding History is missing; funding PnL will be incomplete."
+        if warning and warning not in item["warnings"]:
+            item["warnings"].append(warning)
+
+
+def preview_history_files(specs: list[dict[str, Any]]) -> dict[str, Any]:
+    if not specs or len(specs) > MAX_IMPORT_FILES:
+        raise HistoryCsvError(f"select between 1 and {MAX_IMPORT_FILES} CSV files")
+    files = [_parse_file(spec) for spec in specs]
+    _companion_warnings(files)
+    return {
+        "files": [
+            {key: value for key, value in item.items() if key != "records"}
+            for item in files
+        ],
+        "timezone_options": timezone_options(),
+    }
+
+
+def _iso_seconds(value: str) -> float:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+
+
+def _enrich_binance_positions(files: list[dict[str, Any]]) -> None:
+    fills_by_group: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    total_fees: dict[tuple[str, str], Decimal] = {}
+    fee_event_targets: dict[tuple[str, str], dict[str, Any]] = {}
+    positions: list[dict[str, Any]] = []
+    for item in files:
+        account = str(item["account"])
+        for fill in item["records"]["fills"]:
+            if fill["exchange"] != "binance":
+                continue
+            symbol = str(fill["payload"].get("symbol") or "")
+            fills_by_group.setdefault((account, symbol), []).append({
+                "trade_id": str(fill["payload"].get("id") or ""),
+                "occurred_at": str(fill["payload"].get("datetime") or ""),
+                "payload": fill["payload"],
+            })
+            fee = fill["payload"].get("fee")
+            fee = fee if isinstance(fee, dict) else {}
+            fee_cost = _decimal(fee.get("cost"))
+            fee_currency = _clean(fee.get("currency")).upper() or "USDT"
+            if fee_cost is not None:
+                fee_key = (account, fee_currency)
+                total_fees[fee_key] = total_fees.get(fee_key, Decimal(0)) + fee_cost
+                fee_event_targets.setdefault(fee_key, item)
+        positions.extend(
+            position
+            for position in item["records"]["positions"]
+            if position["exchange"] == "binance"
+        )
+    for (account, symbol), fills in fills_by_group.items():
+        rebuilt = reconstruct_position_history_from_fills(
+            account,
+            "binance",
+            "usd_m",
+            symbol,
+            fills,
+            infer_linear_pnl=True,
+        )
+        for position in positions:
+            if str(position["payload"].get("symbol") or "") != symbol:
+                continue
+            match = next((
+                candidate
+                for candidate in rebuilt
+                if (
+                    abs(
+                        _iso_seconds(candidate["opened_at"])
+                        - _iso_seconds(position["opened_at"])
+                    ) <= 2
+                    and abs(
+                        _iso_seconds(candidate["closed_at"])
+                        - _iso_seconds(position["closed_at"])
+                    ) <= 2
+                )
+            ), None)
+            if match is None:
+                continue
+            rebuilt_payload = match["payload"]
+            position["payload"]["realized_pnl"] = rebuilt_payload.get("realized_pnl")
+            position["payload"]["realized_pnl_breakdown"] = rebuilt_payload.get(
+                "realized_pnl_breakdown"
+            )
+
+    allocated_fees: dict[tuple[str, str], Decimal] = {}
+    for position in positions:
+        payload = position.get("payload")
+        payload = payload if isinstance(payload, dict) else {}
+        breakdown = payload.get("realized_pnl_breakdown")
+        breakdown = breakdown if isinstance(breakdown, dict) else {}
+        fee_cost = _decimal(breakdown.get("fees"))
+        currency = _clean(breakdown.get("currency")).upper()
+        account = str(position.get("account") or "")
+        if fee_cost is not None and currency:
+            key = (account, currency)
+            allocated_fees[key] = allocated_fees.get(key, Decimal(0)) + fee_cost
+
+    for key, total_fee in total_fees.items():
+        residual_fee = total_fee - allocated_fees.get(key, Decimal(0))
+        if abs(residual_fee) <= Decimal("0.000000000001"):
+            continue
+        account, currency = key
+        item = fee_event_targets[key]
+        import_id = str(item["import_id"])
+        event = _event_record(
+            "binance",
+            _stable_id("binance-unallocated-fee", item["file_hash"], account, currency),
+            "trading_fee",
+            "",
+            item["last_occurred_at"],
+            format(-residual_fee, "f"),
+            currency,
+            "trading_fee",
+        )
+        event["account"] = account
+        event["import_id"] = import_id
+        event["payload"]["import"] = {
+            "import_id": import_id,
+            "file_type": item["file_type"],
+            "source_timezone": item["source_timezone"],
+        }
+        item["records"]["pnl_events"].append(event)
+
+
+def build_history_import_batch(specs: list[dict[str, Any]]) -> dict[str, Any]:
+    files = [_parse_file(spec) for spec in specs]
+    _companion_warnings(files)
+    for item, spec in zip(files, specs, strict=True):
+        account = _clean(spec.get("account"))
+        import_id = _clean(spec.get("import_id"))
+        if not account or not import_id:
+            raise HistoryCsvError("account and import_id are required")
+        item["account"] = account
+        item["import_id"] = import_id
+        item["batch_id"] = _clean(spec.get("batch_id")) or import_id
+        for category in ("orders", "fills", "positions", "pnl_events"):
+            for record in item["records"][category]:
+                record["account"] = account
+                record["import_id"] = import_id
+                payload = record.get("payload")
+                if isinstance(payload, dict):
+                    payload["import"] = {
+                        "import_id": import_id,
+                        "file_type": item["file_type"],
+                        "source_timezone": item["source_timezone"],
+                    }
+
+    _enrich_binance_positions(files)
+    batch: dict[str, Any] = {
+        "orders": [],
+        "fills": [],
+        "positions": [],
+        "pnl_events": [],
+        "imports": [],
+    }
+    for item in files:
+        for category in ("orders", "fills", "positions", "pnl_events"):
+            batch[category].extend(item["records"][category])
+        batch["imports"].append({
+            "import_id": item["import_id"],
+            "batch_id": item["batch_id"],
+            "file_hash": item["file_hash"],
+            "original_name": item["name"],
+            "account": item["account"],
+            "exchange": item["exchange"],
+            "file_type": item["file_type"],
+            "market_scope": item["market_scope"],
+            "source_timezone": item["source_timezone"],
+            "row_count": item["row_count"],
+            "first_occurred_at": item["first_occurred_at"],
+            "last_occurred_at": item["last_occurred_at"],
+            "status": "ready",
+            "warnings": item["warnings"],
+        })
+    return batch
+
+
+def fetch_hyperliquid_historical_orders(
+    wallet_address: str,
+    account: str,
+    import_id: str,
+    *,
+    timeout: float = 30.0,
+) -> tuple[list[dict[str, Any]], list[str]]:
+    address = _clean(wallet_address)
+    if not re.fullmatch(r"0x[0-9a-fA-F]{40}", address):
+        raise HistoryCsvError("Hyperliquid account requires a valid walletAddress")
+    body = json.dumps({"type": "historicalOrders", "user": address}).encode("utf-8")
+    request = urllib.request.Request(
+        "https://api.hyperliquid.xyz/info",
+        data=body,
+        headers={"Content-Type": "application/json", "User-Agent": "PyneReal/1"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:  # noqa: S310
+        payload = json.loads(response.read().decode("utf-8"))
+    if not isinstance(payload, list):
+        raise HistoryCsvError("Hyperliquid historicalOrders returned an invalid response")
+    orders: list[dict[str, Any]] = []
+    for index, item in enumerate(payload, start=1):
+        if not isinstance(item, dict):
+            continue
+        raw = item.get("order")
+        raw = raw if isinstance(raw, dict) else {}
+        order_id = _clean(raw.get("oid") or item.get("oid"))
+        if not order_id:
+            continue
+        symbol, scope = _hyperliquid_symbol(raw.get("coin"))
+        created_ms = int(_decimal(raw.get("timestamp")) or 0)
+        updated_ms = int(_decimal(item.get("statusTimestamp")) or created_ms)
+        created_at = datetime.fromtimestamp(created_ms / 1000, UTC).isoformat().replace(
+            "+00:00", "Z"
+        ) if created_ms else None
+        side_value = _clean(raw.get("side")).upper()
+        tif = _clean(raw.get("tif"))
+        order_type = _clean(raw.get("orderType") or raw.get("order_type")).lower()
+        if not order_type:
+            order_type = "market" if tif.lower() == "ioc" else "limit"
+        side = {
+            "A": "sell",
+            "B": "buy",
+        }.get(side_value, side_value.lower())
+        amount = _decimal(raw.get("origSz") or raw.get("sz"))
+        remaining = _decimal(raw.get("sz"))
+        filled = amount - remaining if amount is not None and remaining is not None else None
+        order_payload = {
+            "id": order_id,
+            "client_order_id": _clean(raw.get("cloid")),
+            "symbol": symbol,
+            "type": order_type,
+            "side": side,
+            "status": _clean(item.get("status")).lower(),
+            "time_in_force": tif or None,
+            "price": _number_text(raw.get("limitPx")),
+            "average_price": None,
+            "amount": format(amount, "f") if amount is not None else None,
+            "filled": format(filled, "f") if filled is not None else None,
+            "remaining": format(remaining, "f") if remaining is not None else None,
+            "timestamp": created_ms or None,
+            "datetime": created_at,
+            "updated_timestamp": updated_ms or None,
+            "source_row": index,
+            "import": {
+                "import_id": import_id,
+                "file_type": "historical_orders_api",
+                "source_timezone": "UTC+00:00",
+            },
+        }
+        orders.append({
+            "account": account,
+            "exchange": "hyperliquid",
+            "market_scope": scope,
+            "source": "rest:hyperliquid:historicalOrders",
+            "import_id": import_id,
+            "payload": order_payload,
+        })
+    warnings = []
+    if len(payload) >= 2000:
+        warnings.append(
+            "Hyperliquid returned 2,000 historical orders; older orders may be missing."
+        )
+    return orders, warnings

--- a/account_service/history.py
+++ b/account_service/history.py
@@ -295,6 +295,8 @@ def _normalized_fee(payload: dict[str, Any]) -> tuple[Decimal, str | None]:
 
 
 def hyperliquid_market_scope(symbol: str) -> str:
+    if "/" in symbol and ":" not in symbol:
+        return "spot"
     base = symbol.split("/", 1)[0].strip()
     if "-" not in base:
         return "default"

--- a/account_service/history.py
+++ b/account_service/history.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import math
+from decimal import Decimal, InvalidOperation
 from typing import Any
 
 
@@ -23,6 +24,16 @@ def _integer(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return result if result.is_finite() else None
 
 
 def _derived_id(prefix: str, values: list[Any]) -> str:
@@ -120,6 +131,8 @@ def normalize_order(order: dict[str, Any]) -> dict[str, Any]:
 
 
 def normalize_fill(trade: dict[str, Any]) -> dict[str, Any]:
+    info = trade.get("info")
+    info = info if isinstance(info, dict) else {}
     trade_id = str(trade.get("id") or "").strip()
     order_id = str(trade.get("order") or "").strip()
     timestamp = _integer(trade.get("timestamp"))
@@ -147,6 +160,11 @@ def normalize_fill(trade: dict[str, Any]) -> dict[str, Any]:
         if isinstance(fees, list)
         else []
     )
+    realized_pnl = trade.get("realizedPnl")
+    if realized_pnl is None:
+        realized_pnl = info.get("realizedPnl")
+    if realized_pnl is None:
+        realized_pnl = info.get("closedPnl")
     return {
         "id": trade_id,
         "order_id": order_id,
@@ -161,4 +179,328 @@ def normalize_fill(trade: dict[str, Any]) -> dict[str, Any]:
         "datetime": trade.get("datetime"),
         "fee": _fee(trade.get("fee")),
         "fees": normalized_fees,
+        "position_side": str(
+            trade.get("positionSide") or info.get("positionSide") or ""
+        ).upper() or None,
+        "realized_pnl": _number(realized_pnl),
     }
+
+
+def bitget_position_market_scope(position: dict[str, Any]) -> str | None:
+    info = position.get("info")
+    info = info if isinstance(info, dict) else {}
+    product_type = str(
+        info.get("productType") or position.get("productType") or ""
+    ).upper()
+    if product_type in {"USDT-FUTURES", "USDC-FUTURES", "COIN-FUTURES"}:
+        return product_type
+
+    symbol_scope = bitget_symbol_market_scope(position.get("symbol"))
+    if symbol_scope not in {None, "spot"}:
+        return symbol_scope
+
+    margin_coin = str(info.get("marginCoin") or "").upper()
+    if margin_coin == "USDT":
+        return "USDT-FUTURES"
+    if margin_coin == "USDC":
+        return "USDC-FUTURES"
+    if margin_coin:
+        return "COIN-FUTURES"
+    return None
+
+
+def bitget_symbol_market_scope(symbol: Any) -> str | None:
+    value = str(symbol or "").strip()
+    if not value:
+        return None
+    if ":" not in value:
+        return "spot"
+    settlement = value.rsplit(":", 1)[1].split("-", 1)[0].upper()
+    if settlement == "USDT":
+        return "USDT-FUTURES"
+    if settlement == "USDC":
+        return "USDC-FUTURES"
+    return "COIN-FUTURES" if settlement else None
+
+
+def bitget_history_item_matches_scope(
+    payload: dict[str, Any],
+    market_scope: str,
+) -> bool:
+    if market_scope == "uta":
+        return True
+    actual_scope = bitget_symbol_market_scope(payload.get("symbol"))
+    return actual_scope is None or actual_scope == market_scope
+
+
+def bitget_position_matches_scope(
+    position: dict[str, Any],
+    market_scope: str,
+) -> bool:
+    if market_scope == "uta":
+        return True
+    actual_scope = bitget_position_market_scope(position)
+    return actual_scope is None or actual_scope == market_scope
+
+
+def okx_history_market_scope(payload: dict[str, Any]) -> str | None:
+    info = payload.get("info")
+    info = info if isinstance(info, dict) else {}
+    instrument_type = str(
+        info.get("instType") or payload.get("instType") or ""
+    ).upper()
+    scope_by_type = {
+        "SPOT": "spot",
+        "MARGIN": "spot",
+        "SWAP": "swap",
+        "FUTURES": "futures",
+        "OPTION": "option",
+    }
+    if instrument_type in scope_by_type:
+        return scope_by_type[instrument_type]
+
+    symbol = str(payload.get("symbol") or "").strip()
+    if not symbol:
+        return None
+    if ":" not in symbol:
+        return "spot"
+    contract = symbol.rsplit(":", 1)[1]
+    parts = contract.split("-")
+    if len(parts) >= 3 and parts[-1].upper() in {"C", "P"}:
+        return "option"
+    return "futures" if len(parts) >= 2 else "swap"
+
+
+def _normalized_fee(payload: dict[str, Any]) -> tuple[Decimal, str | None]:
+    fee = payload.get("fee")
+    if isinstance(fee, dict):
+        cost = _decimal(fee.get("cost"))
+        if cost is not None:
+            return cost, str(fee.get("currency") or "").upper() or None
+    fees = payload.get("fees")
+    if not isinstance(fees, list):
+        return Decimal(0), None
+    total = Decimal(0)
+    currencies: set[str] = set()
+    for item in fees:
+        if not isinstance(item, dict):
+            continue
+        cost = _decimal(item.get("cost"))
+        if cost is not None:
+            total += cost
+        currency = str(item.get("currency") or "").upper()
+        if currency:
+            currencies.add(currency)
+    return total, next(iter(currencies)) if len(currencies) == 1 else None
+
+
+def hyperliquid_market_scope(symbol: str) -> str:
+    base = symbol.split("/", 1)[0].strip()
+    if "-" not in base:
+        return "default"
+    return base.split("-", 1)[0].strip().lower() or "default"
+
+
+def reconstruct_position_history_from_fills(
+    account: str,
+    exchange: str,
+    market_scope: str,
+    symbol: str,
+    fills: list[dict[str, Any]],
+    *,
+    infer_linear_pnl: bool,
+) -> list[dict[str, Any]]:
+    """Build completed position lifecycles from normalized fills."""
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in fills:
+        payload = row.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        position_side = str(payload.get("position_side") or "BOTH").upper()
+        grouped.setdefault(position_side, []).append(row)
+
+    results: list[dict[str, Any]] = []
+    tolerance = Decimal("1e-12")
+    for position_side, rows in grouped.items():
+        current = Decimal(0)
+        average = Decimal(0)
+        opened_quantity = Decimal(0)
+        exit_quantity = Decimal(0)
+        exit_value = Decimal(0)
+        gross_pnl = Decimal(0)
+        fees = Decimal(0)
+        fee_currencies: set[str] = set()
+        gross_known = True
+        opened_at = ""
+
+        def start_cycle(
+            signed_quantity: Decimal,
+            price: Decimal,
+            occurred_at: str,
+            fee_cost: Decimal,
+            fee_currency: str | None,
+        ) -> None:
+            nonlocal current, average, opened_quantity, exit_quantity
+            nonlocal exit_value, gross_pnl, fees, gross_known, opened_at
+            current = signed_quantity
+            average = price
+            opened_quantity = abs(signed_quantity)
+            exit_quantity = Decimal(0)
+            exit_value = Decimal(0)
+            gross_pnl = Decimal(0)
+            fees = fee_cost
+            fee_currencies.clear()
+            if fee_currency:
+                fee_currencies.add(fee_currency)
+            gross_known = True
+            opened_at = occurred_at
+
+        def finish_cycle(closed_at: str, side_sign: Decimal) -> None:
+            if not opened_at or exit_quantity <= tolerance:
+                return
+            exit_price = exit_value / exit_quantity
+            currency = (
+                next(iter(fee_currencies))
+                if len(fee_currencies) == 1
+                else None
+            )
+            pnl_complete = gross_known and len(fee_currencies) <= 1
+            net_pnl = gross_pnl - fees if pnl_complete else None
+            identity = [
+                account,
+                exchange,
+                market_scope,
+                symbol,
+                position_side,
+                opened_at,
+                closed_at,
+            ]
+            payload = {
+                "symbol": symbol,
+                "side": "long" if side_sign > 0 else "short",
+                "quantity": float(opened_quantity),
+                "contracts": float(opened_quantity),
+                "contract_size": None,
+                "entry_price": float(average),
+                "exit_price": float(exit_price),
+                "realized_pnl": float(net_pnl) if net_pnl is not None else None,
+                "realized_pnl_breakdown": (
+                    {
+                        "gross_pnl": float(gross_pnl),
+                        "fees": float(fees),
+                        "net_pnl": float(net_pnl),
+                        "currency": currency,
+                        "complete": True,
+                    }
+                    if net_pnl is not None
+                    else None
+                ),
+                "opened_at_known": True,
+                "native_id": None,
+                "position_side": position_side,
+            }
+            results.append({
+                "account": account,
+                "exchange": exchange,
+                "market_scope": market_scope,
+                "position_key": _derived_id("trades", identity),
+                "opened_at": opened_at,
+                "closed_at": closed_at,
+                "source": "trades",
+                "payload": payload,
+            })
+
+        def sort_key(row: dict[str, Any]) -> tuple[str, int | str]:
+            trade_id = str(row.get("trade_id") or "")
+            try:
+                ordered_id: int | str = int(trade_id)
+            except ValueError:
+                ordered_id = trade_id
+            return str(row.get("occurred_at") or ""), ordered_id
+
+        for row in sorted(rows, key=sort_key):
+            payload = row.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            quantity = _decimal(payload.get("amount"))
+            price = _decimal(payload.get("price"))
+            trade_side = str(payload.get("side") or "").lower()
+            occurred_at = str(
+                row.get("occurred_at") or payload.get("datetime") or ""
+            )
+            if (
+                quantity is None
+                or quantity <= 0
+                or price is None
+                or price <= 0
+                or trade_side not in {"buy", "sell"}
+                or not occurred_at
+            ):
+                continue
+            signed = quantity if trade_side == "buy" else -quantity
+            fee_cost, fee_currency = _normalized_fee(payload)
+            if current == 0:
+                start_cycle(signed, price, occurred_at, fee_cost, fee_currency)
+                continue
+            if current * signed > 0:
+                new_size = abs(current) + quantity
+                average = (average * abs(current) + price * quantity) / new_size
+                current += signed
+                opened_quantity += quantity
+                fees += fee_cost
+                if fee_currency:
+                    fee_currencies.add(fee_currency)
+                continue
+
+            side_sign = Decimal(1) if current > 0 else Decimal(-1)
+            closed_quantity = min(abs(current), quantity)
+            closing_fee = fee_cost * closed_quantity / quantity
+            fees += closing_fee
+            if fee_currency:
+                fee_currencies.add(fee_currency)
+            exit_quantity += closed_quantity
+            exit_value += price * closed_quantity
+            native_gross = _decimal(payload.get("realized_pnl"))
+            if native_gross is not None:
+                gross_pnl += native_gross
+            elif infer_linear_pnl:
+                gross_pnl += (price - average) * closed_quantity * side_sign
+            else:
+                gross_known = False
+
+            remaining_position = abs(current) - closed_quantity
+            remaining_trade = quantity - closed_quantity
+            if remaining_position <= tolerance:
+                finish_cycle(occurred_at, side_sign)
+                current = Decimal(0)
+                if remaining_trade > tolerance:
+                    opening_fee = fee_cost - closing_fee
+                    residual = remaining_trade if signed > 0 else -remaining_trade
+                    start_cycle(
+                        residual,
+                        price,
+                        occurred_at,
+                        opening_fee,
+                        fee_currency,
+                    )
+            else:
+                current = side_sign * remaining_position
+
+    return results
+
+
+def reconstruct_binance_position_history(
+    account: str,
+    market_scope: str,
+    symbol: str,
+    fills: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    return reconstruct_position_history_from_fills(
+        account,
+        "binance",
+        market_scope,
+        symbol,
+        fills,
+        infer_linear_pnl=market_scope == "usd_m",
+    )

--- a/account_service/history.py
+++ b/account_service/history.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from typing import Any
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _integer(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _derived_id(prefix: str, values: list[Any]) -> str:
+    encoded = json.dumps(
+        values,
+        ensure_ascii=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return f"{prefix}:{hashlib.sha256(encoded).hexdigest()[:24]}"
+
+
+def _fee(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    return {
+        "currency": value.get("currency"),
+        "cost": _number(value.get("cost")),
+        "rate": _number(value.get("rate")),
+    }
+
+
+def _updated_timestamp(order: dict[str, Any]) -> int | None:
+    for value in (
+        order.get("lastTradeTimestamp"),
+        order.get("lastUpdateTimestamp"),
+        order.get("updateTimestamp"),
+    ):
+        timestamp = _integer(value)
+        if timestamp is not None:
+            return timestamp
+
+    info = order.get("info")
+    if isinstance(info, dict):
+        for key in (
+            "updateTime",
+            "updatedTime",
+            "uTime",
+            "statusTimestamp",
+            "cTime",
+            "timestamp",
+        ):
+            timestamp = _integer(info.get(key))
+            if timestamp is not None:
+                return timestamp
+    return _integer(order.get("timestamp"))
+
+
+def normalize_order(order: dict[str, Any]) -> dict[str, Any]:
+    order_id = str(order.get("id") or "").strip()
+    client_order_id = str(order.get("clientOrderId") or "").strip()
+    timestamp = _integer(order.get("timestamp"))
+    symbol = str(order.get("symbol") or "")
+    if not order_id:
+        order_id = (
+            f"client:{client_order_id}"
+            if client_order_id
+            else _derived_id(
+                "order",
+                [
+                    symbol,
+                    timestamp,
+                    order.get("side"),
+                    order.get("type"),
+                    order.get("amount"),
+                    order.get("price"),
+                ],
+            )
+        )
+    return {
+        "id": order_id,
+        "client_order_id": client_order_id,
+        "symbol": symbol,
+        "type": order.get("type"),
+        "side": order.get("side"),
+        "status": order.get("status"),
+        "time_in_force": order.get("timeInForce"),
+        "price": _number(order.get("price")),
+        "average_price": _number(order.get("average")),
+        "trigger_price": _number(order.get("triggerPrice", order.get("stopPrice"))),
+        "amount": _number(order.get("amount")),
+        "filled": _number(order.get("filled")),
+        "remaining": _number(order.get("remaining")),
+        "cost": _number(order.get("cost")),
+        "reduce_only": (
+            order.get("reduceOnly")
+            if isinstance(order.get("reduceOnly"), bool)
+            else None
+        ),
+        "timestamp": timestamp,
+        "datetime": order.get("datetime"),
+        "updated_timestamp": _updated_timestamp(order),
+        "fee": _fee(order.get("fee")),
+    }
+
+
+def normalize_fill(trade: dict[str, Any]) -> dict[str, Any]:
+    trade_id = str(trade.get("id") or "").strip()
+    order_id = str(trade.get("order") or "").strip()
+    timestamp = _integer(trade.get("timestamp"))
+    symbol = str(trade.get("symbol") or "")
+    if not trade_id:
+        trade_id = _derived_id(
+            "fill",
+            [
+                symbol,
+                order_id,
+                timestamp,
+                trade.get("side"),
+                trade.get("price"),
+                trade.get("amount"),
+                trade.get("cost"),
+            ],
+        )
+    fees = trade.get("fees")
+    normalized_fees = (
+        [
+            normalized
+            for value in fees
+            if (normalized := _fee(value)) is not None
+        ]
+        if isinstance(fees, list)
+        else []
+    )
+    return {
+        "id": trade_id,
+        "order_id": order_id,
+        "symbol": symbol,
+        "type": trade.get("type"),
+        "side": trade.get("side"),
+        "taker_or_maker": trade.get("takerOrMaker"),
+        "price": _number(trade.get("price")),
+        "amount": _number(trade.get("amount")),
+        "cost": _number(trade.get("cost")),
+        "timestamp": timestamp,
+        "datetime": trade.get("datetime"),
+        "fee": _fee(trade.get("fee")),
+        "fees": normalized_fees,
+    }

--- a/account_service/live_positions.py
+++ b/account_service/live_positions.py
@@ -7,6 +7,7 @@ import queue
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -44,6 +45,9 @@ from account_service.backfill import (  # noqa: E402
     manual_history_refresh_timing,
 )
 from account_service.cache import AccountCache  # noqa: E402
+from account_service.csv_import import (  # noqa: E402
+    fetch_hyperliquid_historical_orders,
+)
 from account_service.history import (  # noqa: E402
     normalize_fill,
     normalize_order,
@@ -1269,6 +1273,198 @@ async def _put_control_message(output_queue: Any, payload: dict[str, Any]) -> No
         pass
 
 
+async def _import_history_from_parent(
+    request: dict[str, Any],
+    *,
+    accounts: list[ExchangeAccount],
+    cache: AccountCache,
+    cache_executor: ThreadPoolExecutor,
+    stop: asyncio.Event,
+) -> dict[str, Any]:
+    batch = request.get("batch")
+    if not isinstance(batch, dict):
+        raise ValueError("history import batch is missing")
+    imports = batch.get("imports")
+    imports = imports if isinstance(imports, list) else []
+    if not imports:
+        raise ValueError("history import contains no files")
+
+    account_map = {account.name: account for account in accounts}
+    manifests_by_import: dict[str, dict[str, Any]] = {}
+    hyperliquid_imports: dict[str, list[dict[str, Any]]] = {}
+    for manifest in imports:
+        if not isinstance(manifest, dict):
+            raise ValueError("history import manifest is invalid")
+        import_id = str(manifest.get("import_id") or "").strip()
+        account_name = str(manifest.get("account") or "").strip()
+        exchange_id = str(manifest.get("exchange") or "").strip().lower()
+        account = account_map.get(account_name)
+        if not import_id or account is None or account.exchange_id != exchange_id:
+            raise ValueError("history import account does not match providers.toml")
+        manifests_by_import[import_id] = manifest
+        if exchange_id == "hyperliquid":
+            hyperliquid_imports.setdefault(account_name, []).append(manifest)
+
+    for category in ("orders", "fills", "positions", "pnl_events"):
+        records = batch.get(category)
+        records = records if isinstance(records, list) else []
+        batch[category] = records
+        for record in records:
+            if not isinstance(record, dict):
+                raise ValueError("history import record is invalid")
+            import_id = str(record.get("import_id") or "").strip()
+            manifest = manifests_by_import.get(import_id)
+            if (
+                manifest is None
+                or record.get("account") != manifest.get("account")
+                or record.get("exchange") != manifest.get("exchange")
+            ):
+                raise ValueError("history import record does not match its manifest")
+
+    for account_name, account_imports in hyperliquid_imports.items():
+        account = account_map[account_name]
+        wallet_address = str(account.config.get("walletAddress") or "").strip()
+        anchor = account_imports[0]
+        try:
+            orders, warnings = await asyncio.to_thread(
+                fetch_hyperliquid_historical_orders,
+                wallet_address,
+                account_name,
+                str(anchor.get("import_id") or ""),
+            )
+            batch["orders"].extend(orders)
+            for manifest in account_imports:
+                manifest_warnings = manifest.setdefault("warnings", [])
+                if isinstance(manifest_warnings, list):
+                    manifest_warnings.extend(
+                        warning for warning in warnings if warning not in manifest_warnings
+                    )
+                if warnings:
+                    manifest["status"] = "partial"
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            message = redact_error(exc, secret_values(account.config))
+            warning = f"Hyperliquid Order History could not be enriched: {message}"
+            for manifest in account_imports:
+                manifest["status"] = "partial"
+                manifest_warnings = manifest.setdefault("warnings", [])
+                if isinstance(manifest_warnings, list) and warning not in manifest_warnings:
+                    manifest_warnings.append(warning)
+
+    post_bar_delay = seconds_until_manual_refresh_guard_end()
+    if post_bar_delay > 0.0:
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=post_bar_delay)
+            raise asyncio.CancelledError
+        except TimeoutError:
+            pass
+
+    loop = asyncio.get_running_loop()
+    result = await loop.run_in_executor(
+        cache_executor,
+        partial(
+            cache.apply_history_batch,
+            batch["orders"],
+            batch["fills"],
+            batch["positions"],
+            [],
+            pnl_events=batch["pnl_events"],
+            imports=imports,
+        ),
+    )
+    return result or {"status": "ok", "imports": [], "summary": {}}
+
+
+async def _retry_history_enrichment_from_parent(
+    request: dict[str, Any],
+    *,
+    accounts: list[ExchangeAccount],
+    cache: AccountCache,
+    cache_executor: ThreadPoolExecutor,
+    stop: asyncio.Event,
+) -> dict[str, Any]:
+    import_id = str(request.get("import_id") or "").strip()
+    if not import_id:
+        raise ValueError("history import ID is missing")
+    loop = asyncio.get_running_loop()
+    manifest = await loop.run_in_executor(
+        cache_executor,
+        cache.csv_import,
+        import_id,
+    )
+    if not isinstance(manifest, dict) or manifest.get("exchange") != "hyperliquid":
+        raise ValueError("Hyperliquid history import was not found")
+    account_name = str(manifest.get("account") or "")
+    account = next((item for item in accounts if item.name == account_name), None)
+    if account is None or account.exchange_id != "hyperliquid":
+        raise ValueError("history import account does not match providers.toml")
+
+    previous_warnings = manifest.get("warnings")
+    previous_warnings = previous_warnings if isinstance(previous_warnings, list) else []
+    retained_warnings = [
+        str(warning)
+        for warning in previous_warnings
+        if not str(warning).startswith("Hyperliquid Order History could not be enriched:")
+        and not str(warning).startswith("Hyperliquid returned 2,000 historical orders;")
+    ]
+    try:
+        orders, warnings = await asyncio.to_thread(
+            fetch_hyperliquid_historical_orders,
+            str(account.config.get("walletAddress") or ""),
+            account_name,
+            import_id,
+        )
+        post_bar_delay = seconds_until_manual_refresh_guard_end()
+        if post_bar_delay > 0.0:
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=post_bar_delay)
+                raise asyncio.CancelledError
+            except TimeoutError:
+                pass
+        await loop.run_in_executor(
+            cache_executor,
+            cache.apply_history_batch,
+            orders,
+            [],
+        )
+        combined_warnings = [*retained_warnings, *warnings]
+        await loop.run_in_executor(
+            cache_executor,
+            partial(
+                cache.update_csv_import_status,
+                import_id,
+                status="partial" if warnings else "imported",
+                warnings=combined_warnings,
+            ),
+        )
+        return {
+            "status": "ok",
+            "summary": {"orders": len(orders)},
+            "imports": [{
+                "import_id": import_id,
+                "status": "partial" if warnings else "imported",
+                "warnings": combined_warnings,
+            }],
+        }
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        message = redact_error(exc, secret_values(account.config))
+        warning = f"Hyperliquid Order History could not be enriched: {message}"
+        combined_warnings = [*retained_warnings, warning]
+        await loop.run_in_executor(
+            cache_executor,
+            partial(
+                cache.update_csv_import_status,
+                import_id,
+                status="partial",
+                warnings=combined_warnings,
+            ),
+        )
+        raise
+
+
 async def _apply_parent_messages(
     state: LivePositionState,
     input_queue: Any,
@@ -1319,6 +1515,58 @@ async def _apply_parent_messages(
                 }
             await _put_control_message(control_output_queue, {
                 "type": "history.refresh.result",
+                "request_id": request_id,
+                "payload": result,
+            })
+            continue
+        if message.get("type") == "history.import":
+            request_id = str(message.get("request_id") or "")
+            try:
+                result = await _import_history_from_parent(
+                    message,
+                    accounts=accounts,
+                    cache=cache,
+                    cache_executor=cache_executor,
+                    stop=stop,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                result = {
+                    "status": "error",
+                    "error": {
+                        "type": type(exc).__name__,
+                        "message": str(exc).replace("\n", " ")[:500],
+                    },
+                }
+            await _put_control_message(control_output_queue, {
+                "type": "history.import.result",
+                "request_id": request_id,
+                "payload": result,
+            })
+            continue
+        if message.get("type") == "history.enrichment":
+            request_id = str(message.get("request_id") or "")
+            try:
+                result = await _retry_history_enrichment_from_parent(
+                    message,
+                    accounts=accounts,
+                    cache=cache,
+                    cache_executor=cache_executor,
+                    stop=stop,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                result = {
+                    "status": "error",
+                    "error": {
+                        "type": type(exc).__name__,
+                        "message": str(exc).replace("\n", " ")[:500],
+                    },
+                }
+            await _put_control_message(control_output_queue, {
+                "type": "history.enrichment.result",
                 "request_id": request_id,
                 "payload": result,
             })

--- a/account_service/live_positions.py
+++ b/account_service/live_positions.py
@@ -1,0 +1,625 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import math
+import queue
+import sys
+from pathlib import Path
+from typing import Any
+
+import ccxt
+import ccxt.pro as ccxtpro
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_AI_SCRIPTS = _PROJECT_ROOT / "ai" / "scripts"
+if str(_AI_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_AI_SCRIPTS))
+
+from asset import (  # noqa: E402
+    ExchangeAccount,
+    configured_accounts,
+    merge_dicts,
+    read_provider_config,
+    redact_error,
+    secret_values,
+    utc_now,
+)
+from position import (  # noqa: E402
+    binance_position_matches_scope,
+    is_open_position,
+    normalize_hyperliquid_position,
+    normalize_position,
+)
+
+from account_service.positions import collect_positions_snapshot  # noqa: E402
+
+
+EMIT_INTERVAL_SECONDS = 0.25
+RECONCILE_INTERVAL_SECONDS = 300.0
+
+
+def _position_key(position: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(position.get("market_scope") or ""),
+        str(position.get("dex") or ""),
+        str(position.get("symbol") or ""),
+        str(position.get("side") or ""),
+    )
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+class LivePositionState:
+    def __init__(self, snapshot: dict[str, Any]) -> None:
+        self.snapshot = copy.deepcopy(snapshot)
+        self.dirty = asyncio.Event()
+        self.sequence = 0
+
+    def replace(self, snapshot: dict[str, Any]) -> None:
+        self.snapshot = copy.deepcopy(snapshot)
+        self.mark_dirty()
+
+    def mark_dirty(self) -> None:
+        self.sequence += 1
+        self.dirty.set()
+
+    def result(self, account_name: str) -> dict[str, Any] | None:
+        for result in self.snapshot.get("results", []):
+            if isinstance(result, dict) and result.get("account") == account_name:
+                return result
+        return None
+
+    def positions(self, account_name: str) -> list[dict[str, Any]]:
+        result = self.result(account_name)
+        if result is None:
+            return []
+        positions = result.get("positions")
+        return positions if isinstance(positions, list) else []
+
+    def merge_positions(
+        self,
+        account_name: str,
+        raw_positions: list[dict[str, Any]],
+        *,
+        exchange_id: str,
+        market_scope: str | None = None,
+        dex: str | None = None,
+    ) -> None:
+        result = self.result(account_name)
+        if result is None:
+            return
+        previous_positions = copy.deepcopy(self.positions(account_name))
+        previous_stream_status = result.get("stream_status")
+        current = {
+            _position_key(position): position
+            for position in self.positions(account_name)
+            if isinstance(position, dict)
+        }
+        for raw_position in raw_positions:
+            if not isinstance(raw_position, dict):
+                continue
+            normalized = (
+                normalize_hyperliquid_position(raw_position)
+                if exchange_id == "hyperliquid"
+                else normalize_position(raw_position)
+            )
+            if market_scope:
+                normalized["market_scope"] = market_scope
+            if dex:
+                normalized["dex"] = dex
+            key = _position_key(normalized)
+            previous = current.get(key)
+            if isinstance(previous, dict):
+                previous_breakdown = previous.get("realized_pnl_breakdown")
+                new_breakdown = normalized.get("realized_pnl_breakdown")
+                previous_net = _number(previous.get("realized_pnl"))
+                new_net = _number(normalized.get("realized_pnl"))
+                if new_net is None and previous_net is not None:
+                    normalized["realized_pnl"] = previous_net
+                    normalized["realized_pnl_breakdown"] = copy.deepcopy(previous_breakdown)
+                elif (
+                    new_net is not None
+                    and previous_net is not None
+                    and math.isclose(new_net, previous_net, rel_tol=1e-10, abs_tol=1e-10)
+                    and isinstance(previous_breakdown, dict)
+                    and not (
+                        isinstance(new_breakdown, dict)
+                        and new_breakdown.get("complete") is True
+                    )
+                ):
+                    normalized["realized_pnl_breakdown"] = copy.deepcopy(previous_breakdown)
+            if (
+                exchange_id == "binance"
+                and market_scope
+                and not binance_position_matches_scope(normalized, market_scope)
+            ):
+                current.pop(key, None)
+                continue
+            if is_open_position(normalized):
+                current[key] = normalized
+            else:
+                current.pop(key, None)
+        positions = sorted(
+            current.values(),
+            key=lambda item: (
+                str(item.get("market_scope") or item.get("dex") or ""),
+                str(item.get("symbol") or ""),
+                str(item.get("side") or ""),
+            ),
+        )
+        result["positions"] = positions
+        result["position_count"] = len(positions)
+        result["stream_status"] = "live"
+        if positions != previous_positions or previous_stream_status != "live":
+            self.mark_dirty()
+
+    def apply_mark(
+        self,
+        account_name: str,
+        symbol: str,
+        mark_price: float,
+        market: dict[str, Any] | None,
+    ) -> None:
+        changed = False
+        for position in self.positions(account_name):
+            if not isinstance(position, dict) or position.get("symbol") != symbol:
+                continue
+            position["mark_price"] = mark_price
+            pnl = _calculate_unrealized_pnl(position, mark_price, market)
+            if pnl is not None:
+                position["unrealized_pnl"] = pnl
+                margin_basis = _position_margin_basis(position, market)
+                position["percentage"] = (
+                    pnl / margin_basis * 100
+                    if margin_basis not in {None, 0}
+                    else None
+                )
+            changed = True
+        if changed:
+            self.mark_dirty()
+
+    def payload(self) -> dict[str, Any]:
+        payload = copy.deepcopy(self.snapshot)
+        results = payload.get("results", [])
+        successful = [
+            result
+            for result in results
+            if isinstance(result, dict) and result.get("status") == "ok"
+        ]
+        payload["collected_at"] = utc_now()
+        payload["cached"] = False
+        payload["live"] = True
+        payload["sequence"] = self.sequence
+        payload["summary"] = {
+            "accounts": len(results),
+            "succeeded": len(successful),
+            "failed": len(results) - len(successful),
+            "open_positions": sum(
+                len(result.get("positions", []))
+                for result in successful
+                if isinstance(result.get("positions", []), list)
+            ),
+        }
+        return payload
+
+
+def _calculate_unrealized_pnl(
+    position: dict[str, Any],
+    mark_price: float,
+    market: dict[str, Any] | None,
+) -> float | None:
+    entry_price = _number(position.get("entry_price"))
+    contracts = _number(position.get("contracts"))
+    contract_size = _number(position.get("contract_size")) or 1.0
+    if entry_price in {None, 0} or contracts in {None, 0} or mark_price <= 0:
+        return None
+    side = str(position.get("side") or "").lower()
+    if side not in {"long", "short"}:
+        return None
+    direction = 1.0 if side == "long" else -1.0
+    quantity = abs(contracts) * contract_size
+    if market and market.get("inverse"):
+        return direction * quantity * (1.0 / entry_price - 1.0 / mark_price)
+    return direction * quantity * (mark_price - entry_price)
+
+
+def _position_margin_basis(
+    position: dict[str, Any],
+    market: dict[str, Any] | None,
+) -> float | None:
+    for key in ("initial_margin", "collateral"):
+        value = _number(position.get(key))
+        if value is not None and value > 0:
+            return value
+    entry_price = _number(position.get("entry_price"))
+    contracts = _number(position.get("contracts"))
+    leverage = _number(position.get("leverage"))
+    contract_size = _number(position.get("contract_size")) or 1.0
+    if (
+        entry_price in {None, 0}
+        or contracts in {None, 0}
+        or leverage in {None, 0}
+    ):
+        return None
+    quantity = abs(contracts) * contract_size
+    entry_notional = (
+        quantity / entry_price
+        if market and market.get("inverse")
+        else quantity * entry_price
+    )
+    return entry_notional / leverage
+
+
+def _build_live_exchange(account: ExchangeAccount) -> Any:
+    exchange_class = getattr(ccxtpro, account.exchange_id, None)
+    if exchange_class is None:
+        raise ValueError(f"unsupported CCXT Pro exchange: {account.exchange_id}")
+    config = merge_dicts(
+        {"enableRateLimit": True, "timeout": 30_000},
+        account.config,
+    )
+    sandbox = bool(config.pop("isTestnet", False) or config.pop("sandbox", False))
+    options = config.get("options")
+    options = dict(options) if isinstance(options, dict) else {}
+    options.setdefault("defaultType", "swap")
+    if account.exchange_id == "binance":
+        watch_positions = options.get("watchPositions")
+        watch_positions = (
+            dict(watch_positions) if isinstance(watch_positions, dict) else {}
+        )
+        # Our REST snapshot is authoritative. CCXT Pro 4.5.58 drops subType
+        # while building Binance's COIN-M WS snapshot and can load USD-M twice.
+        watch_positions["fetchPositionsSnapshot"] = False
+        watch_positions["awaitPositionsSnapshot"] = False
+        options["watchPositions"] = watch_positions
+    config["options"] = options
+    exchange = exchange_class(config)
+    if sandbox:
+        exchange.set_sandbox_mode(True)
+    if account.exchange_id == "hyperliquid":
+        if not exchange.walletAddress:
+            raise ccxt.ArgumentsRequired("hyperliquid walletAddress is required")
+    else:
+        exchange.check_required_credentials()
+    return exchange
+
+
+def _subscriptions(
+    exchange_id: str,
+    positions: list[dict[str, Any]],
+) -> list[tuple[list[str] | None, dict[str, Any], str | None, str | None]]:
+    if exchange_id == "binance":
+        return [
+            (None, {"type": "future", "subType": "linear"}, "usd_m", None),
+            (None, {"type": "delivery", "subType": "inverse"}, "coin_m", None),
+        ]
+    if exchange_id == "bitget":
+        grouped: dict[str, list[str]] = {}
+        for position in positions:
+            scope = str(position.get("market_scope") or "USDT-FUTURES")
+            symbol = str(position.get("symbol") or "")
+            if symbol:
+                grouped.setdefault(scope, []).append(symbol)
+        if not grouped:
+            return [(None, {}, "USDT-FUTURES", None)]
+        return [
+            (sorted(set(symbols)), {}, scope, None)
+            for scope, symbols in grouped.items()
+        ]
+    if exchange_id == "hyperliquid":
+        grouped_dexes: dict[str, list[str]] = {}
+        for position in positions:
+            dex = str(position.get("dex") or "default")
+            symbol = str(position.get("symbol") or "")
+            if symbol:
+                grouped_dexes.setdefault(dex, []).append(symbol)
+        if not grouped_dexes:
+            return [(None, {}, None, "default")]
+        return [
+            (sorted(set(symbols)), {}, None, dex)
+            for dex, symbols in grouped_dexes.items()
+        ]
+    return [(None, {}, None, None)]
+
+
+async def _watch_private_positions(
+    exchange: Any,
+    account: ExchangeAccount,
+    state: LivePositionState,
+    symbols: list[str] | None,
+    params: dict[str, Any],
+    market_scope: str | None,
+    dex: str | None,
+    stop: asyncio.Event,
+) -> None:
+    delay = 1.0
+    secrets = secret_values(account.config)
+    while not stop.is_set():
+        try:
+            positions = await exchange.watch_positions(symbols, params=params)
+            if isinstance(positions, list):
+                state.merge_positions(
+                    account.name,
+                    positions,
+                    exchange_id=account.exchange_id,
+                    market_scope=market_scope,
+                    dex=dex,
+                )
+            delay = 1.0
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            print(
+                f"[account] {account.name} position stream error: "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+                file=sys.stderr,
+                flush=True,
+            )
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=delay)
+            except TimeoutError:
+                pass
+            delay = min(delay * 2, 30.0)
+
+
+def _ticker_mark(ticker: dict[str, Any]) -> float | None:
+    for key in ("mark", "markPrice"):
+        value = _number(ticker.get(key))
+        if value is not None and value > 0:
+            return value
+    info = ticker.get("info")
+    if isinstance(info, dict):
+        for key in ("markPrice", "markPx", "mark_price", "lastPr", "lastPrice"):
+            value = _number(info.get(key))
+            if value is not None and value > 0:
+                return value
+    for key in ("last", "close"):
+        value = _number(ticker.get(key))
+        if value is not None and value > 0:
+            return value
+    return None
+
+
+async def _watch_mark(
+    exchange: Any,
+    account: ExchangeAccount,
+    state: LivePositionState,
+    symbol: str,
+    stop: asyncio.Event,
+) -> None:
+    delay = 1.0
+    secrets = secret_values(account.config)
+    while not stop.is_set():
+        try:
+            if exchange.has.get("watchMarkPrice"):
+                ticker = await exchange.watch_mark_price(symbol)
+            else:
+                ticker = await exchange.watch_ticker(symbol)
+            mark_price = _ticker_mark(ticker if isinstance(ticker, dict) else {})
+            if mark_price is not None:
+                market = exchange.market(symbol) if symbol in exchange.markets else None
+                state.apply_mark(account.name, symbol, mark_price, market)
+            delay = 1.0
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            print(
+                f"[account] {account.name} {symbol} mark stream error: "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+                file=sys.stderr,
+                flush=True,
+            )
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=delay)
+            except TimeoutError:
+                pass
+            delay = min(delay * 2, 30.0)
+
+
+async def _ticker_supervisor(
+    exchange: Any,
+    account: ExchangeAccount,
+    state: LivePositionState,
+    stop: asyncio.Event,
+) -> None:
+    tasks: dict[str, asyncio.Task[None]] = {}
+    try:
+        while not stop.is_set():
+            symbols = {
+                str(position.get("symbol") or "")
+                for position in state.positions(account.name)
+                if isinstance(position, dict) and position.get("symbol")
+            }
+            for symbol in symbols - tasks.keys():
+                tasks[symbol] = asyncio.create_task(
+                    _watch_mark(exchange, account, state, symbol, stop)
+                )
+            for symbol in set(tasks) - symbols:
+                tasks.pop(symbol).cancel()
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=1.0)
+            except TimeoutError:
+                pass
+    finally:
+        for task in tasks.values():
+            task.cancel()
+        await asyncio.gather(*tasks.values(), return_exceptions=True)
+
+
+async def _watch_account(
+    account: ExchangeAccount,
+    state: LivePositionState,
+    stop: asyncio.Event,
+) -> None:
+    exchange = None
+    tasks: list[asyncio.Task[None]] = []
+    secrets = secret_values(account.config)
+    try:
+        exchange = _build_live_exchange(account)
+        await exchange.load_markets()
+        if not exchange.has.get("watchPositions"):
+            raise ccxt.NotSupported(f"{account.exchange_id} does not support watchPositions")
+        for symbols, params, market_scope, dex in _subscriptions(
+            account.exchange_id,
+            state.positions(account.name),
+        ):
+            tasks.append(
+                asyncio.create_task(
+                    _watch_private_positions(
+                        exchange,
+                        account,
+                        state,
+                        symbols,
+                        params,
+                        market_scope,
+                        dex,
+                        stop,
+                    )
+                )
+            )
+        tasks.append(asyncio.create_task(_ticker_supervisor(exchange, account, state, stop)))
+        await stop.wait()
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        print(
+            f"[account] {account.name} live stream unavailable: "
+            f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+            file=sys.stderr,
+            flush=True,
+        )
+        await stop.wait()
+    finally:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        if exchange is not None:
+            try:
+                await exchange.close()
+            except Exception:
+                pass
+
+
+async def _emit_updates(state: LivePositionState, output_queue: Any, stop: asyncio.Event) -> None:
+    while not stop.is_set():
+        await state.dirty.wait()
+        state.dirty.clear()
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=EMIT_INTERVAL_SECONDS)
+            break
+        except TimeoutError:
+            pass
+        payload = state.payload()
+        try:
+            output_queue.put_nowait(payload)
+        except queue.Full:
+            try:
+                output_queue.get_nowait()
+            except queue.Empty:
+                pass
+            try:
+                output_queue.put_nowait(payload)
+            except queue.Full:
+                pass
+
+
+async def _reconcile(
+    config_path: str,
+    state: LivePositionState,
+    stop: asyncio.Event,
+) -> None:
+    while not stop.is_set():
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=RECONCILE_INTERVAL_SECONDS)
+            break
+        except TimeoutError:
+            pass
+        try:
+            snapshot = await asyncio.to_thread(collect_positions_snapshot, config_path)
+            state.replace(snapshot)
+        except Exception as exc:
+            print(
+                f"[account] position reconciliation failed: {type(exc).__name__}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+
+async def _run_positions_stream(
+    config_path: str,
+    output_queue: Any,
+    stop_event: Any,
+    initial_snapshot: dict[str, Any] | None,
+) -> None:
+    snapshot = initial_snapshot or await asyncio.to_thread(
+        collect_positions_snapshot,
+        config_path,
+    )
+    state = LivePositionState(snapshot)
+    state.mark_dirty()
+    data = read_provider_config(Path(config_path))
+    accounts = configured_accounts(data)
+    stop = asyncio.Event()
+
+    async def watch_parent_stop() -> None:
+        await asyncio.to_thread(stop_event.wait)
+        stop.set()
+
+    tasks = [
+        asyncio.create_task(_watch_account(account, state, stop))
+        for account in accounts
+    ]
+    tasks.extend(
+        [
+            asyncio.create_task(_emit_updates(state, output_queue, stop)),
+            asyncio.create_task(_reconcile(config_path, state, stop)),
+            asyncio.create_task(watch_parent_stop()),
+        ]
+    )
+    try:
+        await stop.wait()
+    finally:
+        stop.set()
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+def run_positions_stream(
+    config_path: str,
+    output_queue: Any,
+    stop_event: Any,
+    initial_snapshot: dict[str, Any] | None = None,
+) -> None:
+    try:
+        asyncio.run(
+            _run_positions_stream(
+                config_path,
+                output_queue,
+                stop_event,
+                initial_snapshot,
+            )
+        )
+    except KeyboardInterrupt:
+        pass
+    except Exception as exc:
+        print(
+            f"[account] live position process stopped: {type(exc).__name__}",
+            file=sys.stderr,
+            flush=True,
+        )
+    finally:
+        try:
+            output_queue.put_nowait(None)
+        except Exception:
+            pass

--- a/account_service/live_positions.py
+++ b/account_service/live_positions.py
@@ -5,6 +5,7 @@ import copy
 import math
 import queue
 import sys
+import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
@@ -29,15 +30,28 @@ from asset import (  # noqa: E402
 )
 from position import (  # noqa: E402
     binance_position_matches_scope,
+    configure_hyperliquid_dex_markets,
     is_open_position,
     normalize_hyperliquid_position,
     normalize_position,
 )
 
+from account_service.backfill import (  # noqa: E402
+    account_history_backfill_loop,
+    account_history_symbols,
+    backfill_account_once,
+    hyperliquid_dexes,
+    manual_history_refresh_timing,
+)
 from account_service.cache import AccountCache  # noqa: E402
-from account_service.history import normalize_fill, normalize_order  # noqa: E402
+from account_service.history import (  # noqa: E402
+    normalize_fill,
+    normalize_order,
+    okx_history_market_scope,
+)
 from account_service.positions import collect_positions_snapshot  # noqa: E402
 from data_service.schedule_utils import (  # noqa: E402
+    seconds_until_manual_refresh_guard_end,
     seconds_until_post_bar_task_window,
 )
 
@@ -69,12 +83,23 @@ def _number(value: Any) -> float | None:
 class LivePositionState:
     def __init__(self, snapshot: dict[str, Any]) -> None:
         self.snapshot = copy.deepcopy(snapshot)
+        self.refresh_revision = 0
         self.dirty = asyncio.Event()
         self.persist_dirty = asyncio.Event()
         self.sequence = 0
 
-    def replace(self, snapshot: dict[str, Any]) -> None:
+    def replace(
+        self,
+        snapshot: dict[str, Any],
+        *,
+        refresh_revision: int | None = None,
+    ) -> None:
         self.snapshot = copy.deepcopy(snapshot)
+        if refresh_revision is not None:
+            self.refresh_revision = max(
+                self.refresh_revision,
+                refresh_revision,
+            )
         self.mark_dirty()
 
     def mark_dirty(self) -> None:
@@ -209,6 +234,7 @@ class LivePositionState:
         payload["cached"] = False
         payload["live"] = True
         payload["sequence"] = self.sequence
+        payload["_refresh_revision"] = self.refresh_revision
         payload["summary"] = {
             "accounts": len(results),
             "succeeded": len(successful),
@@ -227,6 +253,8 @@ class AccountHistoryBuffer:
         self.dirty = asyncio.Event()
         self._orders: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
         self._fills: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
+        self._positions: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+        self._cursors: dict[tuple[str, str, str, str], dict[str, Any]] = {}
 
     def add_orders(
         self,
@@ -240,10 +268,17 @@ class AccountHistoryBuffer:
             if not isinstance(raw_order, dict):
                 continue
             payload = normalize_order(raw_order)
+            resolved_scope = market_scope
+            if exchange == "okx":
+                resolved_scope = (
+                    okx_history_market_scope(raw_order)
+                    or okx_history_market_scope(payload)
+                    or market_scope
+                )
             key = (
                 account,
                 exchange,
-                market_scope,
+                resolved_scope,
                 str(payload.get("symbol") or ""),
                 str(payload.get("id") or ""),
             )
@@ -262,7 +297,8 @@ class AccountHistoryBuffer:
             self._orders[key] = {
                 "account": account,
                 "exchange": exchange,
-                "market_scope": market_scope,
+                "market_scope": resolved_scope,
+                "source": "live",
                 "payload": payload,
             }
             changed = True
@@ -281,34 +317,136 @@ class AccountHistoryBuffer:
             if not isinstance(raw_fill, dict):
                 continue
             payload = normalize_fill(raw_fill)
+            resolved_scope = market_scope
+            if exchange == "okx":
+                resolved_scope = (
+                    okx_history_market_scope(raw_fill)
+                    or okx_history_market_scope(payload)
+                    or market_scope
+                )
             key = (
                 account,
                 exchange,
-                market_scope,
+                resolved_scope,
                 str(payload.get("symbol") or ""),
                 str(payload.get("id") or ""),
             )
             self._fills[key] = {
                 "account": account,
                 "exchange": exchange,
-                "market_scope": market_scope,
+                "market_scope": resolved_scope,
+                "source": "live",
                 "payload": payload,
             }
             changed = True
         if changed:
             self.dirty.set()
 
-    def drain(self) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    def add_backfill(
+        self,
+        *,
+        orders: list[dict[str, Any]],
+        fills: list[dict[str, Any]],
+        positions: list[dict[str, Any]],
+        cursors: list[dict[str, Any]],
+    ) -> None:
+        self.add_orders_from_records(orders)
+        self.add_fills_from_records(fills)
+        for record in positions:
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("position_key") or ""),
+                str(record.get("closed_at") or ""),
+            )
+            self._positions[key] = record
+        for record in cursors:
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("stream") or ""),
+                str(record.get("market_scope") or ""),
+            )
+            self._cursors[key] = record
+        if positions or cursors:
+            self.dirty.set()
+
+    def add_orders_from_records(self, records: list[dict[str, Any]]) -> None:
+        changed = False
+        for record in records:
+            payload = record.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("market_scope") or ""),
+                str(payload.get("symbol") or ""),
+                str(payload.get("id") or ""),
+            )
+            previous = self._orders.get(key)
+            if previous is not None:
+                previous_timestamp = _number(
+                    previous["payload"].get("updated_timestamp")
+                )
+                timestamp = _number(payload.get("updated_timestamp"))
+                if (
+                    previous_timestamp is not None
+                    and (timestamp is None or timestamp < previous_timestamp)
+                ):
+                    continue
+                if previous.get("source") == "live":
+                    record = {**record, "source": "live"}
+            self._orders[key] = record
+            changed = True
+        if changed:
+            self.dirty.set()
+
+    def add_fills_from_records(self, records: list[dict[str, Any]]) -> None:
+        changed = False
+        for record in records:
+            payload = record.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("market_scope") or ""),
+                str(payload.get("symbol") or ""),
+                str(payload.get("id") or ""),
+            )
+            previous = self._fills.get(key)
+            if previous is not None and previous.get("source") == "live":
+                continue
+            self._fills[key] = record
+            changed = True
+        if changed:
+            self.dirty.set()
+
+    def drain(
+        self,
+    ) -> tuple[
+        list[dict[str, Any]],
+        list[dict[str, Any]],
+        list[dict[str, Any]],
+        list[dict[str, Any]],
+    ]:
         orders = list(self._orders.values())
         fills = list(self._fills.values())
+        positions = list(self._positions.values())
+        cursors = list(self._cursors.values())
         self._orders.clear()
         self._fills.clear()
-        return orders, fills
+        self._positions.clear()
+        self._cursors.clear()
+        return orders, fills, positions, cursors
 
     def restore(
         self,
         orders: list[dict[str, Any]],
         fills: list[dict[str, Any]],
+        positions: list[dict[str, Any]],
+        cursors: list[dict[str, Any]],
     ) -> None:
         for record in orders:
             payload = record.get("payload")
@@ -334,7 +472,23 @@ class AccountHistoryBuffer:
                 str(payload.get("id") or ""),
             )
             self._fills.setdefault(key, record)
-        if orders or fills:
+        for record in positions:
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("position_key") or ""),
+                str(record.get("closed_at") or ""),
+            )
+            self._positions.setdefault(key, record)
+        for record in cursors:
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("stream") or ""),
+                str(record.get("market_scope") or ""),
+            )
+            self._cursors.setdefault(key, record)
+        if orders or fills or positions or cursors:
             self.dirty.set()
 
 
@@ -727,6 +881,11 @@ async def _watch_account(
     account: ExchangeAccount,
     state: LivePositionState,
     history: AccountHistoryBuffer,
+    config_path: str,
+    cached_symbols: set[str],
+    cursors: dict[tuple[str, str, str, str], str],
+    backfill_semaphore: asyncio.Semaphore,
+    backfill_lock: asyncio.Lock,
     stop: asyncio.Event,
 ) -> None:
     exchange = None
@@ -734,6 +893,17 @@ async def _watch_account(
     secrets = secret_values(account.config)
     try:
         exchange = _build_live_exchange(account)
+        known_symbols = account_history_symbols(
+            config_path,
+            account.exchange_id,
+            state.positions(account.name),
+            cached_symbols,
+        )
+        if account.exchange_id == "hyperliquid":
+            configure_hyperliquid_dex_markets(
+                exchange,
+                hyperliquid_dexes(known_symbols),
+            )
         await exchange.load_markets()
         if not exchange.has.get("watchPositions"):
             raise ccxt.NotSupported(f"{account.exchange_id} does not support watchPositions")
@@ -780,6 +950,20 @@ async def _watch_account(
                         stop,
                     )
                 ))
+        tasks.append(asyncio.create_task(
+            account_history_backfill_loop(
+                exchange,
+                account,
+                config_path,
+                lambda: state.positions(account.name),
+                cached_symbols,
+                history,
+                cursors,
+                backfill_semaphore,
+                backfill_lock,
+                stop,
+            )
+        ))
         await stop.wait()
     except asyncio.CancelledError:
         raise
@@ -869,16 +1053,18 @@ async def _persist_history_updates(
         except TimeoutError:
             pass
         history.dirty.clear()
-        orders, fills = history.drain()
+        orders, fills, positions, cursors = history.drain()
         try:
             await loop.run_in_executor(
                 executor,
                 cache.apply_history_batch,
                 orders,
                 fills,
+                positions,
+                cursors,
             )
         except Exception as exc:
-            history.restore(orders, fills)
+            history.restore(orders, fills, positions, cursors)
             print(
                 f"[account] history cache write failed: {type(exc).__name__}: {exc}",
                 file=sys.stderr,
@@ -915,10 +1101,243 @@ async def _reconcile(
             )
 
 
+async def _refresh_history_from_parent(
+    request: dict[str, Any],
+    *,
+    config_path: str,
+    state: LivePositionState,
+    accounts: list[ExchangeAccount],
+    cached_symbols: dict[str, set[str]],
+    cursors: dict[tuple[str, str, str, str], str],
+    backfill_semaphore: asyncio.Semaphore,
+    backfill_locks: dict[str, asyncio.Lock],
+    cache: AccountCache,
+    cache_executor: ThreadPoolExecutor,
+    stop: asyncio.Event,
+) -> dict[str, Any]:
+    kind = str(request.get("kind") or "").strip().lower()
+    if kind not in {"order", "position"}:
+        raise ValueError("history kind must be order or position")
+    account_filter = str(request.get("account") or "").strip().lower()
+    requested_accounts = {
+        str(name).strip().lower()
+        for name in request.get("accounts", [])
+        if isinstance(name, str) and name.strip()
+    }
+    exchange_filter = str(request.get("exchange") or "").strip().lower()
+    requested_symbol = str(request.get("symbol") or "").strip().upper()
+    selected_accounts = [
+        account
+        for account in accounts
+        if (not account_filter or account_filter in account.name.lower())
+        and (not requested_accounts or account.name.lower() in requested_accounts)
+        and (not exchange_filter or account.exchange_id == exchange_filter)
+    ]
+    if not selected_accounts:
+        raise ValueError("no configured account matches the history refresh scope")
+
+    loop = asyncio.get_running_loop()
+    results: list[dict[str, Any]] = []
+    for account in selected_accounts:
+        exchange = None
+        started_at = time.monotonic()
+        try:
+            post_bar_delay = seconds_until_manual_refresh_guard_end()
+            if post_bar_delay > 0.0:
+                try:
+                    await asyncio.wait_for(stop.wait(), timeout=post_bar_delay)
+                    raise asyncio.CancelledError
+                except TimeoutError:
+                    pass
+            exchange = _build_live_exchange(account)
+            known = (
+                {requested_symbol}
+                if requested_symbol
+                else account_history_symbols(
+                    config_path,
+                    account.exchange_id,
+                    state.positions(account.name),
+                    set(cached_symbols.get(account.exchange_id, set())),
+                )
+            )
+            if account.exchange_id == "hyperliquid":
+                configure_hyperliquid_dex_markets(
+                    exchange,
+                    hyperliquid_dexes(known),
+                )
+            await exchange.load_markets()
+
+            refreshed_cursors = dict(cursors)
+            async with backfill_semaphore:
+                async with backfill_locks[account.name]:
+                    with manual_history_refresh_timing():
+                        batch = await backfill_account_once(
+                            exchange,
+                            account,
+                            known,
+                            refreshed_cursors,
+                            stop,
+                            include_orders=kind == "order",
+                            include_fills=kind == "position",
+                            include_positions=kind == "position",
+                            target_symbol=requested_symbol or None,
+                            discover_symbols=False,
+                        )
+                    # A scoped manual refresh must not advance the account-wide
+                    # cursors used by the periodic full-history backfill.
+                    batch["cursors"] = []
+                    post_bar_delay = seconds_until_manual_refresh_guard_end()
+                    if post_bar_delay > 0.0:
+                        try:
+                            await asyncio.wait_for(
+                                stop.wait(),
+                                timeout=post_bar_delay,
+                            )
+                            raise asyncio.CancelledError
+                        except TimeoutError:
+                            pass
+                    await loop.run_in_executor(
+                        cache_executor,
+                        cache.apply_history_batch,
+                        batch["orders"],
+                        batch["fills"],
+                        batch["positions"],
+                        batch["cursors"],
+                    )
+            result = {
+                "account": account.name,
+                "exchange": account.exchange_id,
+                "status": "ok",
+                "orders": len(batch["orders"]),
+                "fills": len(batch["fills"]),
+                "positions": len(batch["positions"]),
+                "elapsed_seconds": round(time.monotonic() - started_at, 3),
+            }
+            print(
+                f"[account] manual history refresh completed | "
+                f"kind={kind} account={account.name} "
+                f"exchange={account.exchange_id} "
+                f"symbol={requested_symbol or '*'} "
+                f"orders={result['orders']} fills={result['fills']} "
+                f"positions={result['positions']} "
+                f"elapsed={result['elapsed_seconds']:.1f}s",
+                flush=True,
+            )
+            results.append(result)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            message = redact_error(exc, secret_values(account.config))
+            print(
+                f"[account] {account.name} manual history refresh failed: "
+                f"{type(exc).__name__}: {message}",
+                file=sys.stderr,
+                flush=True,
+            )
+            results.append({
+                "account": account.name,
+                "exchange": account.exchange_id,
+                "status": "error",
+                "error": {
+                    "type": type(exc).__name__,
+                    "message": str(message)[:500],
+                },
+            })
+        finally:
+            if exchange is not None:
+                try:
+                    await exchange.close()
+                except Exception:
+                    pass
+
+    succeeded = sum(result["status"] == "ok" for result in results)
+    return {
+        "status": "ok" if succeeded else "error",
+        "results": results,
+        "summary": {
+            "requested": len(results),
+            "succeeded": succeeded,
+            "failed": len(results) - succeeded,
+        },
+    }
+
+
+async def _put_control_message(output_queue: Any, payload: dict[str, Any]) -> None:
+    try:
+        await asyncio.to_thread(output_queue.put, payload, True, 5.0)
+    except (queue.Full, ValueError, OSError):
+        pass
+
+
+async def _apply_parent_messages(
+    state: LivePositionState,
+    input_queue: Any,
+    control_output_queue: Any,
+    *,
+    config_path: str,
+    accounts: list[ExchangeAccount],
+    cached_symbols: dict[str, set[str]],
+    cursors: dict[tuple[str, str, str, str], str],
+    backfill_semaphore: asyncio.Semaphore,
+    backfill_locks: dict[str, asyncio.Lock],
+    cache: AccountCache,
+    cache_executor: ThreadPoolExecutor,
+    stop: asyncio.Event,
+) -> None:
+    while not stop.is_set():
+        try:
+            message = await asyncio.to_thread(input_queue.get, True, 1.0)
+        except queue.Empty:
+            continue
+        if not isinstance(message, dict):
+            continue
+        if message.get("type") == "history.refresh":
+            request_id = str(message.get("request_id") or "")
+            try:
+                result = await _refresh_history_from_parent(
+                    message,
+                    config_path=config_path,
+                    state=state,
+                    accounts=accounts,
+                    cached_symbols=cached_symbols,
+                    cursors=cursors,
+                    backfill_semaphore=backfill_semaphore,
+                    backfill_locks=backfill_locks,
+                    cache=cache,
+                    cache_executor=cache_executor,
+                    stop=stop,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                result = {
+                    "status": "error",
+                    "error": {
+                        "type": type(exc).__name__,
+                        "message": str(exc).replace("\n", " ")[:500],
+                    },
+                }
+            await _put_control_message(control_output_queue, {
+                "type": "history.refresh.result",
+                "request_id": request_id,
+                "payload": result,
+            })
+            continue
+        snapshot = message.get("snapshot")
+        if not isinstance(snapshot, dict):
+            continue
+        revision = message.get("revision")
+        if isinstance(revision, bool) or not isinstance(revision, int):
+            continue
+        state.replace(snapshot, refresh_revision=revision)
+
+
 async def _run_positions_stream(
     config_path: str,
     cache_path: str,
     output_queue: Any,
+    control_output_queue: Any,
+    input_queue: Any,
     stop_event: Any,
     initial_snapshot: dict[str, Any] | None,
 ) -> None:
@@ -934,8 +1353,19 @@ async def _run_positions_stream(
         max_workers=1,
         thread_name_prefix="account-cache-writer",
     )
+    loop = asyncio.get_running_loop()
+    cursors = await loop.run_in_executor(cache_executor, cache.sync_cursors)
+    known_symbols = await loop.run_in_executor(
+        cache_executor,
+        cache.known_history_symbols,
+    )
+    backfill_semaphore = asyncio.Semaphore(2)
     data = read_provider_config(Path(config_path))
     accounts = configured_accounts(data)
+    backfill_locks = {
+        account.name: asyncio.Lock()
+        for account in accounts
+    }
     stop = asyncio.Event()
 
     async def watch_parent_stop() -> None:
@@ -943,7 +1373,17 @@ async def _run_positions_stream(
         stop.set()
 
     tasks = [
-        asyncio.create_task(_watch_account(account, state, history, stop))
+        asyncio.create_task(_watch_account(
+            account,
+            state,
+            history,
+            config_path,
+            set(known_symbols.get(account.exchange_id, set())),
+            cursors,
+            backfill_semaphore,
+            backfill_locks[account.name],
+            stop,
+        ))
         for account in accounts
     ]
     tasks.extend(
@@ -954,6 +1394,20 @@ async def _run_positions_stream(
                 _persist_history_updates(history, cache, cache_executor, stop)
             ),
             asyncio.create_task(_reconcile(config_path, state, stop)),
+            asyncio.create_task(_apply_parent_messages(
+                state,
+                input_queue,
+                control_output_queue,
+                config_path=config_path,
+                accounts=accounts,
+                cached_symbols=known_symbols,
+                cursors=cursors,
+                backfill_semaphore=backfill_semaphore,
+                backfill_locks=backfill_locks,
+                cache=cache,
+                cache_executor=cache_executor,
+                stop=stop,
+            )),
             asyncio.create_task(watch_parent_stop()),
         ]
     )
@@ -964,7 +1418,6 @@ async def _run_positions_stream(
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
-        loop = asyncio.get_running_loop()
         try:
             await loop.run_in_executor(
                 cache_executor,
@@ -977,14 +1430,16 @@ async def _run_positions_stream(
                 file=sys.stderr,
                 flush=True,
             )
-        orders, fills = history.drain()
-        if orders or fills:
+        orders, fills, positions, cursor_records = history.drain()
+        if orders or fills or positions or cursor_records:
             try:
                 await loop.run_in_executor(
                     cache_executor,
                     cache.apply_history_batch,
                     orders,
                     fills,
+                    positions,
+                    cursor_records,
                 )
             except Exception as exc:
                 print(
@@ -1001,6 +1456,8 @@ def run_positions_stream(
     config_path: str,
     cache_path: str,
     output_queue: Any,
+    control_output_queue: Any,
+    input_queue: Any,
     stop_event: Any,
     initial_snapshot: dict[str, Any] | None = None,
 ) -> None:
@@ -1010,6 +1467,8 @@ def run_positions_stream(
                 config_path,
                 cache_path,
                 output_queue,
+                control_output_queue,
+                input_queue,
                 stop_event,
                 initial_snapshot,
             )
@@ -1025,5 +1484,9 @@ def run_positions_stream(
     finally:
         try:
             output_queue.put_nowait(None)
+        except Exception:
+            pass
+        try:
+            control_output_queue.put_nowait(None)
         except Exception:
             pass

--- a/account_service/live_positions.py
+++ b/account_service/live_positions.py
@@ -46,7 +46,9 @@ from account_service.backfill import (  # noqa: E402
 )
 from account_service.cache import AccountCache  # noqa: E402
 from account_service.csv_import import (  # noqa: E402
+    canonicalize_hyperliquid_import_batch,
     fetch_hyperliquid_historical_orders,
+    fetch_hyperliquid_symbol_aliases,
 )
 from account_service.history import (  # noqa: E402
     normalize_fill,
@@ -158,6 +160,9 @@ class LivePositionState:
             key = _position_key(normalized)
             previous = current.get(key)
             if isinstance(previous, dict):
+                previous_mark = _number(previous.get("mark_price"))
+                if _number(normalized.get("mark_price")) is None and previous_mark is not None:
+                    normalized["mark_price"] = previous_mark
                 previous_breakdown = previous.get("realized_pnl_breakdown")
                 new_breakdown = normalized.get("realized_pnl_breakdown")
                 previous_net = _number(previous.get("realized_pnl"))
@@ -258,6 +263,7 @@ class AccountHistoryBuffer:
         self._orders: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
         self._fills: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
         self._positions: dict[tuple[str, str, str, str], dict[str, Any]] = {}
+        self._pnl_events: dict[tuple[str, str, str, str], dict[str, Any]] = {}
         self._cursors: dict[tuple[str, str, str, str], dict[str, Any]] = {}
 
     def add_orders(
@@ -352,6 +358,7 @@ class AccountHistoryBuffer:
         orders: list[dict[str, Any]],
         fills: list[dict[str, Any]],
         positions: list[dict[str, Any]],
+        pnl_events: list[dict[str, Any]],
         cursors: list[dict[str, Any]],
     ) -> None:
         self.add_orders_from_records(orders)
@@ -364,6 +371,14 @@ class AccountHistoryBuffer:
                 str(record.get("closed_at") or ""),
             )
             self._positions[key] = record
+        for record in pnl_events:
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("event_type") or ""),
+                str(record.get("event_id") or ""),
+            )
+            self._pnl_events[key] = record
         for record in cursors:
             key = (
                 str(record.get("account") or ""),
@@ -372,7 +387,7 @@ class AccountHistoryBuffer:
                 str(record.get("market_scope") or ""),
             )
             self._cursors[key] = record
-        if positions or cursors:
+        if positions or pnl_events or cursors:
             self.dirty.set()
 
     def add_orders_from_records(self, records: list[dict[str, Any]]) -> None:
@@ -434,22 +449,26 @@ class AccountHistoryBuffer:
         list[dict[str, Any]],
         list[dict[str, Any]],
         list[dict[str, Any]],
+        list[dict[str, Any]],
     ]:
         orders = list(self._orders.values())
         fills = list(self._fills.values())
         positions = list(self._positions.values())
+        pnl_events = list(self._pnl_events.values())
         cursors = list(self._cursors.values())
         self._orders.clear()
         self._fills.clear()
         self._positions.clear()
+        self._pnl_events.clear()
         self._cursors.clear()
-        return orders, fills, positions, cursors
+        return orders, fills, positions, pnl_events, cursors
 
     def restore(
         self,
         orders: list[dict[str, Any]],
         fills: list[dict[str, Any]],
         positions: list[dict[str, Any]],
+        pnl_events: list[dict[str, Any]],
         cursors: list[dict[str, Any]],
     ) -> None:
         for record in orders:
@@ -484,6 +503,14 @@ class AccountHistoryBuffer:
                 str(record.get("closed_at") or ""),
             )
             self._positions.setdefault(key, record)
+        for record in pnl_events:
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("event_type") or ""),
+                str(record.get("event_id") or ""),
+            )
+            self._pnl_events.setdefault(key, record)
         for record in cursors:
             key = (
                 str(record.get("account") or ""),
@@ -492,7 +519,7 @@ class AccountHistoryBuffer:
                 str(record.get("market_scope") or ""),
             )
             self._cursors.setdefault(key, record)
-        if orders or fills or positions or cursors:
+        if orders or fills or positions or pnl_events or cursors:
             self.dirty.set()
 
 
@@ -1057,7 +1084,7 @@ async def _persist_history_updates(
         except TimeoutError:
             pass
         history.dirty.clear()
-        orders, fills, positions, cursors = history.drain()
+        orders, fills, positions, pnl_events, cursors = history.drain()
         try:
             await loop.run_in_executor(
                 executor,
@@ -1066,9 +1093,10 @@ async def _persist_history_updates(
                 fills,
                 positions,
                 cursors,
+                pnl_events,
             )
         except Exception as exc:
-            history.restore(orders, fills, positions, cursors)
+            history.restore(orders, fills, positions, pnl_events, cursors)
             print(
                 f"[account] history cache write failed: {type(exc).__name__}: {exc}",
                 file=sys.stderr,
@@ -1184,6 +1212,7 @@ async def _refresh_history_from_parent(
                             include_orders=kind == "order",
                             include_fills=kind == "position",
                             include_positions=kind == "position",
+                            include_pnl_events=kind == "position",
                             target_symbol=requested_symbol or None,
                             discover_symbols=False,
                         )
@@ -1207,6 +1236,7 @@ async def _refresh_history_from_parent(
                         batch["fills"],
                         batch["positions"],
                         batch["cursors"],
+                        batch["pnl_events"],
                     )
             result = {
                 "account": account.name,
@@ -1215,6 +1245,7 @@ async def _refresh_history_from_parent(
                 "orders": len(batch["orders"]),
                 "fills": len(batch["fills"]),
                 "positions": len(batch["positions"]),
+                "pnl_events": len(batch["pnl_events"]),
                 "elapsed_seconds": round(time.monotonic() - started_at, 3),
             }
             print(
@@ -1224,6 +1255,7 @@ async def _refresh_history_from_parent(
                 f"symbol={requested_symbol or '*'} "
                 f"orders={result['orders']} fills={result['fills']} "
                 f"positions={result['positions']} "
+                f"pnl_events={result['pnl_events']} "
                 f"elapsed={result['elapsed_seconds']:.1f}s",
                 flush=True,
             )
@@ -1326,6 +1358,22 @@ async def _import_history_from_parent(
         wallet_address = str(account.config.get("walletAddress") or "").strip()
         anchor = account_imports[0]
         try:
+            aliases = await asyncio.to_thread(fetch_hyperliquid_symbol_aliases)
+            canonicalize_hyperliquid_import_batch(batch, account_name, aliases)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            message = redact_error(exc, secret_values(account.config))
+            warning = (
+                "Hyperliquid symbol metadata could not be loaded: "
+                f"{message}"
+            )
+            for manifest in account_imports:
+                manifest["status"] = "partial"
+                manifest_warnings = manifest.setdefault("warnings", [])
+                if isinstance(manifest_warnings, list) and warning not in manifest_warnings:
+                    manifest_warnings.append(warning)
+        try:
             orders, warnings = await asyncio.to_thread(
                 fetch_hyperliquid_historical_orders,
                 wallet_address,
@@ -1407,7 +1455,18 @@ async def _retry_history_enrichment_from_parent(
         for warning in previous_warnings
         if not str(warning).startswith("Hyperliquid Order History could not be enriched:")
         and not str(warning).startswith("Hyperliquid returned 2,000 historical orders;")
+        and not str(warning).startswith("Hyperliquid symbol metadata could not be loaded:")
     ]
+    metadata_warnings: list[str] = []
+    try:
+        await asyncio.to_thread(fetch_hyperliquid_symbol_aliases)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        message = redact_error(exc, secret_values(account.config))
+        metadata_warnings.append(
+            f"Hyperliquid symbol metadata could not be loaded: {message}"
+        )
     try:
         orders, warnings = await asyncio.to_thread(
             fetch_hyperliquid_historical_orders,
@@ -1428,13 +1487,14 @@ async def _retry_history_enrichment_from_parent(
             orders,
             [],
         )
-        combined_warnings = [*retained_warnings, *warnings]
+        combined_warnings = [*retained_warnings, *metadata_warnings, *warnings]
+        status = "partial" if combined_warnings else "imported"
         await loop.run_in_executor(
             cache_executor,
             partial(
                 cache.update_csv_import_status,
                 import_id,
-                status="partial" if warnings else "imported",
+                status=status,
                 warnings=combined_warnings,
             ),
         )
@@ -1443,7 +1503,7 @@ async def _retry_history_enrichment_from_parent(
             "summary": {"orders": len(orders)},
             "imports": [{
                 "import_id": import_id,
-                "status": "partial" if warnings else "imported",
+                "status": status,
                 "warnings": combined_warnings,
             }],
         }
@@ -1452,7 +1512,7 @@ async def _retry_history_enrichment_from_parent(
     except Exception as exc:
         message = redact_error(exc, secret_values(account.config))
         warning = f"Hyperliquid Order History could not be enriched: {message}"
-        combined_warnings = [*retained_warnings, warning]
+        combined_warnings = [*retained_warnings, *metadata_warnings, warning]
         await loop.run_in_executor(
             cache_executor,
             partial(
@@ -1571,6 +1631,30 @@ async def _apply_parent_messages(
                 "payload": result,
             })
             continue
+        if message.get("type") == "history.import.delete":
+            request_id = str(message.get("request_id") or "")
+            try:
+                result = await asyncio.get_running_loop().run_in_executor(
+                    cache_executor,
+                    cache.delete_csv_import,
+                    str(message.get("import_id") or ""),
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                result = {
+                    "status": "error",
+                    "error": {
+                        "type": type(exc).__name__,
+                        "message": str(exc).replace("\n", " ")[:500],
+                    },
+                }
+            await _put_control_message(control_output_queue, {
+                "type": "history.import.delete.result",
+                "request_id": request_id,
+                "payload": result,
+            })
+            continue
         snapshot = message.get("snapshot")
         if not isinstance(snapshot, dict):
             continue
@@ -1678,8 +1762,8 @@ async def _run_positions_stream(
                 file=sys.stderr,
                 flush=True,
             )
-        orders, fills, positions, cursor_records = history.drain()
-        if orders or fills or positions or cursor_records:
+        orders, fills, positions, pnl_events, cursor_records = history.drain()
+        if orders or fills or positions or pnl_events or cursor_records:
             try:
                 await loop.run_in_executor(
                     cache_executor,
@@ -1688,6 +1772,7 @@ async def _run_positions_stream(
                     fills,
                     positions,
                     cursor_records,
+                    pnl_events,
                 )
             except Exception as exc:
                 print(

--- a/account_service/live_positions.py
+++ b/account_service/live_positions.py
@@ -5,6 +5,7 @@ import copy
 import math
 import queue
 import sys
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
@@ -33,10 +34,16 @@ from position import (  # noqa: E402
     normalize_position,
 )
 
+from account_service.cache import AccountCache  # noqa: E402
+from account_service.history import normalize_fill, normalize_order  # noqa: E402
 from account_service.positions import collect_positions_snapshot  # noqa: E402
+from data_service.schedule_utils import (  # noqa: E402
+    seconds_until_post_bar_task_window,
+)
 
 
 EMIT_INTERVAL_SECONDS = 0.25
+PERSIST_INTERVAL_SECONDS = 1.0
 RECONCILE_INTERVAL_SECONDS = 300.0
 
 
@@ -63,6 +70,7 @@ class LivePositionState:
     def __init__(self, snapshot: dict[str, Any]) -> None:
         self.snapshot = copy.deepcopy(snapshot)
         self.dirty = asyncio.Event()
+        self.persist_dirty = asyncio.Event()
         self.sequence = 0
 
     def replace(self, snapshot: dict[str, Any]) -> None:
@@ -72,6 +80,7 @@ class LivePositionState:
     def mark_dirty(self) -> None:
         self.sequence += 1
         self.dirty.set()
+        self.persist_dirty.set()
 
     def result(self, account_name: str) -> dict[str, Any] | None:
         for result in self.snapshot.get("results", []):
@@ -213,6 +222,122 @@ class LivePositionState:
         return payload
 
 
+class AccountHistoryBuffer:
+    def __init__(self) -> None:
+        self.dirty = asyncio.Event()
+        self._orders: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
+        self._fills: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
+
+    def add_orders(
+        self,
+        account: str,
+        exchange: str,
+        orders: list[dict[str, Any]],
+        market_scope: str,
+    ) -> None:
+        changed = False
+        for raw_order in orders:
+            if not isinstance(raw_order, dict):
+                continue
+            payload = normalize_order(raw_order)
+            key = (
+                account,
+                exchange,
+                market_scope,
+                str(payload.get("symbol") or ""),
+                str(payload.get("id") or ""),
+            )
+            previous = self._orders.get(key)
+            if previous is not None:
+                previous_timestamp = _number(
+                    previous["payload"].get("updated_timestamp")
+                )
+                timestamp = _number(payload.get("updated_timestamp"))
+                if (
+                    previous_timestamp is not None
+                    and timestamp is not None
+                    and timestamp < previous_timestamp
+                ):
+                    continue
+            self._orders[key] = {
+                "account": account,
+                "exchange": exchange,
+                "market_scope": market_scope,
+                "payload": payload,
+            }
+            changed = True
+        if changed:
+            self.dirty.set()
+
+    def add_fills(
+        self,
+        account: str,
+        exchange: str,
+        fills: list[dict[str, Any]],
+        market_scope: str,
+    ) -> None:
+        changed = False
+        for raw_fill in fills:
+            if not isinstance(raw_fill, dict):
+                continue
+            payload = normalize_fill(raw_fill)
+            key = (
+                account,
+                exchange,
+                market_scope,
+                str(payload.get("symbol") or ""),
+                str(payload.get("id") or ""),
+            )
+            self._fills[key] = {
+                "account": account,
+                "exchange": exchange,
+                "market_scope": market_scope,
+                "payload": payload,
+            }
+            changed = True
+        if changed:
+            self.dirty.set()
+
+    def drain(self) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        orders = list(self._orders.values())
+        fills = list(self._fills.values())
+        self._orders.clear()
+        self._fills.clear()
+        return orders, fills
+
+    def restore(
+        self,
+        orders: list[dict[str, Any]],
+        fills: list[dict[str, Any]],
+    ) -> None:
+        for record in orders:
+            payload = record.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("market_scope") or ""),
+                str(payload.get("symbol") or ""),
+                str(payload.get("id") or ""),
+            )
+            self._orders.setdefault(key, record)
+        for record in fills:
+            payload = record.get("payload")
+            if not isinstance(payload, dict):
+                continue
+            key = (
+                str(record.get("account") or ""),
+                str(record.get("exchange") or ""),
+                str(record.get("market_scope") or ""),
+                str(payload.get("symbol") or ""),
+                str(payload.get("id") or ""),
+            )
+            self._fills.setdefault(key, record)
+        if orders or fills:
+            self.dirty.set()
+
+
 def _calculate_unrealized_pnl(
     position: dict[str, Any],
     mark_price: float,
@@ -330,6 +455,148 @@ def _subscriptions(
             for dex, symbols in grouped_dexes.items()
         ]
     return [(None, {}, None, None)]
+
+
+def _history_subscriptions(account: ExchangeAccount) -> list[tuple[dict[str, Any], str]]:
+    if account.exchange_id == "binance":
+        return [
+            ({"type": "future", "subType": "linear"}, "usd_m"),
+            ({"type": "delivery", "subType": "inverse"}, "coin_m"),
+        ]
+    if account.exchange_id == "bitget":
+        options = account.config.get("options")
+        options = options if isinstance(options, dict) else {}
+        if bool(account.config.get("uta") or options.get("uta")):
+            return [({"uta": True}, "uta")]
+        return [
+            (
+                {
+                    "type": "swap",
+                    "subType": "linear",
+                    "productType": "USDT-FUTURES",
+                },
+                "USDT-FUTURES",
+            ),
+            (
+                {
+                    "type": "swap",
+                    "subType": "linear",
+                    "productType": "USDC-FUTURES",
+                },
+                "USDC-FUTURES",
+            ),
+            (
+                {
+                    "type": "swap",
+                    "subType": "inverse",
+                    "productType": "COIN-FUTURES",
+                },
+                "COIN-FUTURES",
+            ),
+        ]
+    return [({}, "")]
+
+
+async def _watch_private_orders(
+    exchange: Any,
+    account: ExchangeAccount,
+    history: AccountHistoryBuffer,
+    params: dict[str, Any],
+    market_scope: str,
+    stop: asyncio.Event,
+) -> None:
+    delay = 1.0
+    secrets = secret_values(account.config)
+    while not stop.is_set():
+        try:
+            orders = await exchange.watch_orders(None, params=params)
+            if isinstance(orders, list):
+                history.add_orders(
+                    account.name,
+                    account.exchange_id,
+                    orders,
+                    market_scope,
+                )
+            delay = 1.0
+        except asyncio.CancelledError:
+            raise
+        except (
+            ccxt.ArgumentsRequired,
+            ccxt.AuthenticationError,
+            ccxt.BadRequest,
+            ccxt.NotSupported,
+            ccxt.PermissionDenied,
+        ) as exc:
+            print(
+                f"[account] {account.name} order stream unavailable: "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return
+        except Exception as exc:
+            print(
+                f"[account] {account.name} order stream error: "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+                file=sys.stderr,
+                flush=True,
+            )
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=delay)
+            except TimeoutError:
+                pass
+            delay = min(delay * 2, 30.0)
+
+
+async def _watch_private_fills(
+    exchange: Any,
+    account: ExchangeAccount,
+    history: AccountHistoryBuffer,
+    params: dict[str, Any],
+    market_scope: str,
+    stop: asyncio.Event,
+) -> None:
+    delay = 1.0
+    secrets = secret_values(account.config)
+    while not stop.is_set():
+        try:
+            fills = await exchange.watch_my_trades(None, params=params)
+            if isinstance(fills, list):
+                history.add_fills(
+                    account.name,
+                    account.exchange_id,
+                    fills,
+                    market_scope,
+                )
+            delay = 1.0
+        except asyncio.CancelledError:
+            raise
+        except (
+            ccxt.ArgumentsRequired,
+            ccxt.AuthenticationError,
+            ccxt.BadRequest,
+            ccxt.NotSupported,
+            ccxt.PermissionDenied,
+        ) as exc:
+            print(
+                f"[account] {account.name} fill stream unavailable: "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+                file=sys.stderr,
+                flush=True,
+            )
+            return
+        except Exception as exc:
+            print(
+                f"[account] {account.name} fill stream error: "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}",
+                file=sys.stderr,
+                flush=True,
+            )
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=delay)
+            except TimeoutError:
+                pass
+            delay = min(delay * 2, 30.0)
 
 
 async def _watch_private_positions(
@@ -459,6 +726,7 @@ async def _ticker_supervisor(
 async def _watch_account(
     account: ExchangeAccount,
     state: LivePositionState,
+    history: AccountHistoryBuffer,
     stop: asyncio.Event,
 ) -> None:
     exchange = None
@@ -488,6 +756,30 @@ async def _watch_account(
                 )
             )
         tasks.append(asyncio.create_task(_ticker_supervisor(exchange, account, state, stop)))
+        if exchange.has.get("watchOrders"):
+            for params, market_scope in _history_subscriptions(account):
+                tasks.append(asyncio.create_task(
+                    _watch_private_orders(
+                        exchange,
+                        account,
+                        history,
+                        params,
+                        market_scope,
+                        stop,
+                    )
+                ))
+        if exchange.has.get("watchMyTrades"):
+            for params, market_scope in _history_subscriptions(account):
+                tasks.append(asyncio.create_task(
+                    _watch_private_fills(
+                        exchange,
+                        account,
+                        history,
+                        params,
+                        market_scope,
+                        stop,
+                    )
+                ))
         await stop.wait()
     except asyncio.CancelledError:
         raise
@@ -533,6 +825,67 @@ async def _emit_updates(state: LivePositionState, output_queue: Any, stop: async
                 pass
 
 
+async def _persist_updates(
+    state: LivePositionState,
+    cache: AccountCache,
+    executor: ThreadPoolExecutor,
+    stop: asyncio.Event,
+) -> None:
+    loop = asyncio.get_running_loop()
+    while not stop.is_set():
+        await state.persist_dirty.wait()
+        state.persist_dirty.clear()
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=PERSIST_INTERVAL_SECONDS)
+            break
+        except TimeoutError:
+            pass
+        try:
+            await loop.run_in_executor(
+                executor,
+                cache.apply_positions_snapshot,
+                state.payload(),
+            )
+        except Exception as exc:
+            print(
+                f"[account] position cache write failed: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+
+async def _persist_history_updates(
+    history: AccountHistoryBuffer,
+    cache: AccountCache,
+    executor: ThreadPoolExecutor,
+    stop: asyncio.Event,
+) -> None:
+    loop = asyncio.get_running_loop()
+    while not stop.is_set():
+        await history.dirty.wait()
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=PERSIST_INTERVAL_SECONDS)
+            break
+        except TimeoutError:
+            pass
+        history.dirty.clear()
+        orders, fills = history.drain()
+        try:
+            await loop.run_in_executor(
+                executor,
+                cache.apply_history_batch,
+                orders,
+                fills,
+            )
+        except Exception as exc:
+            history.restore(orders, fills)
+            print(
+                f"[account] history cache write failed: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+
+
 async def _reconcile(
     config_path: str,
     state: LivePositionState,
@@ -544,6 +897,13 @@ async def _reconcile(
             break
         except TimeoutError:
             pass
+        post_bar_delay = seconds_until_post_bar_task_window()
+        if post_bar_delay > 0.0:
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=post_bar_delay)
+                break
+            except TimeoutError:
+                pass
         try:
             snapshot = await asyncio.to_thread(collect_positions_snapshot, config_path)
             state.replace(snapshot)
@@ -557,6 +917,7 @@ async def _reconcile(
 
 async def _run_positions_stream(
     config_path: str,
+    cache_path: str,
     output_queue: Any,
     stop_event: Any,
     initial_snapshot: dict[str, Any] | None,
@@ -567,6 +928,12 @@ async def _run_positions_stream(
     )
     state = LivePositionState(snapshot)
     state.mark_dirty()
+    history = AccountHistoryBuffer()
+    cache = AccountCache(Path(cache_path))
+    cache_executor = ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="account-cache-writer",
+    )
     data = read_provider_config(Path(config_path))
     accounts = configured_accounts(data)
     stop = asyncio.Event()
@@ -576,12 +943,16 @@ async def _run_positions_stream(
         stop.set()
 
     tasks = [
-        asyncio.create_task(_watch_account(account, state, stop))
+        asyncio.create_task(_watch_account(account, state, history, stop))
         for account in accounts
     ]
     tasks.extend(
         [
             asyncio.create_task(_emit_updates(state, output_queue, stop)),
+            asyncio.create_task(_persist_updates(state, cache, cache_executor, stop)),
+            asyncio.create_task(
+                _persist_history_updates(history, cache, cache_executor, stop)
+            ),
             asyncio.create_task(_reconcile(config_path, state, stop)),
             asyncio.create_task(watch_parent_stop()),
         ]
@@ -593,10 +964,42 @@ async def _run_positions_stream(
         for task in tasks:
             task.cancel()
         await asyncio.gather(*tasks, return_exceptions=True)
+        loop = asyncio.get_running_loop()
+        try:
+            await loop.run_in_executor(
+                cache_executor,
+                cache.apply_positions_snapshot,
+                state.payload(),
+            )
+        except Exception as exc:
+            print(
+                f"[account] final position cache write failed: {type(exc).__name__}: {exc}",
+                file=sys.stderr,
+                flush=True,
+            )
+        orders, fills = history.drain()
+        if orders or fills:
+            try:
+                await loop.run_in_executor(
+                    cache_executor,
+                    cache.apply_history_batch,
+                    orders,
+                    fills,
+                )
+            except Exception as exc:
+                print(
+                    f"[account] final history cache write failed: "
+                    f"{type(exc).__name__}: {exc}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+        await loop.run_in_executor(cache_executor, cache.close)
+        cache_executor.shutdown(wait=True, cancel_futures=True)
 
 
 def run_positions_stream(
     config_path: str,
+    cache_path: str,
     output_queue: Any,
     stop_event: Any,
     initial_snapshot: dict[str, Any] | None = None,
@@ -605,6 +1008,7 @@ def run_positions_stream(
         asyncio.run(
             _run_positions_stream(
                 config_path,
+                cache_path,
                 output_queue,
                 stop_event,
                 initial_snapshot,
@@ -614,7 +1018,7 @@ def run_positions_stream(
         pass
     except Exception as exc:
         print(
-            f"[account] live position process stopped: {type(exc).__name__}",
+            f"[account] live account process stopped: {type(exc).__name__}",
             file=sys.stderr,
             flush=True,
         )

--- a/account_service/positions.py
+++ b/account_service/positions.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+_AI_SCRIPTS = _PROJECT_ROOT / "ai" / "scripts"
+if str(_AI_SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(_AI_SCRIPTS))
+
+from asset import configured_accounts, read_provider_config, utc_now  # noqa: E402
+from position import collect_one  # noqa: E402
+
+
+SCHEMA_VERSION = "1.0"
+
+
+def collect_positions_snapshot(config_path: str) -> dict[str, Any]:
+    """Collect every configured account without exposing credentials to the parent."""
+
+    data = read_provider_config(Path(config_path))
+    accounts = configured_accounts(data)
+    if not accounts:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "collected_at": utc_now(),
+            "source": "exchange.positions",
+            "read_only": True,
+            "results": [],
+            "summary": {
+                "accounts": 0,
+                "succeeded": 0,
+                "failed": 0,
+                "open_positions": 0,
+            },
+        }
+
+    args = argparse.Namespace(
+        timeout_ms=30_000,
+        attempts=2,
+        symbols=[],
+        dex=None,
+        include_closed=False,
+        all_derivative_scopes=True,
+    )
+    worker_count = min(4, len(accounts))
+    with ThreadPoolExecutor(
+        max_workers=worker_count,
+        thread_name_prefix="account-position",
+    ) as executor:
+        futures = [
+            executor.submit(
+                collect_one,
+                account.name,
+                account.exchange_id,
+                "swap",
+                account.config,
+                args,
+                log_progress=False,
+            )
+            for account in accounts
+        ]
+        results = [future.result() for future in futures]
+
+    succeeded = sum(result.get("status") == "ok" for result in results)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "collected_at": utc_now(),
+        "source": "exchange.positions",
+        "read_only": True,
+        "results": results,
+        "summary": {
+            "accounts": len(accounts),
+            "succeeded": succeeded,
+            "failed": len(results) - succeeded,
+            "open_positions": sum(
+                int(result.get("position_count") or 0)
+                for result in results
+            ),
+        },
+    }

--- a/account_service/positions.py
+++ b/account_service/positions.py
@@ -47,14 +47,14 @@ def collect_positions_snapshot(config_path: str) -> dict[str, Any]:
         include_closed=False,
         all_derivative_scopes=True,
     )
-    worker_count = min(4, len(accounts))
-    with ThreadPoolExecutor(
-        max_workers=worker_count,
-        thread_name_prefix="account-position",
-    ) as executor:
-        futures = [
-            executor.submit(
-                collect_one,
+    bitget_accounts = [account for account in accounts if account.exchange_id == "bitget"]
+    account_groups = ([bitget_accounts] if bitget_accounts else []) + [
+        [account] for account in accounts if account.exchange_id != "bitget"
+    ]
+
+    def collect_group(group: list[Any]) -> list[dict[str, Any]]:
+        return [
+            collect_one(
                 account.name,
                 account.exchange_id,
                 "swap",
@@ -62,9 +62,19 @@ def collect_positions_snapshot(config_path: str) -> dict[str, Any]:
                 args,
                 log_progress=False,
             )
-            for account in accounts
+            for account in group
         ]
-        results = [future.result() for future in futures]
+
+    with ThreadPoolExecutor(
+        max_workers=min(4, len(account_groups)),
+        thread_name_prefix="account-position",
+    ) as executor:
+        results_by_account = {
+            result["account"]: result
+            for group_results in executor.map(collect_group, account_groups)
+            for result in group_results
+        }
+        results = [results_by_account[account.name] for account in accounts]
 
     succeeded = sum(result.get("status") == "ok" for result in results)
     return {

--- a/ai/scripts/position.py
+++ b/ai/scripts/position.py
@@ -8,6 +8,7 @@ import json
 import ssl
 import sys
 import time
+from decimal import Decimal, InvalidOperation
 from pathlib import Path
 from typing import Any
 
@@ -28,7 +29,7 @@ from asset import (
 )
 
 
-SCHEMA_VERSION = "1.4"
+SCHEMA_VERSION = "1.5"
 DEFAULT_ACCOUNT_TYPE = "swap"
 
 BINANCE_ALL_POSITION_SCOPES = (
@@ -46,6 +47,8 @@ BITGET_ALL_POSITION_SCOPES = (
     "USDC-FUTURES",
     "COIN-FUTURES",
 )
+BYBIT_TRANSACTION_MAX_RANGE_MS = 7 * 24 * 60 * 60 * 1000
+BYBIT_BREAKDOWN_MAX_AGE_MS = 31 * 24 * 60 * 60 * 1000
 
 
 def normalized_side(position: dict[str, Any], contracts: int | float | None) -> str | None:
@@ -57,12 +60,424 @@ def normalized_side(position: dict[str, Any], contracts: int | float | None) -> 
     return None
 
 
+def _sum_present_numbers(source: dict[str, Any], keys: tuple[str, ...]) -> float | None:
+    values = [number_or_none(source.get(key)) for key in keys]
+    present = [value for value in values if value is not None]
+    return sum(present) if present else None
+
+
+def _decimal_or_none(value: Any) -> Decimal | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        result = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return result if result.is_finite() else None
+
+
+def _integer_or_none(value: Any) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _pnl_breakdown(
+    gross_pnl: Decimal,
+    fee_cost: Decimal,
+    net_pnl: Decimal,
+    *,
+    currency: str | None,
+) -> dict[str, Any]:
+    return {
+        "gross_pnl": float(gross_pnl),
+        "fees": float(fee_cost),
+        "net_pnl": float(net_pnl),
+        "currency": currency,
+        "complete": True,
+    }
+
+
+def normalize_realized_pnl(position: dict[str, Any]) -> tuple[float | None, dict[str, Any] | None]:
+    """Normalize the current position's realized PnL without estimating missing data."""
+
+    info = position.get("info")
+    info = info if isinstance(info, dict) else {}
+    ccxt_net = number_or_none(position.get("realizedPnl"))
+    gross_pnl: float | None = None
+    fee_cost: float | None = None
+    net_pnl = ccxt_net
+    complete = False
+
+    # OKX: realizedPnl = pnl + settledPnl + fee + fundingFee + liqPenalty.
+    if "instId" in info and "realizedPnl" in info:
+        net_pnl = number_or_none(info.get("realizedPnl"))
+        gross_pnl = _sum_present_numbers(info, ("pnl", "settledPnl"))
+        if net_pnl is not None and gross_pnl is not None:
+            fee_cost = gross_pnl - net_pnl
+            complete = True
+
+    # Bitget classic: achievedProfits excludes transaction and funding fees.
+    elif "achievedProfits" in info:
+        gross_pnl = _sum_present_numbers(info, ("achievedProfits", "cashDividend"))
+        funding_adjustment = number_or_none(info.get("totalFee")) or 0.0
+        deducted_fee = number_or_none(info.get("deductedFee")) or 0.0
+        if gross_pnl is not None:
+            fee_cost = deducted_fee - funding_adjustment
+            net_pnl = gross_pnl - fee_cost
+            complete = True
+
+    # Bitget UTA exposes signed fee/funding components alongside current net PnL.
+    elif "curRealisedPnl" in info and any(
+        key in info for key in ("openFeeTotal", "closeFeeTotal", "totalFunding")
+    ):
+        net_pnl = number_or_none(info.get("curRealisedPnl"))
+        signed_adjustment = _sum_present_numbers(
+            info,
+            ("openFeeTotal", "closeFeeTotal", "totalFunding"),
+        )
+        if net_pnl is not None and signed_adjustment is not None:
+            fee_cost = -signed_adjustment
+            gross_pnl = net_pnl + fee_cost
+            complete = True
+
+    # Bybit's curRealisedPnl is already net of trading and funding fees for
+    # the current holding position. A separate transaction-log lookup adds
+    # the fee breakdown when available.
+    elif "curRealisedPnl" in info:
+        net_pnl = number_or_none(info.get("curRealisedPnl"))
+
+    if net_pnl is None:
+        return None, None
+    return net_pnl, {
+        "gross_pnl": gross_pnl,
+        "fees": fee_cost,
+        "net_pnl": net_pnl,
+        "complete": complete,
+    }
+
+
+def _private_call_with_retry(
+    exchange: ccxt.Exchange,
+    call: Any,
+    params: dict[str, Any],
+    attempts: int,
+    secrets: list[str],
+    label: str,
+) -> Any:
+    for attempt in range(1, attempts + 1):
+        try:
+            return call(params)
+        except (
+            ccxt.ArgumentsRequired,
+            ccxt.AuthenticationError,
+            ccxt.BadRequest,
+            ccxt.NotSupported,
+            ccxt.PermissionDenied,
+        ):
+            raise
+        except ccxt.BaseError as exc:
+            if attempt >= attempts:
+                raise
+            delay = min(2 ** (attempt - 1), 4)
+            eprint(
+                f"[position] {exchange.id} {label} failed ({attempt}/{attempts}): "
+                f"{type(exc).__name__}: {redact_error(exc, secrets)}; "
+                f"retrying in {delay}s"
+            )
+            time.sleep(delay)
+    raise RuntimeError(f"{label} retry loop ended unexpectedly")
+
+
+def _binance_position_cycle(
+    trades: list[dict[str, Any]],
+    position: dict[str, Any],
+    normalized: dict[str, Any],
+) -> tuple[int, list[dict[str, Any]]] | None:
+    info = position.get("info")
+    info = info if isinstance(info, dict) else {}
+    position_side = str(info.get("positionSide") or "BOTH").upper()
+    side = str(normalized.get("side") or "").lower()
+    contracts = _decimal_or_none(normalized.get("contracts"))
+    if side not in {"long", "short"} or contracts in {None, Decimal(0)}:
+        return None
+
+    current = abs(contracts) if side == "long" else -abs(contracts)
+    relevant: list[tuple[int, int, str, Decimal, dict[str, Any]]] = []
+    for trade in trades:
+        if not isinstance(trade, dict):
+            continue
+        trade_position_side = str(trade.get("positionSide") or "BOTH").upper()
+        if trade_position_side != position_side:
+            continue
+        timestamp = _integer_or_none(trade.get("time"))
+        quantity = _decimal_or_none(trade.get("qty"))
+        trade_side = str(trade.get("side") or "").upper()
+        if timestamp is None or quantity in {None, Decimal(0)}:
+            continue
+        if trade_side not in {"BUY", "SELL"}:
+            continue
+        trade_id = _integer_or_none(trade.get("id")) or 0
+        relevant.append((timestamp, trade_id, trade_side, quantity, trade))
+
+    tolerance = max(abs(current) * Decimal("1e-12"), Decimal("1e-12"))
+    cycle: list[dict[str, Any]] = []
+    for timestamp, _, trade_side, quantity, trade in sorted(relevant, reverse=True):
+        cycle.append(trade)
+        delta = quantity if trade_side == "BUY" else -quantity
+        before = current - delta
+        if abs(before) <= tolerance:
+            cycle.reverse()
+            return timestamp, cycle
+        # A single fill that flips direction contains PnL from two position
+        # lifecycles and cannot be split reliably from Income History.
+        if before * current < 0:
+            return None
+        current = before
+    return None
+
+
+def _binance_position_start_time(
+    trades: list[dict[str, Any]],
+    position: dict[str, Any],
+    normalized: dict[str, Any],
+) -> int | None:
+    cycle = _binance_position_cycle(trades, position, normalized)
+    return cycle[0] if cycle is not None else None
+
+
+def enrich_binance_realized_pnl(
+    exchange: ccxt.Exchange,
+    position: dict[str, Any],
+    normalized: dict[str, Any],
+    market_scope: str,
+    attempts: int,
+    secrets: list[str],
+) -> None:
+    if not is_open_position(normalized):
+        return
+    info = position.get("info")
+    info = info if isinstance(info, dict) else {}
+    raw_symbol = str(info.get("symbol") or "").upper()
+    if not raw_symbol:
+        return
+    if market_scope == "coin_m":
+        trades_call = exchange.dapiPrivateGetUserTrades
+        income_call = exchange.dapiPrivateGetIncome
+    else:
+        trades_call = exchange.fapiPrivateGetUserTrades
+        income_call = exchange.fapiPrivateGetIncome
+
+    trades = _private_call_with_retry(
+        exchange,
+        trades_call,
+        {"symbol": raw_symbol, "limit": 1000},
+        attempts,
+        secrets,
+        f"{market_scope} user trades",
+    )
+    if not isinstance(trades, list):
+        return
+    cycle = _binance_position_cycle(trades, position, normalized)
+    if cycle is None:
+        return
+    start_time, cycle_trades = cycle
+
+    # Trade rows provide exact cycle-specific realized PnL and commissions.
+    # Income History is needed only for funding, which is not a trade event.
+    gross_pnl = Decimal(0)
+    trading_fees = Decimal(0)
+    assets: set[str] = set()
+    for trade in cycle_trades:
+        gross_pnl += _decimal_or_none(trade.get("realizedPnl")) or Decimal(0)
+        trading_fees += _decimal_or_none(trade.get("commission")) or Decimal(0)
+        commission_asset = str(trade.get("commissionAsset") or "").upper()
+        if commission_asset:
+            assets.add(commission_asset)
+
+    unified_symbol = str(normalized.get("symbol") or "")
+    if ":" in unified_symbol:
+        settlement = unified_symbol.rsplit(":", 1)[1].split("-", 1)[0].upper()
+        if settlement:
+            assets.add(settlement)
+
+    # Binance Income timestamps are rounded to the second while trade times
+    # include milliseconds, so include the whole opening second.
+    income_start = start_time // 1000 * 1000
+    incomes = _private_call_with_retry(
+        exchange,
+        income_call,
+        {
+            "symbol": raw_symbol,
+            "incomeType": "FUNDING_FEE",
+            "startTime": income_start,
+            "limit": 1000,
+        },
+        attempts,
+        secrets,
+        f"{market_scope} income history",
+    )
+    if not isinstance(incomes, list) or len(incomes) >= 1000:
+        return
+
+    funding = Decimal(0)
+    for income in incomes:
+        if not isinstance(income, dict):
+            continue
+        value = _decimal_or_none(income.get("income"))
+        timestamp = _integer_or_none(income.get("time"))
+        if (
+            str(income.get("incomeType") or "").upper() != "FUNDING_FEE"
+            or value is None
+            or timestamp is None
+            or timestamp < income_start
+        ):
+            continue
+        funding += value
+        asset = str(income.get("asset") or "").upper()
+        if asset:
+            assets.add(asset)
+    if len(assets) > 1:
+        return
+
+    fee_cost = trading_fees - funding
+    net_pnl = gross_pnl - fee_cost
+    normalized["realized_pnl"] = float(net_pnl)
+    normalized["realized_pnl_breakdown"] = _pnl_breakdown(
+        gross_pnl,
+        fee_cost,
+        net_pnl,
+        currency=next(iter(assets), None),
+    )
+
+
+def _bybit_transaction_pages(
+    exchange: ccxt.Exchange,
+    category: str,
+    start_time: int,
+    end_time: int,
+    attempts: int,
+    secrets: list[str],
+) -> list[dict[str, Any]] | None:
+    rows: list[dict[str, Any]] = []
+    window_start = start_time
+    while window_start <= end_time:
+        window_end = min(window_start + BYBIT_TRANSACTION_MAX_RANGE_MS - 1, end_time)
+        cursor = ""
+        while True:
+            params: dict[str, Any] = {
+                "accountType": "UNIFIED",
+                "category": category,
+                "startTime": window_start,
+                "endTime": window_end,
+                "limit": 50,
+            }
+            if cursor:
+                params["cursor"] = cursor
+            response = _private_call_with_retry(
+                exchange,
+                exchange.privateGetV5AccountTransactionLog,
+                params,
+                attempts,
+                secrets,
+                "transaction log",
+            )
+            result = response.get("result") if isinstance(response, dict) else None
+            if not isinstance(result, dict):
+                return None
+            page = result.get("list")
+            if not isinstance(page, list):
+                return None
+            rows.extend(item for item in page if isinstance(item, dict))
+            next_cursor = str(result.get("nextPageCursor") or "")
+            if not next_cursor or next_cursor == cursor:
+                break
+            cursor = next_cursor
+        window_start = window_end + 1
+    return rows
+
+
+def enrich_bybit_realized_pnl(
+    exchange: ccxt.Exchange,
+    position: dict[str, Any],
+    normalized: dict[str, Any],
+    attempts: int,
+    secrets: list[str],
+) -> None:
+    net_value = _decimal_or_none(normalized.get("realized_pnl"))
+    if net_value is None or not is_open_position(normalized):
+        return
+    info = position.get("info")
+    info = info if isinstance(info, dict) else {}
+    raw_symbol = str(info.get("symbol") or "").upper()
+    category = str(info.get("category") or "linear").lower()
+    start_time = _integer_or_none(info.get("openTime"))
+    if start_time is None or start_time <= 0:
+        start_time = _integer_or_none(position.get("timestamp"))
+    end_time = exchange.milliseconds()
+    if (
+        not raw_symbol
+        or category not in {"linear", "inverse", "option"}
+        or start_time is None
+        or start_time <= 0
+        or end_time - start_time > BYBIT_BREAKDOWN_MAX_AGE_MS
+    ):
+        return
+
+    try:
+        transactions = _bybit_transaction_pages(
+            exchange,
+            category,
+            start_time,
+            end_time,
+            attempts,
+            secrets,
+        )
+    except (ccxt.NotSupported, ccxt.PermissionDenied, ccxt.BadRequest):
+        return
+    if transactions is None:
+        return
+
+    gross_pnl = Decimal(0)
+    trading_fees = Decimal(0)
+    funding = Decimal(0)
+    currencies: set[str] = set()
+    for transaction in transactions:
+        if str(transaction.get("symbol") or "").upper() != raw_symbol:
+            continue
+        cash_flow = _decimal_or_none(transaction.get("cashFlow")) or Decimal(0)
+        fee = _decimal_or_none(transaction.get("fee")) or Decimal(0)
+        funding_value = _decimal_or_none(transaction.get("funding")) or Decimal(0)
+        gross_pnl += cash_flow
+        trading_fees += fee
+        funding += funding_value
+        currency = str(transaction.get("currency") or "").upper()
+        if currency:
+            currencies.add(currency)
+
+    calculated_net = gross_pnl + funding - trading_fees
+    tolerance = max(abs(net_value) * Decimal("1e-8"), Decimal("1e-8"))
+    if len(currencies) > 1 or abs(calculated_net - net_value) > tolerance:
+        return
+    fee_cost = trading_fees - funding
+    normalized["realized_pnl_breakdown"] = _pnl_breakdown(
+        gross_pnl,
+        fee_cost,
+        net_value,
+        currency=next(iter(currencies), None),
+    )
+
+
 def normalize_position(position: dict[str, Any]) -> dict[str, Any]:
     contracts = number_or_none(position.get("contracts"))
     contract_size = number_or_none(position.get("contractSize"))
     quantity = contracts
     if contracts is not None and contract_size is not None:
         quantity = contracts * contract_size
+    realized_pnl, realized_pnl_breakdown = normalize_realized_pnl(position)
     return {
         "symbol": str(position.get("symbol") or ""),
         "side": normalized_side(position, contracts),
@@ -81,7 +496,8 @@ def normalize_position(position: dict[str, Any]) -> dict[str, Any]:
         "margin_mode": position.get("marginMode"),
         "hedged": position.get("hedged") if isinstance(position.get("hedged"), bool) else None,
         "unrealized_pnl": number_or_none(position.get("unrealizedPnl")),
-        "realized_pnl": number_or_none(position.get("realizedPnl")),
+        "realized_pnl": realized_pnl,
+        "realized_pnl_breakdown": realized_pnl_breakdown,
         "percentage": number_or_none(position.get("percentage")),
         "stop_loss_price": number_or_none(position.get("stopLossPrice")),
         "take_profit_price": number_or_none(position.get("takeProfitPrice")),
@@ -167,6 +583,28 @@ def binance_position_scopes(
             {"type": account_type, "subType": "linear", "useV2": True},
         )
     ]
+
+
+def binance_position_matches_scope(
+    position: dict[str, Any],
+    market_scope: str,
+) -> bool:
+    """Validate a Binance derivative scope from its CCXT unified symbol."""
+
+    symbol = str(position.get("symbol") or "")
+    if ":" not in symbol or "/" not in symbol:
+        return True
+    market_pair, settlement = symbol.rsplit(":", 1)
+    base, quote = market_pair.split("/", 1)
+    settlement = settlement.split("-", 1)[0]
+    base = base.upper()
+    quote = quote.upper()
+    settlement = settlement.upper()
+    if market_scope == "usd_m":
+        return settlement == quote
+    if market_scope == "coin_m":
+        return settlement == base
+    return True
 
 
 def bitget_position_scopes(
@@ -438,13 +876,16 @@ def collect_one(
     account_type: str,
     config: dict[str, Any],
     args: argparse.Namespace,
+    *,
+    log_progress: bool = True,
 ) -> dict[str, Any]:
     secrets = secret_values(config)
     exchange: ccxt.Exchange | None = None
-    eprint(
-        f"[position] collecting account={account_name} exchange={exchange_id} "
-        f"account_type={account_type}"
-    )
+    if log_progress:
+        eprint(
+            f"[position] collecting account={account_name} exchange={exchange_id} "
+            f"account_type={account_type}"
+        )
     try:
         exchange = build_exchange(exchange_id, config, args.timeout_ms, account_type)
         if not exchange.has.get("fetchPositions"):
@@ -476,7 +917,22 @@ def collect_one(
                 for position in positions:
                     item = normalize_position(position)
                     item["market_scope"] = scope
-                    normalized.append(item)
+                    if binance_position_matches_scope(item, scope):
+                        try:
+                            enrich_binance_realized_pnl(
+                                exchange,
+                                position,
+                                item,
+                                scope,
+                                args.attempts,
+                                secrets,
+                            )
+                        except Exception as exc:
+                            eprint(
+                                f"[position] binance {scope} realized PnL unavailable: "
+                                f"{type(exc).__name__}: {redact_error(exc, secrets)}"
+                            )
+                        normalized.append(item)
             source = "ccxt.fetch_positions"
         elif exchange_id == "bitget":
             normalized = []
@@ -509,7 +965,24 @@ def collect_one(
                 args.attempts,
                 secrets,
             )
-            normalized = [normalize_position(position) for position in positions]
+            normalized = []
+            for position in positions:
+                item = normalize_position(position)
+                if exchange_id == "bybit":
+                    try:
+                        enrich_bybit_realized_pnl(
+                            exchange,
+                            position,
+                            item,
+                            args.attempts,
+                            secrets,
+                        )
+                    except Exception as exc:
+                        eprint(
+                            f"[position] bybit realized PnL breakdown unavailable: "
+                            f"{type(exc).__name__}: {redact_error(exc, secrets)}"
+                        )
+                normalized.append(item)
             queried_dexes = []
             queried_scopes = [account_type]
             source = "ccxt.fetch_positions"

--- a/ai/scripts/position.py
+++ b/ai/scripts/position.py
@@ -635,6 +635,7 @@ def bitget_position_scopes(
 
 def fetch_bitget_positions_with_retry(
     exchange: ccxt.Exchange,
+    account_name: str,
     product_type: str,
     symbols: list[str] | None,
     attempts: int,
@@ -675,7 +676,7 @@ def fetch_bitget_positions_with_retry(
                 raise
             delay = min(2 ** (attempt - 1), 4)
             eprint(
-                f"[position] bitget {product_type} fetch failed "
+                f"[position] {account_name}/bitget {product_type} fetch failed "
                 f"({attempt}/{attempts}): {type(exc).__name__}: "
                 f"{redact_error(exc, secrets)}; retrying in {delay}s"
             )
@@ -945,6 +946,7 @@ def collect_one(
             for product_type in product_types:
                 positions = fetch_bitget_positions_with_retry(
                     exchange,
+                    account_name,
                     product_type,
                     args.symbols or None,
                     args.attempts,

--- a/ai/scripts/position.py
+++ b/ai/scripts/position.py
@@ -90,11 +90,15 @@ def _pnl_breakdown(
     fee_cost: Decimal,
     net_pnl: Decimal,
     *,
+    funding: Decimal,
+    funding_source: str,
     currency: str | None,
 ) -> dict[str, Any]:
     return {
         "gross_pnl": float(gross_pnl),
         "fees": float(fee_cost),
+        "funding": float(funding),
+        "funding_source": funding_source,
         "net_pnl": float(net_pnl),
         "currency": currency,
         "complete": True,
@@ -109,6 +113,8 @@ def normalize_realized_pnl(position: dict[str, Any]) -> tuple[float | None, dict
     ccxt_net = number_or_none(position.get("realizedPnl"))
     gross_pnl: float | None = None
     fee_cost: float | None = None
+    funding: float | None = None
+    funding_source: str | None = None
     net_pnl = ccxt_net
     complete = False
 
@@ -116,18 +122,20 @@ def normalize_realized_pnl(position: dict[str, Any]) -> tuple[float | None, dict
     if "instId" in info and "realizedPnl" in info:
         net_pnl = number_or_none(info.get("realizedPnl"))
         gross_pnl = _sum_present_numbers(info, ("pnl", "settledPnl"))
+        funding = number_or_none(info.get("fundingFee"))
         if net_pnl is not None and gross_pnl is not None:
-            fee_cost = gross_pnl - net_pnl
+            fee_cost = gross_pnl + (funding or 0.0) - net_pnl
+            funding_source = "position" if funding is not None else None
             complete = True
 
     # Bitget classic: achievedProfits excludes transaction and funding fees.
     elif "achievedProfits" in info:
         gross_pnl = _sum_present_numbers(info, ("achievedProfits", "cashDividend"))
-        funding_adjustment = number_or_none(info.get("totalFee")) or 0.0
-        deducted_fee = number_or_none(info.get("deductedFee")) or 0.0
+        funding = number_or_none(info.get("totalFee")) or 0.0
+        fee_cost = number_or_none(info.get("deductedFee")) or 0.0
         if gross_pnl is not None:
-            fee_cost = deducted_fee - funding_adjustment
-            net_pnl = gross_pnl - fee_cost
+            net_pnl = gross_pnl + funding - fee_cost
+            funding_source = "position"
             complete = True
 
     # Bitget UTA exposes signed fee/funding components alongside current net PnL.
@@ -135,13 +143,15 @@ def normalize_realized_pnl(position: dict[str, Any]) -> tuple[float | None, dict
         key in info for key in ("openFeeTotal", "closeFeeTotal", "totalFunding")
     ):
         net_pnl = number_or_none(info.get("curRealisedPnl"))
-        signed_adjustment = _sum_present_numbers(
+        signed_trading_fees = _sum_present_numbers(
             info,
-            ("openFeeTotal", "closeFeeTotal", "totalFunding"),
+            ("openFeeTotal", "closeFeeTotal"),
         )
-        if net_pnl is not None and signed_adjustment is not None:
-            fee_cost = -signed_adjustment
-            gross_pnl = net_pnl + fee_cost
+        funding = number_or_none(info.get("totalFunding")) or 0.0
+        if net_pnl is not None and signed_trading_fees is not None:
+            fee_cost = -signed_trading_fees
+            gross_pnl = net_pnl + fee_cost - funding
+            funding_source = "position"
             complete = True
 
     # Bybit's curRealisedPnl is already net of trading and funding fees for
@@ -155,6 +165,8 @@ def normalize_realized_pnl(position: dict[str, Any]) -> tuple[float | None, dict
     return net_pnl, {
         "gross_pnl": gross_pnl,
         "fees": fee_cost,
+        "funding": funding,
+        "funding_source": funding_source,
         "net_pnl": net_pnl,
         "complete": complete,
     }
@@ -348,8 +360,10 @@ def enrich_binance_realized_pnl(
     normalized["realized_pnl"] = float(net_pnl)
     normalized["realized_pnl_breakdown"] = _pnl_breakdown(
         gross_pnl,
-        fee_cost,
+        trading_fees,
         net_pnl,
+        funding=funding,
+        funding_source="income",
         currency=next(iter(assets), None),
     )
 
@@ -462,11 +476,12 @@ def enrich_bybit_realized_pnl(
     tolerance = max(abs(net_value) * Decimal("1e-8"), Decimal("1e-8"))
     if len(currencies) > 1 or abs(calculated_net - net_value) > tolerance:
         return
-    fee_cost = trading_fees - funding
     normalized["realized_pnl_breakdown"] = _pnl_breakdown(
         gross_pnl,
-        fee_cost,
+        trading_fees,
         net_value,
+        funding=funding,
+        funding_source="transaction_log",
         currency=next(iter(currencies), None),
     )
 
@@ -513,6 +528,11 @@ def normalize_hyperliquid_position(position: dict[str, Any]) -> dict[str, Any]:
     info = info if isinstance(info, dict) else {}
     entry = info.get("position")
     entry = entry if isinstance(entry, dict) else {}
+    if normalized.get("mark_price") is None:
+        notional = number_or_none(normalized.get("notional"))
+        quantity = number_or_none(normalized.get("quantity"))
+        if notional is not None and quantity not in {None, 0}:
+            normalized["mark_price"] = abs(notional / quantity)
     return_on_equity = number_or_none(entry.get("returnOnEquity"))
     if return_on_equity is not None:
         normalized["percentage"] = round(return_on_equity * 100, 12)

--- a/data_service/account_data.py
+++ b/data_service/account_data.py
@@ -35,11 +35,17 @@ class AccountDataService:
         self,
         config_path: Path,
         *,
+        cache_path: Path | None = None,
         cache_ttl_seconds: float = 10.0,
         executor_factory: Callable[[], Executor] | None = None,
         positions_collector: Callable[[str], dict[str, Any]] = collect_positions_snapshot,
     ) -> None:
         self.config_path = config_path.resolve()
+        self.cache_path = (
+            cache_path
+            if cache_path is not None
+            else self.config_path.parent.parent / "data" / "cache" / "account_cache.sqlite"
+        ).resolve()
         self.cache_ttl_seconds = cache_ttl_seconds
         self._executor_factory = executor_factory or self._new_process_executor
         self._positions_collector = positions_collector
@@ -121,6 +127,9 @@ class AccountDataService:
     async def disconnect_live(self, ws: Any) -> None:
         await self.live_ws.disconnect(ws)
 
+    async def start(self) -> None:
+        await self._ensure_live_stream()
+
     async def _ensure_live_stream(self) -> None:
         async with self._live_lock:
             if self._live_process is not None and self._live_process.is_alive():
@@ -132,6 +141,7 @@ class AccountDataService:
                 target=run_positions_stream,
                 args=(
                     str(self.config_path),
+                    str(self.cache_path),
                     self._live_output,
                     self._live_stop,
                     copy.deepcopy(self._positions),

--- a/data_service/account_data.py
+++ b/data_service/account_data.py
@@ -4,23 +4,59 @@ import asyncio
 import copy
 import multiprocessing
 import queue
+import shutil
+import tempfile
 import time
 from collections.abc import Callable
 from concurrent.futures import Executor, ProcessPoolExecutor
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 from account_service.cache import AccountCache
+from account_service.csv_import import (
+    MAX_IMPORT_FILE_BYTES,
+    MAX_IMPORT_FILES,
+    MAX_IMPORT_TOTAL_BYTES,
+    TIMEZONE_CONFIRMATION_WARNING,
+    HistoryCsvError,
+    build_history_import_batch,
+    preview_history_files,
+)
 from account_service.live_positions import run_positions_stream
 from account_service.positions import collect_positions_snapshot
+from ai.scripts.asset import (
+    ExchangeAccount,
+    build_exchange,
+    configured_accounts,
+    read_provider_config,
+)
 from tv_logos import exchange_logo_url
 from ws_manager import WSManager
 
 
 class AccountDataError(RuntimeError):
     pass
+
+
+def _fetch_okx_account_uid(account: ExchangeAccount) -> str:
+    configured_uid = str(account.config.get("uid") or "").strip()
+    if configured_uid:
+        return configured_uid
+    exchange = build_exchange("okx", account.config, 10_000, None)
+    try:
+        response = exchange.privateGetAccountConfig({})
+        rows = response.get("data") if isinstance(response, dict) else None
+        data = rows[0] if isinstance(rows, list) and rows else {}
+        return str(data.get("uid") or "").strip() if isinstance(data, dict) else ""
+    except Exception:
+        return ""
+    finally:
+        try:
+            exchange.close()
+        except Exception:
+            pass
 
 
 def _add_exchange_logos(payload: dict[str, Any]) -> dict[str, Any]:
@@ -54,6 +90,7 @@ class AccountDataService:
         self._executor_factory = executor_factory or self._new_process_executor
         self._positions_collector = positions_collector
         self._executor: Executor | None = None
+        self._import_executor: Executor | None = None
         self._positions: dict[str, Any] | None = None
         self._positions_at = 0.0
         self._positions_lock = asyncio.Lock()
@@ -66,6 +103,13 @@ class AccountDataService:
         self._live_reader: asyncio.Task[None] | None = None
         self._live_control_reader: asyncio.Task[None] | None = None
         self._history_refresh_waiters: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._history_import_waiters: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._history_import_previews: dict[str, dict[str, Any]] = {}
+        self._history_import_jobs: dict[str, dict[str, Any]] = {}
+        self._history_import_tasks: dict[str, asyncio.Task[None]] = {}
+        self._history_import_root: Path | None = None
+        self._okx_account_uid_cache: dict[str, str] = {}
+        self._okx_account_uid_lock = asyncio.Lock()
         self._positions_revision = 0
         self.live_ws = WSManager()
 
@@ -80,6 +124,37 @@ class AccountDataService:
         if self._executor is None:
             self._executor = self._executor_factory()
         return self._executor
+
+    def _ensure_import_executor(self) -> Executor:
+        if self._import_executor is None:
+            self._import_executor = self._executor_factory()
+        return self._import_executor
+
+    async def _okx_account_uids(
+        self,
+        accounts: list[ExchangeAccount],
+    ) -> dict[str, str]:
+        okx_accounts = [account for account in accounts if account.exchange_id == "okx"]
+        async with self._okx_account_uid_lock:
+            missing = [
+                account
+                for account in okx_accounts
+                if account.name not in self._okx_account_uid_cache
+            ]
+            if missing:
+                resolved = await asyncio.gather(*(
+                    asyncio.to_thread(_fetch_okx_account_uid, account)
+                    for account in missing
+                ))
+                self._okx_account_uid_cache.update(
+                    (account.name, uid)
+                    for account, uid in zip(missing, resolved, strict=True)
+                )
+            return {
+                account.name: self._okx_account_uid_cache.get(account.name, "")
+                for account in okx_accounts
+                if self._okx_account_uid_cache.get(account.name)
+            }
 
     def _positions_cache_valid(self) -> bool:
         return (
@@ -231,7 +306,7 @@ class AccountDataService:
     async def pnl(
         self,
         *,
-        days: int = 90,
+        days: int | None = 90,
         account: str = "",
         exchange: str = "",
     ) -> dict[str, Any]:
@@ -261,13 +336,21 @@ class AccountDataService:
             for result in results
             if isinstance(result, dict) and result.get("account")
         }
+        funding_available = any(
+            isinstance(result, dict) and result.get("funding") is not None
+            for result in results
+        )
+        borrow_interest_available = any(
+            isinstance(result, dict) and result.get("borrow_interest") is not None
+            for result in results
+        )
         return {
             "schema_version": "1.0",
             "collected_at": str(payload.get("to") or ""),
             "read_only": True,
             "cached": True,
             "period": {
-                "days": int(payload.get("days") or days),
+                "days": payload.get("days"),
                 "from": payload.get("from"),
                 "to": payload.get("to"),
             },
@@ -276,10 +359,428 @@ class AccountDataService:
             "summary": {
                 "accounts": len(accounts),
                 "rows": len(results),
-                "funding_available": False,
-                "borrow_interest_available": False,
+                "funding_available": funding_available,
+                "borrow_interest_available": borrow_interest_available,
             },
         }
+
+    def _cleanup_history_import_state(self) -> None:
+        now = time.monotonic()
+        expired_previews = [
+            preview_id
+            for preview_id, preview in self._history_import_previews.items()
+            if float(preview.get("expires_monotonic") or 0.0) <= now
+        ]
+        for preview_id in expired_previews:
+            preview = self._history_import_previews.pop(preview_id, None)
+            if preview is not None:
+                shutil.rmtree(str(preview.get("directory") or ""), ignore_errors=True)
+
+        expired_jobs = [
+            job_id
+            for job_id, job in self._history_import_jobs.items()
+            if job.get("status") in {"completed", "failed"}
+            and now - float(job.get("finished_monotonic") or now) > 24 * 60 * 60
+        ]
+        for job_id in expired_jobs:
+            self._history_import_jobs.pop(job_id, None)
+
+    @staticmethod
+    def _public_import_job(job: dict[str, Any]) -> dict[str, Any]:
+        return {
+            key: copy.deepcopy(value)
+            for key, value in job.items()
+            if key not in {"finished_monotonic"}
+        }
+
+    async def preview_history_import(
+        self,
+        uploads: list[tuple[str, bytes]],
+    ) -> dict[str, Any]:
+        self._cleanup_history_import_state()
+        if not uploads or len(uploads) > MAX_IMPORT_FILES:
+            raise AccountDataError(
+                f"select between 1 and {MAX_IMPORT_FILES} CSV files"
+            )
+        total_size = sum(len(content) for _, content in uploads)
+        if total_size > MAX_IMPORT_TOTAL_BYTES:
+            raise AccountDataError(
+                f"combined CSV size exceeds {MAX_IMPORT_TOTAL_BYTES // (1024 * 1024)} MB"
+            )
+
+        if self._history_import_root is None:
+            self._history_import_root = Path(
+                tempfile.mkdtemp(prefix="pynereal-history-import-")
+            )
+        preview_id = uuid4().hex
+        directory = self._history_import_root / preview_id
+        directory.mkdir(parents=True, exist_ok=False)
+        specs: list[dict[str, Any]] = []
+        try:
+            for original_name, content in uploads:
+                name = Path(str(original_name or "")).name.strip()
+                if not name or Path(name).suffix.lower() != ".csv":
+                    raise AccountDataError("only CSV files can be imported")
+                if len(content) > MAX_IMPORT_FILE_BYTES:
+                    raise AccountDataError(
+                        f"CSV exceeds {MAX_IMPORT_FILE_BYTES // (1024 * 1024)} MB: {name}"
+                    )
+                file_id = uuid4().hex
+                path = directory / f"{file_id}.csv"
+                await asyncio.to_thread(path.write_bytes, content)
+                specs.append({"file_id": file_id, "name": name, "path": str(path)})
+
+            loop = asyncio.get_running_loop()
+            preview = await loop.run_in_executor(
+                self._ensure_import_executor(),
+                preview_history_files,
+                specs,
+            )
+            provider_data = await asyncio.to_thread(
+                read_provider_config,
+                self.config_path,
+            )
+            accounts = configured_accounts(provider_data)
+            okx_account_uids = await self._okx_account_uids(accounts) if any(
+                str(item.get("exchange") or "") == "okx"
+                for item in preview.get("files", [])
+                if isinstance(item, dict)
+            ) else {}
+            candidates_by_exchange: dict[str, list[str]] = {}
+            for account in accounts:
+                candidates_by_exchange.setdefault(account.exchange_id, []).append(
+                    account.name
+                )
+
+            preview_files = preview.get("files")
+            preview_files = preview_files if isinstance(preview_files, list) else []
+            stored_files: dict[str, dict[str, Any]] = {}
+            specs_by_id = {str(item["file_id"]): item for item in specs}
+            for file_preview in preview_files:
+                file_id = str(file_preview.get("file_id") or "")
+                exchange_id = str(file_preview.get("exchange") or "")
+                candidates = sorted(candidates_by_exchange.get(exchange_id, []))
+                file_preview["account_candidates"] = candidates
+                source_uid = str(file_preview.get("source_account_uid") or "")
+                uid_matches = [
+                    account_name
+                    for account_name in candidates
+                    if source_uid and okx_account_uids.get(account_name) == source_uid
+                ]
+                file_preview["suggested_account"] = uid_matches[0] if len(
+                    uid_matches
+                ) == 1 else candidates[0] if len(candidates) == 1 else ""
+                stored_files[file_id] = {
+                    **copy.deepcopy(file_preview),
+                    "path": specs_by_id[file_id]["path"],
+                }
+            if len(stored_files) != len(specs):
+                raise AccountDataError("not every selected file could be previewed")
+
+            expires_at = datetime.now(UTC) + timedelta(minutes=30)
+            self._history_import_previews[preview_id] = {
+                "preview_id": preview_id,
+                "directory": str(directory),
+                "files": stored_files,
+                "timezone_options": preview.get("timezone_options", []),
+                "expires_at": expires_at.isoformat().replace("+00:00", "Z"),
+                "expires_monotonic": time.monotonic() + 30 * 60,
+            }
+            return {
+                "preview_id": preview_id,
+                "expires_at": self._history_import_previews[preview_id]["expires_at"],
+                "files": preview_files,
+                "timezone_options": preview.get("timezone_options", []),
+            }
+        except AccountDataError:
+            shutil.rmtree(directory, ignore_errors=True)
+            raise
+        except (HistoryCsvError, ValueError) as exc:
+            shutil.rmtree(directory, ignore_errors=True)
+            raise AccountDataError(str(exc)[:500]) from exc
+        except Exception as exc:
+            shutil.rmtree(directory, ignore_errors=True)
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+
+    async def remove_history_import_preview_file(
+        self,
+        preview_id: str,
+        file_id: str,
+    ) -> dict[str, Any]:
+        self._cleanup_history_import_state()
+        preview = self._history_import_previews.get(str(preview_id or "").strip())
+        if preview is None:
+            raise AccountDataError("history import preview expired or was not found")
+        files = preview.get("files")
+        files = files if isinstance(files, dict) else {}
+        file_preview = files.pop(str(file_id or "").strip(), None)
+        if not isinstance(file_preview, dict):
+            raise AccountDataError("history import preview file was not found")
+        path = Path(str(file_preview.get("path") or ""))
+        if path.is_file():
+            await asyncio.to_thread(path.unlink)
+        if not files:
+            self._history_import_previews.pop(str(preview_id).strip(), None)
+            await asyncio.to_thread(
+                shutil.rmtree,
+                str(preview.get("directory") or ""),
+                True,
+            )
+        return {"ok": True, "remaining": len(files)}
+
+    async def commit_history_import(self, payload: dict[str, Any]) -> dict[str, Any]:
+        self._cleanup_history_import_state()
+        preview_id = str(payload.get("preview_id") or "").strip()
+        preview = self._history_import_previews.get(preview_id)
+        if preview is None:
+            raise AccountDataError("history import preview expired or was not found")
+        selections = payload.get("files")
+        selections = selections if isinstance(selections, list) else []
+        selection_map = {
+            str(item.get("file_id") or ""): item
+            for item in selections
+            if isinstance(item, dict) and item.get("file_id")
+        }
+        preview_files = preview["files"]
+        if set(selection_map) != set(preview_files):
+            raise AccountDataError("confirm the account and timezone for every CSV file")
+
+        batch_id = uuid4().hex
+        specs: list[dict[str, Any]] = []
+        for file_id, file_preview in preview_files.items():
+            selection = selection_map[file_id]
+            account_name = str(selection.get("account") or "").strip()
+            if account_name not in file_preview.get("account_candidates", []):
+                raise AccountDataError(
+                    f"select a configured {file_preview['exchange']} account for "
+                    f"{file_preview['name']}"
+                )
+            source_timezone = str(selection.get("source_timezone") or "").strip()
+            if not source_timezone:
+                raise AccountDataError(f"select the source timezone for {file_preview['name']}")
+            if selection.get("timezone_confirmed") is not True:
+                raise AccountDataError(
+                    f"confirm the source timezone for {file_preview['name']}"
+                )
+            specs.append({
+                "file_id": file_id,
+                "name": file_preview["name"],
+                "path": file_preview["path"],
+                "account": account_name,
+                "source_timezone": source_timezone,
+                "timezone_confirmed": True,
+                "import_id": uuid4().hex,
+                "batch_id": batch_id,
+            })
+
+        loop = asyncio.get_running_loop()
+        try:
+            batch = await loop.run_in_executor(
+                self._ensure_import_executor(),
+                build_history_import_batch,
+                specs,
+            )
+        except (HistoryCsvError, ValueError) as exc:
+            raise AccountDataError(str(exc)[:500]) from exc
+        except Exception as exc:
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+
+        job_id = uuid4().hex
+        now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        job = {
+            "job_id": job_id,
+            "batch_id": batch_id,
+            "kind": "import",
+            "status": "queued",
+            "created_at": now,
+            "updated_at": now,
+            "file_count": len(specs),
+            "summary": None,
+            "imports": [],
+            "error": None,
+        }
+        self._history_import_jobs[job_id] = job
+        task = asyncio.create_task(self._run_history_import_job(job_id, batch))
+        self._history_import_tasks[job_id] = task
+        task.add_done_callback(lambda _task, key=job_id: self._history_import_tasks.pop(key, None))
+        return self._public_import_job(job)
+
+    async def _run_history_import_job(
+        self,
+        job_id: str,
+        batch: dict[str, Any],
+    ) -> None:
+        job = self._history_import_jobs[job_id]
+        job["status"] = "running"
+        job["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        request_id = uuid4().hex
+        loop = asyncio.get_running_loop()
+        waiter: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._history_import_waiters[request_id] = waiter
+        try:
+            await self._ensure_live_stream()
+            process = self._live_process
+            input_queue = self._live_input
+            if process is None or not process.is_alive() or input_queue is None:
+                raise AccountDataError("account worker is not available")
+            await asyncio.to_thread(input_queue.put, {
+                "type": "history.import",
+                "request_id": request_id,
+                "batch": batch,
+            }, True, 10.0)
+            result = await asyncio.wait_for(asyncio.shield(waiter), timeout=600.0)
+            if result.get("status") != "ok":
+                error = result.get("error")
+                error = error if isinstance(error, dict) else {}
+                raise AccountDataError(
+                    str(error.get("message") or "history import failed")[:500]
+                )
+            job["status"] = "completed"
+            job["summary"] = result.get("summary")
+            job["imports"] = result.get("imports", [])
+        except asyncio.CancelledError:
+            job["status"] = "failed"
+            job["error"] = "history import was cancelled"
+            raise
+        except Exception as exc:
+            job["status"] = "failed"
+            job["error"] = str(exc).replace("\n", " ")[:500]
+        finally:
+            self._history_import_waiters.pop(request_id, None)
+            if not waiter.done():
+                waiter.cancel()
+            job["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            job["finished_monotonic"] = time.monotonic()
+
+    def history_import_job(self, job_id: str) -> dict[str, Any]:
+        self._cleanup_history_import_state()
+        job = self._history_import_jobs.get(job_id)
+        if job is None:
+            raise AccountDataError("history import job was not found")
+        return self._public_import_job(job)
+
+    async def retry_history_import_enrichment(
+        self,
+        import_id: str,
+    ) -> dict[str, Any]:
+        try:
+            manifest = await asyncio.to_thread(
+                AccountCache(self.cache_path).csv_import,
+                import_id,
+            )
+        except Exception as exc:
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+        if not isinstance(manifest, dict) or manifest.get("exchange") != "hyperliquid":
+            raise AccountDataError("Hyperliquid history import was not found")
+
+        job_id = uuid4().hex
+        now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        job = {
+            "job_id": job_id,
+            "batch_id": str(manifest.get("batch_id") or ""),
+            "kind": "enrichment",
+            "status": "queued",
+            "created_at": now,
+            "updated_at": now,
+            "file_count": 1,
+            "summary": None,
+            "imports": [],
+            "error": None,
+        }
+        self._history_import_jobs[job_id] = job
+        task = asyncio.create_task(
+            self._run_history_enrichment_job(job_id, import_id)
+        )
+        self._history_import_tasks[job_id] = task
+        task.add_done_callback(
+            lambda _task, key=job_id: self._history_import_tasks.pop(key, None)
+        )
+        return self._public_import_job(job)
+
+    async def _run_history_enrichment_job(
+        self,
+        job_id: str,
+        import_id: str,
+    ) -> None:
+        job = self._history_import_jobs[job_id]
+        job["status"] = "running"
+        job["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        request_id = uuid4().hex
+        loop = asyncio.get_running_loop()
+        waiter: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._history_import_waiters[request_id] = waiter
+        try:
+            await self._ensure_live_stream()
+            process = self._live_process
+            input_queue = self._live_input
+            if process is None or not process.is_alive() or input_queue is None:
+                raise AccountDataError("account worker is not available")
+            await asyncio.to_thread(input_queue.put, {
+                "type": "history.enrichment",
+                "request_id": request_id,
+                "import_id": import_id,
+            }, True, 10.0)
+            result = await asyncio.wait_for(asyncio.shield(waiter), timeout=600.0)
+            if result.get("status") != "ok":
+                error = result.get("error")
+                error = error if isinstance(error, dict) else {}
+                raise AccountDataError(
+                    str(error.get("message") or "history enrichment failed")[:500]
+                )
+            job["status"] = "completed"
+            job["summary"] = result.get("summary")
+            job["imports"] = result.get("imports", [])
+        except asyncio.CancelledError:
+            job["status"] = "failed"
+            job["error"] = "history enrichment was cancelled"
+            raise
+        except Exception as exc:
+            job["status"] = "failed"
+            job["error"] = str(exc).replace("\n", " ")[:500]
+        finally:
+            self._history_import_waiters.pop(request_id, None)
+            if not waiter.done():
+                waiter.cancel()
+            job["updated_at"] = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            job["finished_monotonic"] = time.monotonic()
+
+    async def history_imports(self, *, limit: int = 100) -> dict[str, Any]:
+        try:
+            payload = await asyncio.to_thread(
+                AccountCache(self.cache_path).csv_imports,
+                limit=limit,
+            )
+        except ValueError:
+            raise
+        except Exception as exc:
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+        for result in payload.get("results", []):
+            if isinstance(result, dict):
+                warnings = result.get("warnings")
+                if isinstance(warnings, list):
+                    result["warnings"] = [
+                        warning
+                        for warning in warnings
+                        if warning != TIMEZONE_CONFIRMATION_WARNING
+                    ]
+                result["exchange_logo_url"] = exchange_logo_url(
+                    str(result.get("exchange") or "")
+                )
+                result["enrichment_retry_available"] = (
+                    result.get("exchange") == "hyperliquid"
+                    and result.get("status") == "partial"
+                )
+        self._cleanup_history_import_state()
+        payload["active_jobs"] = [
+            self._public_import_job(job)
+            for job in self._history_import_jobs.values()
+            if job.get("status") in {"queued", "running"}
+        ]
+        return payload
 
     async def refresh_history(
         self,
@@ -482,16 +983,28 @@ class AccountDataService:
         while True:
             message = await asyncio.to_thread(output.get)
             if message is None:
-                for waiter in self._history_refresh_waiters.values():
+                waiters = [
+                    *self._history_refresh_waiters.values(),
+                    *self._history_import_waiters.values(),
+                ]
+                for waiter in waiters:
                     if not waiter.done():
                         waiter.set_exception(AccountDataError("account worker stopped"))
                 return
             if not isinstance(message, dict):
                 continue
-            if message.get("type") != "history.refresh.result":
+            message_type = message.get("type")
+            if message_type == "history.refresh.result":
+                waiter_map = self._history_refresh_waiters
+            elif message_type in {
+                "history.import.result",
+                "history.enrichment.result",
+            }:
+                waiter_map = self._history_import_waiters
+            else:
                 continue
             request_id = str(message.get("request_id") or "")
-            waiter = self._history_refresh_waiters.get(request_id)
+            waiter = waiter_map.get(request_id)
             payload = message.get("payload")
             if waiter is None or waiter.done() or not isinstance(payload, dict):
                 continue
@@ -513,8 +1026,12 @@ class AccountDataService:
         self._live_control_output = None
         self._live_input = None
         self._positions_revision = 0
-        waiters = list(self._history_refresh_waiters.values())
+        waiters = [
+            *self._history_refresh_waiters.values(),
+            *self._history_import_waiters.values(),
+        ]
         self._history_refresh_waiters.clear()
+        self._history_import_waiters.clear()
         for waiter in waiters:
             if not waiter.done():
                 waiter.set_exception(AccountDataError("account worker stopped"))
@@ -548,8 +1065,30 @@ class AccountDataService:
             await asyncio.to_thread(input_queue.join_thread)
 
     async def close(self) -> None:
+        import_tasks = list(self._history_import_tasks.values())
+        self._history_import_tasks.clear()
+        for task in import_tasks:
+            task.cancel()
+        if import_tasks:
+            await asyncio.gather(*import_tasks, return_exceptions=True)
         await self._close_live_stream()
         executor = self._executor
         self._executor = None
         if executor is not None:
             await asyncio.to_thread(executor.shutdown, wait=True, cancel_futures=True)
+        import_executor = self._import_executor
+        self._import_executor = None
+        if import_executor is not None:
+            await asyncio.to_thread(
+                import_executor.shutdown,
+                wait=True,
+                cancel_futures=True,
+            )
+        if self._history_import_root is not None:
+            await asyncio.to_thread(
+                shutil.rmtree,
+                self._history_import_root,
+                True,
+            )
+            self._history_import_root = None
+        self._history_import_previews.clear()

--- a/data_service/account_data.py
+++ b/data_service/account_data.py
@@ -228,6 +228,59 @@ class AccountDataService:
             raise AccountDataError(message[:500] or type(exc).__name__) from exc
         return self._history_group_response(groups, exchange=exchange)
 
+    async def pnl(
+        self,
+        *,
+        days: int = 90,
+        account: str = "",
+        exchange: str = "",
+    ) -> dict[str, Any]:
+        try:
+            payload = await asyncio.to_thread(
+                AccountCache(self.cache_path).pnl_summary,
+                days=days,
+                account=account,
+                exchange=exchange,
+            )
+        except ValueError:
+            raise
+        except Exception as exc:
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+
+        results = payload.get("results")
+        results = results if isinstance(results, list) else []
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            result["exchange_logo_url"] = exchange_logo_url(
+                str(result.get("exchange") or "")
+            )
+        accounts = {
+            str(result.get("account") or "")
+            for result in results
+            if isinstance(result, dict) and result.get("account")
+        }
+        return {
+            "schema_version": "1.0",
+            "collected_at": str(payload.get("to") or ""),
+            "read_only": True,
+            "cached": True,
+            "period": {
+                "days": int(payload.get("days") or days),
+                "from": payload.get("from"),
+                "to": payload.get("to"),
+            },
+            "totals": payload.get("totals", []),
+            "results": results,
+            "summary": {
+                "accounts": len(accounts),
+                "rows": len(results),
+                "funding_available": False,
+                "borrow_interest_available": False,
+            },
+        }
+
     async def refresh_history(
         self,
         *,

--- a/data_service/account_data.py
+++ b/data_service/account_data.py
@@ -1,0 +1,193 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import multiprocessing
+import time
+from collections.abc import Callable
+from concurrent.futures import Executor, ProcessPoolExecutor
+from pathlib import Path
+from typing import Any
+
+from account_service.live_positions import run_positions_stream
+from account_service.positions import collect_positions_snapshot
+from tv_logos import exchange_logo_url
+from ws_manager import WSManager
+
+
+class AccountDataError(RuntimeError):
+    pass
+
+
+def _add_exchange_logos(payload: dict[str, Any]) -> dict[str, Any]:
+    for result in payload.get("results", []):
+        if not isinstance(result, dict):
+            continue
+        exchange = str(result.get("exchange") or "")
+        result["exchange_logo_url"] = exchange_logo_url(exchange)
+    return payload
+
+
+class AccountDataService:
+    """Read-only account snapshots executed outside the data-service process."""
+
+    def __init__(
+        self,
+        config_path: Path,
+        *,
+        cache_ttl_seconds: float = 10.0,
+        executor_factory: Callable[[], Executor] | None = None,
+        positions_collector: Callable[[str], dict[str, Any]] = collect_positions_snapshot,
+    ) -> None:
+        self.config_path = config_path.resolve()
+        self.cache_ttl_seconds = cache_ttl_seconds
+        self._executor_factory = executor_factory or self._new_process_executor
+        self._positions_collector = positions_collector
+        self._executor: Executor | None = None
+        self._positions: dict[str, Any] | None = None
+        self._positions_at = 0.0
+        self._positions_lock = asyncio.Lock()
+        self._live_lock = asyncio.Lock()
+        self._live_process: multiprocessing.Process | None = None
+        self._live_output: Any = None
+        self._live_stop: Any = None
+        self._live_reader: asyncio.Task[None] | None = None
+        self.live_ws = WSManager()
+
+    @staticmethod
+    def _new_process_executor() -> ProcessPoolExecutor:
+        return ProcessPoolExecutor(
+            max_workers=1,
+            mp_context=multiprocessing.get_context("spawn"),
+        )
+
+    def _ensure_executor(self) -> Executor:
+        if self._executor is None:
+            self._executor = self._executor_factory()
+        return self._executor
+
+    def _positions_cache_valid(self) -> bool:
+        return (
+            self._positions is not None
+            and time.monotonic() - self._positions_at < self.cache_ttl_seconds
+        )
+
+    async def positions(self, *, force: bool = False) -> dict[str, Any]:
+        requested_at = time.monotonic()
+        if not force and self._positions_cache_valid():
+            result = copy.deepcopy(self._positions)
+            result["cached"] = True
+            return result
+
+        async with self._positions_lock:
+            if (
+                force
+                and self._positions is not None
+                and self._positions_at >= requested_at
+            ):
+                result = copy.deepcopy(self._positions)
+                result["cached"] = True
+                return result
+            if not force and self._positions_cache_valid():
+                result = copy.deepcopy(self._positions)
+                result["cached"] = True
+                return result
+
+            loop = asyncio.get_running_loop()
+            try:
+                result = await loop.run_in_executor(
+                    self._ensure_executor(),
+                    self._positions_collector,
+                    str(self.config_path),
+                )
+            except Exception as exc:
+                message = str(exc).replace("\n", " ").strip()
+                raise AccountDataError(message[:500] or type(exc).__name__) from exc
+            result = _add_exchange_logos(result)
+            self._positions = result
+            self._positions_at = time.monotonic()
+            output = copy.deepcopy(result)
+            output["cached"] = False
+            return output
+
+    async def connect_live(self, ws: Any) -> None:
+        await self.live_ws.connect(ws)
+        await self._ensure_live_stream()
+        if self._positions is not None:
+            payload = copy.deepcopy(self._positions)
+            payload["cached"] = True
+            await self.live_ws.send(ws, {"type": "account.positions", "payload": payload})
+
+    async def disconnect_live(self, ws: Any) -> None:
+        await self.live_ws.disconnect(ws)
+
+    async def _ensure_live_stream(self) -> None:
+        async with self._live_lock:
+            if self._live_process is not None and self._live_process.is_alive():
+                return
+            context = multiprocessing.get_context("spawn")
+            self._live_output = context.Queue(maxsize=8)
+            self._live_stop = context.Event()
+            self._live_process = context.Process(
+                target=run_positions_stream,
+                args=(
+                    str(self.config_path),
+                    self._live_output,
+                    self._live_stop,
+                    copy.deepcopy(self._positions),
+                ),
+                name="pynereal-account-positions",
+                daemon=True,
+            )
+            self._live_process.start()
+            self._live_reader = asyncio.create_task(self._read_live_output())
+
+    async def _read_live_output(self) -> None:
+        output = self._live_output
+        if output is None:
+            return
+        while True:
+            payload = await asyncio.to_thread(output.get)
+            if payload is None:
+                return
+            if not isinstance(payload, dict):
+                continue
+            payload = _add_exchange_logos(payload)
+            self._positions = payload
+            self._positions_at = time.monotonic()
+            await self.live_ws.broadcast_json(
+                {"type": "account.positions", "payload": payload}
+            )
+
+    async def _close_live_stream(self) -> None:
+        process = self._live_process
+        stop = self._live_stop
+        reader = self._live_reader
+        output = self._live_output
+        self._live_process = None
+        self._live_stop = None
+        self._live_reader = None
+        self._live_output = None
+        if stop is not None:
+            stop.set()
+        if process is not None:
+            await asyncio.to_thread(process.join, 10)
+            if process.is_alive():
+                process.terminate()
+                await asyncio.to_thread(process.join, 5)
+        if reader is not None and not reader.done():
+            try:
+                await asyncio.wait_for(reader, timeout=2)
+            except TimeoutError:
+                reader.cancel()
+                await asyncio.gather(reader, return_exceptions=True)
+        if output is not None:
+            output.close()
+            await asyncio.to_thread(output.join_thread)
+
+    async def close(self) -> None:
+        await self._close_live_stream()
+        executor = self._executor
+        self._executor = None
+        if executor is not None:
+            await asyncio.to_thread(executor.shutdown, wait=True, cancel_futures=True)

--- a/data_service/account_data.py
+++ b/data_service/account_data.py
@@ -681,6 +681,7 @@ class AccountDataService:
         job = {
             "job_id": job_id,
             "batch_id": str(manifest.get("batch_id") or ""),
+            "import_id": import_id,
             "kind": "enrichment",
             "status": "queued",
             "created_at": now,
@@ -781,6 +782,45 @@ class AccountDataService:
             if job.get("status") in {"queued", "running"}
         ]
         return payload
+
+    async def delete_history_import(self, import_id: str) -> dict[str, Any]:
+        normalized_id = import_id.strip()
+        if not normalized_id:
+            raise AccountDataError("CSV import was not found")
+        self._cleanup_history_import_state()
+        if any(
+            job.get("status") in {"queued", "running"}
+            and job.get("import_id") == normalized_id
+            for job in self._history_import_jobs.values()
+        ):
+            raise AccountDataError("CSV import enrichment is still running")
+        request_id = uuid4().hex
+        loop = asyncio.get_running_loop()
+        waiter: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._history_import_waiters[request_id] = waiter
+        try:
+            await self._ensure_live_stream()
+            process = self._live_process
+            input_queue = self._live_input
+            if process is None or not process.is_alive() or input_queue is None:
+                raise AccountDataError("account worker is not available")
+            await asyncio.to_thread(input_queue.put, {
+                "type": "history.import.delete",
+                "request_id": request_id,
+                "import_id": normalized_id,
+            }, True, 10.0)
+            result = await asyncio.wait_for(asyncio.shield(waiter), timeout=30.0)
+            if result.get("status") == "error":
+                error = result.get("error")
+                error = error if isinstance(error, dict) else {}
+                raise AccountDataError(
+                    str(error.get("message") or "CSV import deletion failed")[:500]
+                )
+            return result
+        finally:
+            self._history_import_waiters.pop(request_id, None)
+            if not waiter.done():
+                waiter.cancel()
 
     async def refresh_history(
         self,
@@ -999,6 +1039,7 @@ class AccountDataService:
             elif message_type in {
                 "history.import.result",
                 "history.enrichment.result",
+                "history.import.delete.result",
             }:
                 waiter_map = self._history_import_waiters
             else:

--- a/data_service/account_data.py
+++ b/data_service/account_data.py
@@ -3,12 +3,16 @@ from __future__ import annotations
 import asyncio
 import copy
 import multiprocessing
+import queue
 import time
 from collections.abc import Callable
 from concurrent.futures import Executor, ProcessPoolExecutor
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
+from uuid import uuid4
 
+from account_service.cache import AccountCache
 from account_service.live_positions import run_positions_stream
 from account_service.positions import collect_positions_snapshot
 from tv_logos import exchange_logo_url
@@ -56,8 +60,13 @@ class AccountDataService:
         self._live_lock = asyncio.Lock()
         self._live_process: multiprocessing.Process | None = None
         self._live_output: Any = None
+        self._live_control_output: Any = None
+        self._live_input: Any = None
         self._live_stop: Any = None
         self._live_reader: asyncio.Task[None] | None = None
+        self._live_control_reader: asyncio.Task[None] | None = None
+        self._history_refresh_waiters: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._positions_revision = 0
         self.live_ws = WSManager()
 
     @staticmethod
@@ -112,9 +121,236 @@ class AccountDataService:
             result = _add_exchange_logos(result)
             self._positions = result
             self._positions_at = time.monotonic()
+            if force:
+                self._sync_live_snapshot(result)
             output = copy.deepcopy(result)
             output["cached"] = False
             return output
+
+    def _sync_live_snapshot(self, snapshot: dict[str, Any]) -> None:
+        input_queue = self._live_input
+        process = self._live_process
+        if input_queue is None or process is None or not process.is_alive():
+            return
+        revision = self._positions_revision + 1
+        message = {
+            "revision": revision,
+            "snapshot": copy.deepcopy(snapshot),
+        }
+        try:
+            input_queue.put_nowait(message)
+        except queue.Full:
+            try:
+                input_queue.get_nowait()
+            except queue.Empty:
+                pass
+            try:
+                input_queue.put_nowait(message)
+            except queue.Full:
+                return
+        self._positions_revision = revision
+
+    async def position_history(
+        self,
+        *,
+        cursor: str | None = None,
+        limit: int = 50,
+        account: str = "",
+        exchange: str = "",
+        symbol: str = "",
+        exact_market: bool = False,
+    ) -> dict[str, Any]:
+        try:
+            page = await asyncio.to_thread(
+                AccountCache(self.cache_path).position_history_page,
+                cursor=cursor,
+                limit=limit,
+                account=account,
+                exchange=exchange,
+                symbol=symbol,
+                exact_market=exact_market,
+            )
+        except ValueError:
+            raise
+        except Exception as exc:
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+        return self._history_response(page)
+
+    async def position_history_groups(self, *, exchange: str = "") -> dict[str, Any]:
+        try:
+            groups = await asyncio.to_thread(
+                AccountCache(self.cache_path).position_history_groups,
+                exchange=exchange,
+            )
+        except Exception as exc:
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+        return self._history_group_response(groups, exchange=exchange)
+
+    async def order_history(
+        self,
+        *,
+        cursor: str | None = None,
+        limit: int = 50,
+        account: str = "",
+        exchange: str = "",
+        symbol: str = "",
+        status: str = "",
+        exact_market: bool = False,
+    ) -> dict[str, Any]:
+        try:
+            page = await asyncio.to_thread(
+                AccountCache(self.cache_path).order_history_page,
+                cursor=cursor,
+                limit=limit,
+                account=account,
+                exchange=exchange,
+                symbol=symbol,
+                status=status,
+                exact_market=exact_market,
+            )
+        except ValueError:
+            raise
+        except Exception as exc:
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+        return self._history_response(page)
+
+    async def order_history_groups(self, *, exchange: str = "") -> dict[str, Any]:
+        try:
+            groups = await asyncio.to_thread(
+                AccountCache(self.cache_path).order_history_groups,
+                exchange=exchange,
+            )
+        except Exception as exc:
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+        return self._history_group_response(groups, exchange=exchange)
+
+    async def refresh_history(
+        self,
+        *,
+        kind: str,
+        account: str = "",
+        exchange: str = "",
+        symbol: str = "",
+    ) -> dict[str, Any]:
+        normalized_kind = kind.strip().lower()
+        if normalized_kind not in {"order", "position"}:
+            raise AccountDataError("history kind must be order or position")
+
+        account_filter = account.strip()
+        account_names: list[str] = []
+        if not account_filter:
+            try:
+                account_names = await asyncio.to_thread(
+                    AccountCache(self.cache_path).history_accounts,
+                    kind=normalized_kind,
+                    exchange=exchange,
+                    symbol=symbol,
+                )
+            except Exception as exc:
+                message = str(exc).replace("\n", " ").strip()
+                raise AccountDataError(message[:500] or type(exc).__name__) from exc
+            if not account_names:
+                raise AccountDataError(
+                    "no cached accounts match the selected history scope"
+                )
+
+        await self._ensure_live_stream()
+        process = self._live_process
+        input_queue = self._live_input
+        if process is None or not process.is_alive() or input_queue is None:
+            raise AccountDataError("account worker is not available")
+
+        request_id = uuid4().hex
+        loop = asyncio.get_running_loop()
+        waiter: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._history_refresh_waiters[request_id] = waiter
+        message = {
+            "type": "history.refresh",
+            "request_id": request_id,
+            "kind": normalized_kind,
+            "account": account_filter,
+            "accounts": account_names,
+            "exchange": exchange.strip().lower(),
+            "symbol": symbol.strip(),
+        }
+        try:
+            await asyncio.to_thread(input_queue.put, message, True, 5.0)
+            result = await asyncio.wait_for(asyncio.shield(waiter), timeout=600.0)
+        except (queue.Full, ValueError, OSError) as exc:
+            raise AccountDataError("account worker request queue is unavailable") from exc
+        except TimeoutError as exc:
+            raise AccountDataError("account history refresh timed out") from exc
+        finally:
+            self._history_refresh_waiters.pop(request_id, None)
+            if not waiter.done():
+                waiter.cancel()
+
+        if result.get("status") != "ok":
+            error = result.get("error")
+            if not isinstance(error, dict):
+                errors = [
+                    item.get("error")
+                    for item in result.get("results", [])
+                    if isinstance(item, dict) and isinstance(item.get("error"), dict)
+                ]
+                error = errors[0] if errors else {}
+            message = str(error.get("message") or "account history refresh failed")
+            raise AccountDataError(message[:500])
+        return result
+
+    @staticmethod
+    def _history_response(page: dict[str, Any]) -> dict[str, Any]:
+        results = page.get("results")
+        results = results if isinstance(results, list) else []
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            exchange = str(result.get("exchange") or "")
+            result["exchange_logo_url"] = exchange_logo_url(exchange)
+        total = int(page.get("total") or 0)
+        return {
+            "schema_version": "1.0",
+            "collected_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "read_only": True,
+            "cached": True,
+            "results": results,
+            "next_cursor": page.get("next_cursor"),
+            "summary": {
+                "total": total,
+                "returned": len(results),
+                "has_more": bool(page.get("next_cursor")),
+            },
+        }
+
+    @staticmethod
+    def _history_group_response(
+        groups: dict[str, Any],
+        *,
+        exchange: str,
+    ) -> dict[str, Any]:
+        results = groups.get("results")
+        results = results if isinstance(results, list) else []
+        for result in results:
+            if not isinstance(result, dict):
+                continue
+            exchange_id = str(result.get("exchange") or "")
+            result["exchange_logo_url"] = exchange_logo_url(exchange_id)
+        return {
+            "schema_version": "1.0",
+            "collected_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "read_only": True,
+            "cached": True,
+            "group_by": "symbol" if exchange.strip() else "exchange",
+            "results": results,
+            "summary": {
+                "groups": len(results),
+                "total": int(groups.get("total") or 0),
+            },
+        }
 
     async def connect_live(self, ws: Any) -> None:
         await self.live_ws.connect(ws)
@@ -136,13 +372,18 @@ class AccountDataService:
                 return
             context = multiprocessing.get_context("spawn")
             self._live_output = context.Queue(maxsize=8)
+            self._live_control_output = context.Queue(maxsize=8)
+            self._live_input = context.Queue(maxsize=16)
             self._live_stop = context.Event()
+            self._positions_revision = 0
             self._live_process = context.Process(
                 target=run_positions_stream,
                 args=(
                     str(self.config_path),
                     str(self.cache_path),
                     self._live_output,
+                    self._live_control_output,
+                    self._live_input,
                     self._live_stop,
                     copy.deepcopy(self._positions),
                 ),
@@ -151,6 +392,9 @@ class AccountDataService:
             )
             self._live_process.start()
             self._live_reader = asyncio.create_task(self._read_live_output())
+            self._live_control_reader = asyncio.create_task(
+                self._read_live_control_output()
+            )
 
     async def _read_live_output(self) -> None:
         output = self._live_output
@@ -162,6 +406,15 @@ class AccountDataService:
                 return
             if not isinstance(payload, dict):
                 continue
+            raw_revision = payload.pop("_refresh_revision", 0)
+            revision = (
+                raw_revision
+                if isinstance(raw_revision, int)
+                and not isinstance(raw_revision, bool)
+                else 0
+            )
+            if revision < self._positions_revision:
+                continue
             payload = _add_exchange_logos(payload)
             self._positions = payload
             self._positions_at = time.monotonic()
@@ -169,15 +422,49 @@ class AccountDataService:
                 {"type": "account.positions", "payload": payload}
             )
 
+    async def _read_live_control_output(self) -> None:
+        output = self._live_control_output
+        if output is None:
+            return
+        while True:
+            message = await asyncio.to_thread(output.get)
+            if message is None:
+                for waiter in self._history_refresh_waiters.values():
+                    if not waiter.done():
+                        waiter.set_exception(AccountDataError("account worker stopped"))
+                return
+            if not isinstance(message, dict):
+                continue
+            if message.get("type") != "history.refresh.result":
+                continue
+            request_id = str(message.get("request_id") or "")
+            waiter = self._history_refresh_waiters.get(request_id)
+            payload = message.get("payload")
+            if waiter is None or waiter.done() or not isinstance(payload, dict):
+                continue
+            waiter.set_result(payload)
+
     async def _close_live_stream(self) -> None:
         process = self._live_process
         stop = self._live_stop
         reader = self._live_reader
+        control_reader = self._live_control_reader
         output = self._live_output
+        control_output = self._live_control_output
+        input_queue = self._live_input
         self._live_process = None
         self._live_stop = None
         self._live_reader = None
+        self._live_control_reader = None
         self._live_output = None
+        self._live_control_output = None
+        self._live_input = None
+        self._positions_revision = 0
+        waiters = list(self._history_refresh_waiters.values())
+        self._history_refresh_waiters.clear()
+        for waiter in waiters:
+            if not waiter.done():
+                waiter.set_exception(AccountDataError("account worker stopped"))
         if stop is not None:
             stop.set()
         if process is not None:
@@ -191,9 +478,21 @@ class AccountDataService:
             except TimeoutError:
                 reader.cancel()
                 await asyncio.gather(reader, return_exceptions=True)
+        if control_reader is not None and not control_reader.done():
+            try:
+                await asyncio.wait_for(control_reader, timeout=2)
+            except TimeoutError:
+                control_reader.cancel()
+                await asyncio.gather(control_reader, return_exceptions=True)
         if output is not None:
             output.close()
             await asyncio.to_thread(output.join_thread)
+        if control_output is not None:
+            control_output.close()
+            await asyncio.to_thread(control_output.join_thread)
+        if input_queue is not None:
+            input_queue.close()
+            await asyncio.to_thread(input_queue.join_thread)
 
     async def close(self) -> None:
         await self._close_live_stream()

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -756,6 +756,102 @@ def build_control_router(
             return JSONResponse({"error": str(exc)}, status_code=503)
         return JSONResponse(result)
 
+    @r.post("/api/account/history/refresh")
+    async def refresh_account_history(
+        payload: dict = Body(default_factory=dict),
+    ) -> JSONResponse:
+        values: dict[str, str] = {}
+        for field in ("kind", "account", "exchange", "symbol"):
+            value = payload.get(field, "")
+            if not isinstance(value, str):
+                return JSONResponse(
+                    {"error": f"{field} must be a string"},
+                    status_code=400,
+                )
+            values[field] = value
+        if values["kind"].strip().lower() not in {"order", "position"}:
+            return JSONResponse(
+                {"error": "kind must be order or position"},
+                status_code=400,
+            )
+        try:
+            result = await account_data_service.refresh_history(**values)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
+    @r.get("/api/account/position-history")
+    async def get_account_position_history(
+        cursor: str | None = None,
+        limit: int = 50,
+        account: str = "",
+        exchange: str = "",
+        symbol: str = "",
+        exact_market: bool = False,
+    ) -> JSONResponse:
+        try:
+            result = await account_data_service.position_history(
+                cursor=cursor,
+                limit=limit,
+                account=account,
+                exchange=exchange,
+                symbol=symbol,
+                exact_market=exact_market,
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
+    @r.get("/api/account/position-history/groups")
+    async def get_account_position_history_groups(
+        exchange: str = "",
+    ) -> JSONResponse:
+        try:
+            result = await account_data_service.position_history_groups(
+                exchange=exchange,
+            )
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
+    @r.get("/api/account/orders")
+    async def get_account_orders(
+        cursor: str | None = None,
+        limit: int = 50,
+        account: str = "",
+        exchange: str = "",
+        symbol: str = "",
+        status: str = "",
+        exact_market: bool = False,
+    ) -> JSONResponse:
+        try:
+            result = await account_data_service.order_history(
+                cursor=cursor,
+                limit=limit,
+                account=account,
+                exchange=exchange,
+                symbol=symbol,
+                status=status,
+                exact_market=exact_market,
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
+    @r.get("/api/account/orders/groups")
+    async def get_account_order_groups(exchange: str = "") -> JSONResponse:
+        try:
+            result = await account_data_service.order_history_groups(
+                exchange=exchange,
+            )
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
     @r.get("/api/assets/transfer/options")
     async def get_asset_transfer_options(
         exchange: str,

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -35,6 +35,7 @@ from registry import (
     SessionRegistry,
 )
 from runtime import Session
+from schedule_utils import seconds_until_bar_boundary_guard_end
 from config import (
     SessionSpec,
     default_webhook_url,
@@ -733,7 +734,14 @@ def build_control_router(
 
     @r.get("/api/assets")
     @r.get("/api/account/assets")
-    async def get_assets(refresh: bool = False) -> JSONResponse:
+    async def get_assets(
+        refresh: bool = False,
+        auto_refresh: bool = False,
+    ) -> JSONResponse:
+        if refresh and auto_refresh:
+            delay = seconds_until_bar_boundary_guard_end()
+            if delay > 0.0:
+                await asyncio.sleep(delay)
         try:
             result = await asset_portfolio_service.snapshot(force=refresh)
         except AssetPortfolioError as exc:

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -21,6 +21,7 @@ from pynecore.core.csv_file import CSVReader
 import ccxt.pro as ccxtpro
 
 from ai.provider.codex_service import CodexService
+from account_data import AccountDataError, AccountDataService
 from asset_portfolio import AssetPortfolioError, AssetPortfolioService
 from asset_transfer import AssetTransferError, AssetTransferService
 from calendar_store import CalendarEventStore, CalendarStoreError
@@ -693,6 +694,7 @@ def build_control_router(
     registry: SessionRegistry,
     codex_service: CodexService,
     calendar_store: CalendarEventStore,
+    account_data_service: AccountDataService,
     asset_portfolio_service: AssetPortfolioService,
     asset_transfer_service: AssetTransferService,
     update_service: UpdateService,
@@ -730,10 +732,19 @@ def build_control_router(
         return JSONResponse(result, status_code=202)
 
     @r.get("/api/assets")
+    @r.get("/api/account/assets")
     async def get_assets(refresh: bool = False) -> JSONResponse:
         try:
             result = await asset_portfolio_service.snapshot(force=refresh)
         except AssetPortfolioError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
+    @r.get("/api/account/positions")
+    async def get_account_positions(refresh: bool = False) -> JSONResponse:
+        try:
+            result = await account_data_service.positions(force=refresh)
+        except AccountDataError as exc:
             return JSONResponse({"error": str(exc)}, status_code=503)
         return JSONResponse(result)
 

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -862,6 +862,14 @@ def build_control_router(
             return JSONResponse({"error": str(exc)}, status_code=503)
         return JSONResponse(result)
 
+    @r.delete("/api/account/history/imports/{import_id}")
+    async def delete_account_history_import(import_id: str) -> JSONResponse:
+        try:
+            result = await account_data_service.delete_history_import(import_id)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        return JSONResponse(result)
+
     @r.post("/api/account/history/imports/{import_id}/retry-enrichment")
     async def retry_account_history_import_enrichment(
         import_id: str,
@@ -960,7 +968,7 @@ def build_control_router(
                 normalized_days = int(days)
             except ValueError:
                 return JSONResponse(
-                    {"error": "days must be 7, 30, 90, or all"},
+                    {"error": "days must be 7, 30, 90, 180, 365, or all"},
                     status_code=400,
                 )
         try:

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -852,6 +852,24 @@ def build_control_router(
             return JSONResponse({"error": str(exc)}, status_code=503)
         return JSONResponse(result)
 
+    @r.get("/api/account/pnl")
+    async def get_account_pnl(
+        days: int = 90,
+        account: str = "",
+        exchange: str = "",
+    ) -> JSONResponse:
+        try:
+            result = await account_data_service.pnl(
+                days=days,
+                account=account,
+                exchange=exchange,
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
     @r.get("/api/assets/transfer/options")
     async def get_asset_transfer_options(
         exchange: str,

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -9,7 +9,7 @@ from datetime import UTC, date, datetime
 from pathlib import Path
 from typing import Any, AsyncIterator, Dict, List, Optional
 
-from fastapi import APIRouter, Body, Request
+from fastapi import APIRouter, Body, File, Request, UploadFile
 from fastapi.responses import JSONResponse, StreamingResponse
 from markdown_it import MarkdownIt
 
@@ -22,6 +22,11 @@ import ccxt.pro as ccxtpro
 
 from ai.provider.codex_service import CodexService
 from account_data import AccountDataError, AccountDataService
+from account_service.csv_import import (
+    MAX_IMPORT_FILE_BYTES,
+    MAX_IMPORT_FILES,
+    MAX_IMPORT_TOTAL_BYTES,
+)
 from asset_portfolio import AssetPortfolioError, AssetPortfolioService
 from asset_transfer import AssetTransferError, AssetTransferService
 from calendar_store import CalendarEventStore, CalendarStoreError
@@ -780,6 +785,95 @@ def build_control_router(
             return JSONResponse({"error": str(exc)}, status_code=503)
         return JSONResponse(result)
 
+    @r.post("/api/account/history/import/preview")
+    async def preview_account_history_import(
+        files: list[UploadFile] = File(...),
+    ) -> JSONResponse:
+        if not files or len(files) > MAX_IMPORT_FILES:
+            return JSONResponse(
+                {"error": f"select between 1 and {MAX_IMPORT_FILES} CSV files"},
+                status_code=400,
+            )
+        uploads: list[tuple[str, bytes]] = []
+        total_size = 0
+        try:
+            for upload in files:
+                content = await upload.read(MAX_IMPORT_FILE_BYTES + 1)
+                if len(content) > MAX_IMPORT_FILE_BYTES:
+                    return JSONResponse(
+                        {"error": f"CSV is too large: {upload.filename or 'upload.csv'}"},
+                        status_code=413,
+                    )
+                total_size += len(content)
+                if total_size > MAX_IMPORT_TOTAL_BYTES:
+                    return JSONResponse(
+                        {"error": "combined CSV upload is too large"},
+                        status_code=413,
+                    )
+                uploads.append((upload.filename or "upload.csv", content))
+        finally:
+            for upload in files:
+                await upload.close()
+        try:
+            result = await account_data_service.preview_history_import(uploads)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        return JSONResponse(result)
+
+    @r.post("/api/account/history/import/commit")
+    async def commit_account_history_import(
+        payload: dict = Body(default_factory=dict),
+    ) -> JSONResponse:
+        try:
+            result = await account_data_service.commit_history_import(payload)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        return JSONResponse(result, status_code=202)
+
+    @r.delete("/api/account/history/import/previews/{preview_id}/files/{file_id}")
+    async def remove_account_history_import_preview_file(
+        preview_id: str,
+        file_id: str,
+    ) -> JSONResponse:
+        try:
+            result = await account_data_service.remove_history_import_preview_file(
+                preview_id,
+                file_id,
+            )
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=404)
+        return JSONResponse(result)
+
+    @r.get("/api/account/history/import/jobs/{job_id}")
+    async def get_account_history_import_job(job_id: str) -> JSONResponse:
+        try:
+            result = account_data_service.history_import_job(job_id)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=404)
+        return JSONResponse(result)
+
+    @r.get("/api/account/history/imports")
+    async def get_account_history_imports(limit: int = 100) -> JSONResponse:
+        try:
+            result = await account_data_service.history_imports(limit=limit)
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
+    @r.post("/api/account/history/imports/{import_id}/retry-enrichment")
+    async def retry_account_history_import_enrichment(
+        import_id: str,
+    ) -> JSONResponse:
+        try:
+            result = await account_data_service.retry_history_import_enrichment(
+                import_id
+            )
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        return JSONResponse(result, status_code=202)
+
     @r.get("/api/account/position-history")
     async def get_account_position_history(
         cursor: str | None = None,
@@ -854,13 +948,24 @@ def build_control_router(
 
     @r.get("/api/account/pnl")
     async def get_account_pnl(
-        days: int = 90,
+        days: str = "90",
         account: str = "",
         exchange: str = "",
     ) -> JSONResponse:
+        normalized_days: int | None
+        if days.strip().lower() == "all":
+            normalized_days = None
+        else:
+            try:
+                normalized_days = int(days)
+            except ValueError:
+                return JSONResponse(
+                    {"error": "days must be 7, 30, 90, or all"},
+                    status_code=400,
+                )
         try:
             result = await account_data_service.pnl(
-                days=days,
+                days=normalized_days,
                 account=account,
                 exchange=exchange,
             )

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -235,7 +235,11 @@ async def main() -> None:
         if update_finish_task is not None:
             update_finish_task.cancel()
             shutdown_tasks.append(update_finish_task)
-        await asyncio.gather(*shutdown_tasks, return_exceptions=True)
+        try:
+            await asyncio.gather(*shutdown_tasks, return_exceptions=True)
+        except asyncio.CancelledError:
+            # Ctrl-C can cancel this wait while child services still need to close.
+            pass
         heartbeat.cancel()
         try:
             await registry.shutdown()

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -162,7 +162,8 @@ async def main() -> None:
         _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
     )
     account_data_service = AccountDataService(
-        _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
+        _PROJECT_ROOT / "workdir" / "config" / "providers.toml",
+        cache_path=_PROJECT_ROOT / "workdir" / "data" / "cache" / "account_cache.sqlite",
     )
     asset_transfer_service = AssetTransferService(
         _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
@@ -199,6 +200,10 @@ async def main() -> None:
 
     await registry.start_all(specs)
     await asset_portfolio_service.start()
+    try:
+        await account_data_service.start()
+    except Exception as exc:
+        print(f"[account] service startup failed: {type(exc).__name__}: {exc}")
     heartbeat = asyncio.create_task(_hub_status_heartbeat(registry))
 
     server = uvicorn.Server(

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -182,6 +182,7 @@ async def main() -> None:
         ai_enabled=lambda: codex_service.enabled,
         request_shutdown=update_shutdown.set,
     )
+    await asyncio.to_thread(update_service.sync_dependencies_after_legacy_update)
     registry.set_ai_instruction_handler(codex_service.handle_strategy_instruction)
     try:
         await codex_service.start()

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -13,6 +13,7 @@ import uvicorn
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
 
 from ai.provider.codex_service import CodexService
+from account_data import AccountDataService
 from asset_portfolio import AssetPortfolioService
 from asset_transfer import AssetTransferService
 from calendar_store import CalendarEventStore
@@ -36,6 +37,7 @@ def build_app(
     registry: SessionRegistry,
     codex_service: CodexService,
     calendar_store: CalendarEventStore,
+    account_data_service: AccountDataService,
     asset_portfolio_service: AssetPortfolioService,
     asset_transfer_service: AssetTransferService,
     update_service: UpdateService,
@@ -47,6 +49,7 @@ def build_app(
             registry,
             codex_service,
             calendar_store,
+            account_data_service,
             asset_portfolio_service,
             asset_transfer_service,
             update_service,
@@ -72,6 +75,17 @@ def build_app(
             await registry.hub_ws.disconnect(ws)
         except Exception:
             await registry.hub_ws.disconnect(ws)
+
+    @app.websocket("/ws/account")
+    async def account_ws(ws: WebSocket):
+        await account_data_service.connect_live(ws)
+        try:
+            while True:
+                await ws.receive_text()
+        except WebSocketDisconnect:
+            await account_data_service.disconnect_live(ws)
+        except Exception:
+            await account_data_service.disconnect_live(ws)
 
     @app.websocket("/ws/{session_id}")
     async def session_ws(ws: WebSocket, session_id: str):
@@ -147,6 +161,9 @@ async def main() -> None:
     asset_portfolio_service = AssetPortfolioService(
         _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
     )
+    account_data_service = AccountDataService(
+        _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
+    )
     asset_transfer_service = AssetTransferService(
         _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
     )
@@ -174,6 +191,7 @@ async def main() -> None:
         registry,
         codex_service,
         calendar_store,
+        account_data_service,
         asset_portfolio_service,
         asset_transfer_service,
         update_service,
@@ -218,9 +236,12 @@ async def main() -> None:
             await registry.shutdown()
         finally:
             try:
-                await asset_portfolio_service.close()
+                await account_data_service.close()
             finally:
-                await codex_service.close()
+                try:
+                    await asset_portfolio_service.close()
+                finally:
+                    await codex_service.close()
     if update_shutdown.is_set():
         update_service.apply_and_restart()
 

--- a/data_service/schedule_utils.py
+++ b/data_service/schedule_utils.py
@@ -5,6 +5,8 @@ import time
 
 POST_BAR_TASK_OFFSET_SECONDS = 10.0
 POST_BAR_TASK_WINDOW_SECONDS = 10.0
+MANUAL_REFRESH_POST_BOUNDARY_GUARD_SECONDS = 5.0
+MANUAL_REFRESH_PRE_BOUNDARY_GUARD_SECONDS = 10.0
 
 
 def seconds_until_post_bar_task_slot(
@@ -47,4 +49,20 @@ def seconds_until_bar_boundary_guard_end(
     guard_start = 60.0 - POST_BAR_TASK_OFFSET_SECONDS
     if second >= guard_start:
         return 60.0 - second + POST_BAR_TASK_OFFSET_SECONDS
+    return 0.0
+
+
+def seconds_until_manual_refresh_guard_end(
+    now_seconds: float | None = None,
+) -> float:
+    """Delay manual refreshes from 10 seconds before to 5 seconds after a minute."""
+
+    current = time.time() if now_seconds is None else now_seconds
+    second = current % 60.0
+    post_guard = MANUAL_REFRESH_POST_BOUNDARY_GUARD_SECONDS
+    if second < post_guard:
+        return post_guard - second
+    guard_start = 60.0 - MANUAL_REFRESH_PRE_BOUNDARY_GUARD_SECONDS
+    if second >= guard_start:
+        return 60.0 - second + post_guard
     return 0.0

--- a/data_service/schedule_utils.py
+++ b/data_service/schedule_utils.py
@@ -33,3 +33,18 @@ def seconds_until_post_bar_task_window(
     if second < window_start:
         return window_start - second
     return 60.0 - second + window_start
+
+
+def seconds_until_bar_boundary_guard_end(
+    now_seconds: float | None = None,
+) -> float:
+    """Delay work during the 10 seconds before and after a minute boundary."""
+
+    current = time.time() if now_seconds is None else now_seconds
+    second = current % 60.0
+    if second < POST_BAR_TASK_OFFSET_SECONDS:
+        return POST_BAR_TASK_OFFSET_SECONDS - second
+    guard_start = 60.0 - POST_BAR_TASK_OFFSET_SECONDS
+    if second >= guard_start:
+        return 60.0 - second + POST_BAR_TASK_OFFSET_SECONDS
+    return 0.0

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -236,9 +236,35 @@ body {
 }
 .hub-submenu {
   display: grid;
-  margin: 0 8px 6px 36px;
+  max-height: 0;
+  margin: 0 8px 0 36px;
   padding-left: 9px;
+  overflow: hidden;
   border-left: 1px solid #2a3440;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-4px);
+  transition:
+    max-height 220ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    margin-bottom 220ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    opacity 150ms ease,
+    transform 180ms ease,
+    visibility 0s linear 220ms;
+}
+.hub-submenu.open {
+  max-height: 260px;
+  margin-bottom: 6px;
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition:
+    max-height 220ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    margin-bottom 220ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    opacity 150ms ease,
+    transform 180ms ease,
+    visibility 0s;
 }
 .hub-submenu-item {
   appearance: none;
@@ -297,9 +323,35 @@ body {
 }
 .hub-subsubmenu {
   display: grid;
-  margin: 0 0 4px 30px;
+  max-height: 0;
+  margin: 0 0 0 30px;
   padding-left: 9px;
+  overflow: hidden;
   border-left: 1px solid #2a3440;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-3px);
+  transition:
+    max-height 190ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    margin-bottom 190ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    opacity 140ms ease,
+    transform 170ms ease,
+    visibility 0s linear 190ms;
+}
+.hub-subsubmenu.open {
+  max-height: 68px;
+  margin-bottom: 4px;
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition:
+    max-height 190ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    margin-bottom 190ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    opacity 140ms ease,
+    transform 170ms ease,
+    visibility 0s;
 }
 .hub-subsubmenu-item {
   appearance: none;
@@ -1523,7 +1575,10 @@ tr:last-child td { border-bottom: none; }
   white-space: nowrap;
   cursor: pointer;
 }
-.account-tab-order-history span + span::before { content: " "; }
+.account-tab-history {
+  line-height: inherit;
+}
+.account-tab-history span + span::before { content: " "; }
 @media (hover: hover) and (pointer: fine) {
   .account-tab:hover { color: #d8dee7; }
 }
@@ -3170,11 +3225,12 @@ tr:last-child td { border-bottom: none; }
     text-align: center;
     white-space: normal;
   }
-  .account-tab-order-history {
+  .account-tab-history {
     flex-direction: column;
     gap: 0;
+    line-height: 1.15;
   }
-  .account-tab-order-history span + span::before { content: ""; }
+  .account-tab-history span + span::before { content: ""; }
   .account-view-body {
     padding: 12px;
     padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px));

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -246,24 +246,23 @@ body {
   pointer-events: none;
   transform: translateY(-4px);
   transition:
-    max-height 220ms cubic-bezier(0.22, 0.75, 0.25, 1),
-    margin-bottom 220ms cubic-bezier(0.22, 0.75, 0.25, 1),
-    opacity 150ms ease,
-    transform 180ms ease,
-    visibility 0s linear 220ms;
+    max-height 250ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    margin-bottom 250ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    opacity 190ms ease,
+    transform 230ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    visibility 0s linear 250ms;
 }
 .hub-submenu.open {
-  max-height: 260px;
   margin-bottom: 6px;
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
   transform: translateY(0);
   transition:
-    max-height 220ms cubic-bezier(0.22, 0.75, 0.25, 1),
-    margin-bottom 220ms cubic-bezier(0.22, 0.75, 0.25, 1),
-    opacity 150ms ease,
-    transform 180ms ease,
+    max-height 250ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    margin-bottom 250ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    opacity 190ms ease,
+    transform 230ms cubic-bezier(0.2, 0.7, 0.2, 1),
     visibility 0s;
 }
 .hub-submenu-item {
@@ -333,24 +332,23 @@ body {
   pointer-events: none;
   transform: translateY(-3px);
   transition:
-    max-height 190ms cubic-bezier(0.22, 0.75, 0.25, 1),
-    margin-bottom 190ms cubic-bezier(0.22, 0.75, 0.25, 1),
-    opacity 140ms ease,
-    transform 170ms ease,
-    visibility 0s linear 190ms;
+    max-height 210ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    margin-bottom 210ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    opacity 165ms ease,
+    transform 195ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    visibility 0s linear 210ms;
 }
 .hub-subsubmenu.open {
-  max-height: 68px;
   margin-bottom: 4px;
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
   transform: translateY(0);
   transition:
-    max-height 190ms cubic-bezier(0.22, 0.75, 0.25, 1),
-    margin-bottom 190ms cubic-bezier(0.22, 0.75, 0.25, 1),
-    opacity 140ms ease,
-    transform 170ms ease,
+    max-height 210ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    margin-bottom 210ms cubic-bezier(0.2, 0.7, 0.2, 1),
+    opacity 165ms ease,
+    transform 195ms cubic-bezier(0.2, 0.7, 0.2, 1),
     visibility 0s;
 }
 .hub-subsubmenu-item {
@@ -1533,6 +1531,11 @@ tr:last-child td { border-bottom: none; }
   width: min(1120px, 100%);
   max-height: calc(100vh - 32px);
 }
+/* desktop: animate the box height between account tabs of differing sizes so
+   switching settles smoothly instead of snapping (JS sets an inline height) */
+@media (min-width: 721px) {
+  .assets-modal-box { transition: height 260ms cubic-bezier(0.2, 0.7, 0.2, 1); }
+}
 .assets-modal-header { min-height: 50px; }
 .assets-title-group {
   flex: 1;
@@ -1600,6 +1603,10 @@ tr:last-child td { border-bottom: none; }
   min-height: 0;
   overflow: hidden;
 }
+#account-assets-view {
+  display: flex;
+  flex-direction: column;
+}
 .assets-body {
   flex: 1;
   min-height: 0;
@@ -1655,6 +1662,8 @@ tr:last-child td { border-bottom: none; }
   border-radius: 7px;
   background: #11161d;
 }
+/* Positions render as a plain vertical record list (desktop + mobile) */
+.account-position-live-logo { display: inline-flex; }
 .account-table {
   width: 100%;
   min-width: 1000px;
@@ -1798,6 +1807,380 @@ tr:last-child td { border-bottom: none; }
   color: #ff9b95;
   font-size: 10px;
   overflow-wrap: anywhere;
+}
+.account-history-view .account-view-body {
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+.account-history-navigation {
+  flex: none;
+  display: flex;
+  min-height: 42px;
+  align-items: center;
+  gap: 9px;
+  margin-bottom: 11px;
+  padding: 0 2px 11px;
+  border-bottom: 1px solid var(--border);
+}
+.account-history-navigation > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+.account-history-navigation strong {
+  overflow: hidden;
+  color: #f2f5f8;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-history-navigation span {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-history-back {
+  flex: none;
+  width: 32px;
+  height: 32px;
+}
+.account-history-groups {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+.account-history-group-list {
+  display: grid;
+  gap: 7px;
+}
+.account-history-group-row {
+  appearance: none;
+  display: grid;
+  width: 100%;
+  min-height: 58px;
+  grid-template-columns: minmax(0, 1fr) auto 18px;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #11161d;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+@media (hover: hover) and (pointer: fine) {
+  .account-history-group-row:hover {
+    border-color: #3a4656;
+    background: #151b23;
+  }
+  .account-history-groups {
+    scrollbar-color: #3a4350 #0b0e13;
+    scrollbar-width: thin;
+  }
+  .account-history-groups::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+  .account-history-groups::-webkit-scrollbar-track { background: #0b0e13; }
+  .account-history-groups::-webkit-scrollbar-thumb {
+    border: 2px solid #0b0e13;
+    border-radius: 999px;
+    background: #3a4350;
+  }
+  .account-history-groups::-webkit-scrollbar-thumb:hover { background: #4a5565; }
+}
+.account-history-group-identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+.account-history-group-copy {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+.account-history-group-copy strong {
+  overflow: hidden;
+  color: #e5eaf0;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-history-group-copy small,
+.account-history-group-summary small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-history-group-summary {
+  display: grid;
+  gap: 3px;
+  color: #dfe5ec;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.account-history-group-chevron {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: #748091;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+.account-history-details {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  flex-direction: column;
+}
+.account-history-filters {
+  display: grid;
+  grid-template-columns: minmax(160px, 240px);
+  gap: 7px;
+  margin-bottom: 11px;
+}
+.account-history-detail-filters { max-width: 460px; }
+.account-order-detail-filters {
+  max-width: 650px;
+  grid-template-columns: repeat(2, minmax(140px, 200px));
+}
+.account-history-filters input,
+.account-history-filters select {
+  width: 100%;
+  min-width: 0;
+  height: 32px;
+  padding: 0 9px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #0d1117;
+  color: var(--text);
+  font: inherit;
+  font-size: 11px;
+}
+.account-history-filters select { cursor: pointer; }
+.account-history-filters input:focus,
+.account-history-filters select:focus {
+  border-color: var(--accent);
+  outline: none;
+}
+.account-history-filters input::-webkit-search-cancel-button { display: none; }
+/* history filter custom dropdowns reuse the script-select skin */
+.account-history-select {
+  min-width: 0;
+  flex: none;
+  width: 100%;
+}
+.account-history-select .script-native-select {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  opacity: 0;
+  pointer-events: none;
+}
+.account-history-select .script-select-button {
+  min-width: 0;
+  height: 32px;
+  padding: 0 9px;
+  background: #0d1117;
+  font-size: 11px;
+}
+.account-history-select .script-select-label { font-size: 11px; }
+.account-history-select .script-select-option { padding: 7px 9px; font-size: 12px; }
+.account-history-select .script-select-empty { font-size: 12px; }
+.account-history-filters .btn-icon {
+  width: 32px;
+  height: 32px;
+}
+.account-history-meta {
+  min-height: 18px;
+  margin: 0 2px 8px;
+  color: var(--muted);
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.account-history-list-wrap {
+  flex: 1 1 0;
+  height: 0;
+  min-height: 320px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: #0d1117;
+  overscroll-behavior: contain;
+}
+.account-history-record-list { display: flex; flex-direction: column; }
+/* fade freshly rendered rows in so navigation / filter reloads don't flash */
+@keyframes accountHistoryFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+.account-history-record,
+.account-history-group-row {
+  animation: accountHistoryFadeIn 180ms ease both;
+}
+@media (prefers-reduced-motion: reduce) {
+  .account-history-record,
+  .account-history-group-row { animation: none; }
+}
+.account-history-record {
+  display: grid;
+  gap: 11px;
+  padding: 13px 18px;
+  border-bottom: 1px solid #222a34;
+}
+.account-history-record:last-child { border-bottom: 0; }
+.account-history-record-header {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 18px;
+}
+.account-history-record-identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+.account-history-record-copy {
+  display: grid;
+  min-width: 0;
+  gap: 4px;
+}
+.account-history-record-symbol {
+  display: flex;
+  min-width: 0;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 7px;
+}
+.account-history-record-symbol strong {
+  overflow: hidden;
+  color: #edf2f7;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-history-record-symbol span {
+  color: #aeb7c2;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.account-history-record-symbol .account-position-long { color: #4ed69c; }
+.account-history-record-symbol .account-position-short { color: #ff7f79; }
+.account-history-record-symbol .account-position-partially-closed { color: #f2cc60; }
+.account-history-record-symbol .account-position-fully-closed { color: #8f9aa7; }
+.account-history-record-copy small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-history-record-trailing {
+  display: grid;
+  flex: none;
+  gap: 4px;
+  justify-items: end;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.account-history-record-trailing > span {
+  color: var(--muted);
+  font-size: 9px;
+}
+.account-history-record-metrics {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  gap: 18px;
+}
+.account-history-record-metric {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+  justify-items: end;
+  text-align: right;
+}
+.account-history-record-metric > span {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 9px;
+  line-height: 1.2;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-history-record-metric > strong {
+  overflow: hidden;
+  color: #dfe5ec;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  font-weight: 550;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.account-history-record-metric > .account-pnl-positive { color: #4ed69c; }
+.account-history-record-metric > .account-pnl-negative { color: #ff7f79; }
+.account-history-record-metric > .account-history-source { color: var(--muted); }
+@media (hover: hover) and (pointer: fine) {
+  .account-history-list-wrap {
+    scrollbar-color: #3a4350 #0b0e13;
+    scrollbar-width: thin;
+  }
+  .account-history-list-wrap::-webkit-scrollbar { width: 10px; }
+  .account-history-list-wrap::-webkit-scrollbar-track { background: #0b0e13; }
+  .account-history-list-wrap::-webkit-scrollbar-thumb {
+    border: 2px solid #0b0e13;
+    border-radius: 999px;
+    background: #3a4350;
+  }
+  .account-history-list-wrap::-webkit-scrollbar-thumb:hover { background: #4a5565; }
+}
+.account-history-source {
+  color: var(--muted);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+.account-order-status {
+  color: #aeb7c2;
+  text-transform: capitalize;
+}
+.account-order-status-filled,
+.account-order-status-closed { color: #4ed69c; }
+.account-order-status-canceled,
+.account-order-status-cancelled,
+.account-order-status-rejected,
+.account-order-status-expired { color: #ff7f79; }
+.account-order-status-open,
+.account-order-status-new,
+.account-order-status-partially-filled { color: #f2cc60; }
+.account-history-more {
+  display: flex;
+  justify-content: center;
+  min-height: 28px;
+  margin-top: 10px;
+}
+.account-history-more .btn {
+  min-width: 112px;
+  font-size: 11px;
 }
 .assets-summary {
   display: flex;
@@ -3235,6 +3618,42 @@ tr:last-child td { border-bottom: none; }
     padding: 12px;
     padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px));
   }
+  .account-history-navigation {
+    min-height: 39px;
+    margin-bottom: 9px;
+    padding-bottom: 9px;
+  }
+  .account-history-group-row {
+    min-height: 62px;
+    grid-template-columns: minmax(0, 1fr) auto 16px;
+    gap: 9px;
+    padding: 10px 11px;
+  }
+  .account-history-details {
+    overflow-y: auto;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+  }
+  .account-history-filters {
+    max-width: none;
+    grid-template-columns: minmax(0, 1fr);
+    gap: 7px;
+  }
+  .account-order-detail-filters {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+  .account-history-filters input,
+  .account-history-filters select {
+    height: 34px;
+    font-size: 11px;
+  }
+  .account-history-select .script-select-button { height: 34px; }
+  .account-history-filters .btn-icon {
+    width: 34px;
+    height: 34px;
+  }
+  .account-history-meta { margin-bottom: 7px; }
+  .account-history-more { margin-top: 8px; }
   .account-summary {
     align-items: center;
     gap: 12px;
@@ -3248,6 +3667,41 @@ tr:last-child td { border-bottom: none; }
     border: 0;
     border-radius: 0;
     background: transparent;
+  }
+  .account-history-list-wrap {
+    flex: none;
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+    border-radius: 0;
+    background: transparent;
+  }
+  .account-history-record { gap: 10px; padding: 14px 2px; }
+  .account-history-record-header { gap: 12px; align-items: flex-start; }
+  .account-history-record-symbol { gap: 5px; }
+  .account-history-record-symbol strong { font-size: 13px; }
+  .account-history-record-trailing { font-size: 11px; }
+  /* Binance-mobile style: one field per row, label left / value right */
+  .account-history-record-metrics {
+    grid-auto-flow: row;
+    grid-template-columns: 1fr;
+    gap: 0;
+    padding-left: 0;
+  }
+  .account-history-record-metric {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 8px 1px;
+    border-top: 1px solid #1b222c;
+  }
+  .account-history-record-metric > span { font-size: 11px; }
+  .account-history-record-metric > strong {
+    flex: none;
+    max-width: 62%;
+    font-size: 12px;
+    text-align: right;
   }
   .account-table {
     display: block;

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -1716,6 +1716,59 @@ tr:last-child td { border-bottom: none; }
   font-size: 11px;
   line-height: 1.45;
 }
+.history-import-description {
+  display: inline;
+}
+.history-import-help {
+  position: relative;
+  display: inline-flex;
+  vertical-align: middle;
+}
+.history-import-help > button {
+  width: 17px;
+  height: 17px;
+  margin: 0 0 1px 3px;
+  padding: 0;
+  border: 1px solid #465261;
+  border-radius: 50%;
+  background: #161b22;
+  color: #aeb8c4;
+  font: inherit;
+  font-size: 10px;
+  font-weight: 700;
+  line-height: 15px;
+  cursor: help;
+}
+.history-import-help-popover {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 7px);
+  right: 0;
+  width: min(390px, calc(100vw - 48px));
+  display: none;
+  gap: 4px;
+  padding: 10px 11px;
+  border: 1px solid #3a4655;
+  border-radius: 6px;
+  background: #111820;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, .38);
+  color: var(--muted);
+  font-size: 10px;
+  line-height: 1.45;
+}
+.history-import-help-popover strong {
+  color: #e4e9ef;
+  font-size: 10px;
+  font-weight: 650;
+}
+.history-import-help.show .history-import-help-popover {
+  display: grid;
+}
+@media (hover: hover) and (pointer: fine) {
+  .history-import-help:hover .history-import-help-popover {
+    display: grid;
+  }
+}
 .history-import-dropzone {
   appearance: none;
   width: 100%;
@@ -1973,6 +2026,10 @@ tr:last-child td { border-bottom: none; }
   border-bottom: 1px solid #222a34;
 }
 .history-import-log-row:last-child { border-bottom: 0; }
+.history-import-log-row.is-deleting {
+  opacity: .5;
+  pointer-events: none;
+}
 .history-import-log-logo {
   width: 22px;
   height: 22px;
@@ -2634,6 +2691,7 @@ tr:last-child td { border-bottom: none; }
   font-size: 11px;
   font-variant-numeric: tabular-nums;
   font-weight: 550;
+  line-height: 1.3;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -1769,6 +1769,15 @@ tr:last-child td { border-bottom: none; }
     display: grid;
   }
 }
+@media (max-width: 720px) {
+  .history-import-heading { position: relative; }
+  .history-import-help { position: static; }
+  .history-import-help-popover {
+    right: 0;
+    left: 0;
+    width: auto;
+  }
+}
 .history-import-dropzone {
   appearance: none;
   width: 100%;

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -1607,6 +1607,10 @@ tr:last-child td { border-bottom: none; }
   display: flex;
   flex-direction: column;
 }
+#account-pnl-view {
+  display: flex;
+  flex-direction: column;
+}
 .assets-body {
   flex: 1;
   min-height: 0;
@@ -1649,12 +1653,155 @@ tr:last-child td { border-bottom: none; }
   font-size: 24px;
   font-variant-numeric: tabular-nums;
 }
+.account-summary strong.account-pnl-positive { color: #4ed69c; }
+.account-summary strong.account-pnl-negative { color: #ff7f79; }
 .account-summary-meta {
   display: grid;
   gap: 4px;
   color: var(--muted);
   font-size: 11px;
   text-align: right;
+}
+.pnl-view-body {
+  flex: 1;
+  height: auto;
+  display: flex;
+  min-height: 0;
+  flex-direction: column;
+  overflow: hidden;
+}
+.pnl-summary-totals {
+  display: grid;
+  gap: 3px;
+}
+.pnl-summary-value {
+  display: block;
+  white-space: nowrap;
+}
+.account-history-record-symbol .account-pnl-partial { color: #f2cc60; }
+.pnl-period-control {
+  display: inline-flex;
+  align-self: flex-start;
+  margin: 0 0 12px 2px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #0d1117;
+}
+.pnl-period-control button {
+  min-width: 44px;
+  height: 27px;
+  padding: 0 10px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 10px;
+  font-weight: 650;
+  cursor: pointer;
+}
+.pnl-period-control button.active {
+  background: #26313e;
+  color: #f2f5f8;
+}
+.pnl-period-control button:focus-visible {
+  outline: 2px solid #58a6ff;
+  outline-offset: 1px;
+}
+.pnl-list {
+  flex: 1 1 0;
+  height: 0;
+  overflow-x: hidden;
+  overflow-y: auto;
+  min-height: 180px;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: #0d1117;
+  overscroll-behavior: contain;
+}
+.account-pnl-record { animation: none; }
+.pnl-list.pnl-exchange-overview {
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #11161d;
+}
+.pnl-exchange-row {
+  appearance: none;
+  width: 100%;
+  min-height: 68px;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto 18px;
+  align-items: center;
+  gap: 14px;
+  padding: 12px 14px;
+  border: 0;
+  border-bottom: 1px solid #222a34;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+  transition: background 120ms ease;
+}
+.pnl-exchange-row:last-child { border-bottom: 0; }
+.pnl-exchange-row:hover { background: #171e27; }
+.pnl-exchange-row:focus-visible {
+  position: relative;
+  z-index: 1;
+  outline: 2px solid #58a6ff;
+  outline-offset: -2px;
+}
+.pnl-exchange-identity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 9px;
+}
+.pnl-exchange-logo {
+  display: inline-flex;
+  flex: none;
+}
+.pnl-exchange-totals {
+  display: grid;
+  gap: 4px;
+  justify-items: end;
+  font-variant-numeric: tabular-nums;
+}
+.pnl-exchange-total {
+  font-size: 12px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+.pnl-coverage-note {
+  padding: 10px 2px 0;
+  color: var(--muted);
+  font-size: 10px;
+  text-align: right;
+}
+@media (min-width: 721px) {
+  .pnl-list.pnl-list-sized {
+    flex: 0 0 auto;
+    height: var(--pnl-list-height);
+    min-height: 0;
+    overflow-y: hidden;
+  }
+  .pnl-list.pnl-list-sized.pnl-list-scrollable { overflow-y: auto; }
+}
+@media (hover: hover) and (pointer: fine) {
+  .pnl-list {
+    scrollbar-color: #3a4350 #0b0e13;
+    scrollbar-width: thin;
+  }
+  .pnl-list::-webkit-scrollbar { width: 10px; }
+  .pnl-list::-webkit-scrollbar-track { background: #0b0e13; }
+  .pnl-list::-webkit-scrollbar-thumb {
+    border: 2px solid #0b0e13;
+    border-radius: 999px;
+    background: #3a4350;
+  }
 }
 .account-table-wrap {
   overflow: auto;
@@ -2032,12 +2179,14 @@ tr:last-child td { border-bottom: none; }
   to { opacity: 1; }
 }
 .account-history-record,
-.account-history-group-row {
+.account-history-group-row,
+.pnl-exchange-row {
   animation: accountHistoryFadeIn 180ms ease both;
 }
 @media (prefers-reduced-motion: reduce) {
   .account-history-record,
-  .account-history-group-row { animation: none; }
+  .account-history-group-row,
+  .pnl-exchange-row { animation: none; }
 }
 .account-history-record {
   display: grid;
@@ -3618,6 +3767,16 @@ tr:last-child td { border-bottom: none; }
     padding: 12px;
     padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px));
   }
+  .pnl-view-body {
+    overflow-y: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .pnl-list {
+    flex: none;
+    height: auto;
+    min-height: 0;
+    overflow: visible;
+  }
   .account-history-navigation {
     min-height: 39px;
     margin-bottom: 9px;
@@ -3677,6 +3836,10 @@ tr:last-child td { border-bottom: none; }
     background: transparent;
   }
   .account-history-record { gap: 10px; padding: 14px 2px; }
+  .account-pnl-record {
+    padding-right: 20px;
+    padding-left: 20px;
+  }
   .account-history-record-header { gap: 12px; align-items: flex-start; }
   .account-history-record-symbol { gap: 5px; }
   .account-history-record-symbol strong { font-size: 13px; }

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -24,6 +24,8 @@ body {
   .log-content,
   .calendar-body,
   .assets-body,
+  .account-view-body,
+  .account-table-wrap,
   .asset-transfer-body,
   .integrity-issues,
   .calendar-forecast-content,
@@ -36,6 +38,8 @@ body {
   .log-content::-webkit-scrollbar,
   .calendar-body::-webkit-scrollbar,
   .assets-body::-webkit-scrollbar,
+  .account-view-body::-webkit-scrollbar,
+  .account-table-wrap::-webkit-scrollbar,
   .asset-transfer-body::-webkit-scrollbar,
   .integrity-issues::-webkit-scrollbar,
   .calendar-forecast-content::-webkit-scrollbar,
@@ -48,6 +52,8 @@ body {
   .log-content::-webkit-scrollbar-track,
   .calendar-body::-webkit-scrollbar-track,
   .assets-body::-webkit-scrollbar-track,
+  .account-view-body::-webkit-scrollbar-track,
+  .account-table-wrap::-webkit-scrollbar-track,
   .asset-transfer-body::-webkit-scrollbar-track,
   .integrity-issues::-webkit-scrollbar-track,
   .calendar-forecast-content::-webkit-scrollbar-track,
@@ -59,6 +65,8 @@ body {
   .log-content::-webkit-scrollbar-thumb,
   .calendar-body::-webkit-scrollbar-thumb,
   .assets-body::-webkit-scrollbar-thumb,
+  .account-view-body::-webkit-scrollbar-thumb,
+  .account-table-wrap::-webkit-scrollbar-thumb,
   .asset-transfer-body::-webkit-scrollbar-thumb,
   .integrity-issues::-webkit-scrollbar-thumb,
   .calendar-forecast-content::-webkit-scrollbar-thumb,
@@ -72,6 +80,8 @@ body {
   .log-content::-webkit-scrollbar-thumb:hover,
   .calendar-body::-webkit-scrollbar-thumb:hover,
   .assets-body::-webkit-scrollbar-thumb:hover,
+  .account-view-body::-webkit-scrollbar-thumb:hover,
+  .account-table-wrap::-webkit-scrollbar-thumb:hover,
   .asset-transfer-body::-webkit-scrollbar-thumb:hover,
   .integrity-issues::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-content::-webkit-scrollbar-thumb:hover,
@@ -83,6 +93,8 @@ body {
   .log-content::-webkit-scrollbar-corner,
   .calendar-body::-webkit-scrollbar-corner,
   .assets-body::-webkit-scrollbar-corner,
+  .account-view-body::-webkit-scrollbar-corner,
+  .account-table-wrap::-webkit-scrollbar-corner,
   .asset-transfer-body::-webkit-scrollbar-corner,
   .integrity-issues::-webkit-scrollbar-corner {
     background: #0b0e13;
@@ -190,14 +202,124 @@ body {
   outline: none;
 }
 .hub-menu-emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
   width: 24px;
   font-size: 18px;
   line-height: 1;
   text-align: center;
 }
-/* the money-bag glyph fills its em square more than the calendar's, so it reads
-   wider at the same font-size — nudge it down to match Calendar's footprint */
-#hub-assets-open .hub-menu-emoji { font-size: 16px; }
+.hub-menu-glyph {
+  width: 20px;
+  height: 20px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.hub-menu-parent-chevron {
+  width: 15px;
+  height: 15px;
+  margin-left: auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform 160ms ease;
+}
+.hub-menu-parent[aria-expanded="true"] .hub-menu-parent-chevron {
+  transform: rotate(90deg);
+}
+.hub-submenu {
+  display: grid;
+  margin: 0 8px 6px 36px;
+  padding-left: 9px;
+  border-left: 1px solid #2a3440;
+}
+.hub-submenu-item {
+  appearance: none;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-height: 34px;
+  padding: 6px 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: #9ca8b7;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+.hub-submenu-item:hover,
+.hub-submenu-item:focus-visible {
+  background: #1b232d;
+  color: #ffffff;
+  outline: none;
+}
+.hub-submenu-emoji {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex: none;
+  width: 20px;
+  font-size: 14px;
+  line-height: 1;
+  text-align: center;
+}
+.hub-submenu-glyph {
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.hub-submenu-parent-chevron {
+  width: 13px;
+  height: 13px;
+  margin-left: auto;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transition: transform 160ms ease;
+}
+.hub-submenu-parent[aria-expanded="true"] .hub-submenu-parent-chevron {
+  transform: rotate(90deg);
+}
+.hub-subsubmenu {
+  display: grid;
+  margin: 0 0 4px 30px;
+  padding-left: 9px;
+  border-left: 1px solid #2a3440;
+}
+.hub-subsubmenu-item {
+  appearance: none;
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: #8b95a3;
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+.hub-subsubmenu-item:hover,
+.hub-subsubmenu-item:focus-visible {
+  background: #1b232d;
+  color: #ffffff;
+  outline: none;
+}
 .hub-menu-footer {
   position: relative;
   margin-top: auto;
@@ -1356,7 +1478,7 @@ tr:last-child td { border-bottom: none; }
 /* ---- account assets ---- */
 .assets-modal { z-index: 80; }
 .assets-modal-box {
-  width: min(1000px, 100%);
+  width: min(1120px, 100%);
   max-height: calc(100vh - 32px);
 }
 .assets-modal-header { min-height: 50px; }
@@ -1377,6 +1499,52 @@ tr:last-child td { border-bottom: none; }
 }
 #assets-back { flex: none; }
 .assets-modal button { touch-action: manipulation; }
+.account-tabs {
+  flex: none;
+  display: flex;
+  gap: 3px;
+  overflow-x: auto;
+  padding: 8px 12px 0;
+  border-bottom: 1px solid var(--border);
+  scrollbar-width: none;
+}
+.account-tabs::-webkit-scrollbar { display: none; }
+.account-tab {
+  appearance: none;
+  position: relative;
+  flex: none;
+  min-height: 35px;
+  padding: 7px 10px 9px;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 12px;
+  white-space: nowrap;
+  cursor: pointer;
+}
+.account-tab-order-history span + span::before { content: " "; }
+@media (hover: hover) and (pointer: fine) {
+  .account-tab:hover { color: #d8dee7; }
+}
+.account-tab.active {
+  color: #f2f5f8;
+  font-weight: 600;
+}
+.account-tab.active::after {
+  content: "";
+  position: absolute;
+  right: 8px;
+  bottom: -1px;
+  left: 8px;
+  height: 2px;
+  background: #58a6ff;
+}
+.account-view {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
 .assets-body {
   flex: 1;
   min-height: 0;
@@ -1384,6 +1552,197 @@ tr:last-child td { border-bottom: none; }
   padding: 18px;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
+}
+.account-view-body {
+  height: 100%;
+  min-height: 0;
+  overflow: auto;
+  padding: 18px;
+  overscroll-behavior: contain;
+}
+.account-view-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  font-size: 13px;
+}
+.account-summary {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 14px;
+  padding: 0 2px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.account-summary-label {
+  display: block;
+  margin-bottom: 5px;
+  color: var(--muted);
+  font-size: 11px;
+}
+.account-summary strong {
+  color: #f2f5f8;
+  font-size: 24px;
+  font-variant-numeric: tabular-nums;
+}
+.account-summary-meta {
+  display: grid;
+  gap: 4px;
+  color: var(--muted);
+  font-size: 11px;
+  text-align: right;
+}
+.account-table-wrap {
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #11161d;
+}
+.account-table {
+  width: 100%;
+  min-width: 1000px;
+  table-layout: fixed;
+  border-collapse: collapse;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+}
+.account-table th,
+.account-table td {
+  padding: 10px 11px;
+  border-bottom: 1px solid #222a34;
+  text-align: right;
+  white-space: nowrap;
+}
+.account-table th:nth-child(1),
+.account-table td:nth-child(1) { width: 110px; }
+.account-table th:nth-child(2),
+.account-table td:nth-child(2) { width: 125px; }
+.account-table th:nth-child(3),
+.account-table td:nth-child(3) { width: 55px; }
+.account-table th:nth-child(4),
+.account-table td:nth-child(4) { width: 75px; }
+.account-table th:nth-child(5),
+.account-table td:nth-child(5),
+.account-table th:nth-child(6),
+.account-table td:nth-child(6) { width: 90px; }
+.account-table th:nth-child(7),
+.account-table td:nth-child(7),
+.account-table th:nth-child(8),
+.account-table td:nth-child(8) { width: 110px; }
+.account-table th:nth-child(9),
+.account-table td:nth-child(9) { width: 70px; }
+.account-table th:nth-child(10),
+.account-table td:nth-child(10) { width: 65px; }
+.account-table th:nth-child(11),
+.account-table td:nth-child(11) { width: 100px; }
+.account-table th:first-child,
+.account-table th:nth-child(2),
+.account-table td:first-child,
+.account-table td:nth-child(2) {
+  text-align: left;
+}
+.account-table th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: #171e27;
+  color: #8995a5;
+  font-size: 10px;
+  font-weight: 600;
+}
+.account-table tbody tr:last-child td { border-bottom: 0; }
+.account-table-account {
+  color: #dfe5ec;
+  font-weight: 600;
+}
+.account-table-account .exchange-logo {
+  margin-right: 7px;
+  vertical-align: middle;
+}
+.account-table-account-name { vertical-align: middle; }
+.account-table-account small,
+.account-table-symbol small {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 500;
+  text-transform: uppercase;
+}
+.account-table-account,
+.account-table-symbol {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.account-position-long,
+.account-pnl-positive { color: #4ed69c; }
+.account-position-short,
+.account-pnl-negative { color: #ff7f79; }
+.position-pnl-value {
+  appearance: none;
+  padding: 0 0 1px;
+  border: 0;
+  border-bottom: 1px dashed currentColor;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  font-variant-numeric: tabular-nums;
+  cursor: pointer;
+}
+.position-pnl-value:focus-visible {
+  color: #f2f5f8;
+  outline: none;
+}
+@media (hover: hover) and (pointer: fine) {
+  .position-pnl-value:hover { color: #f2f5f8; }
+}
+.position-pnl-popover {
+  position: fixed;
+  z-index: 95;
+  width: min(230px, calc(100vw - 24px));
+  padding: 12px;
+  border: 1px solid #344050;
+  border-radius: 7px;
+  background: #0b0e13;
+  color: var(--text);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.48);
+  font-size: 11px;
+}
+.position-pnl-popover strong {
+  display: block;
+  margin-bottom: 8px;
+  color: #f2f5f8;
+  font-size: 12px;
+}
+.position-pnl-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 5px 0;
+  color: var(--muted);
+}
+.position-pnl-row > :last-child { color: var(--text); }
+.position-pnl-net-row {
+  margin-top: 3px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+  font-weight: 600;
+}
+.position-pnl-note {
+  margin-top: 8px;
+  color: var(--muted);
+  line-height: 1.4;
+}
+.account-errors {
+  display: grid;
+  gap: 6px;
+  margin-top: 12px;
+  color: #ff9b95;
+  font-size: 10px;
+  overflow-wrap: anywhere;
 }
 .assets-summary {
   display: flex;
@@ -2789,6 +3148,123 @@ tr:last-child td { border-bottom: none; }
     padding: 12px;
     padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px));
   }
+  .account-tabs {
+    display: grid;
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+    gap: 0;
+    overflow: hidden;
+    padding-right: 5px;
+    padding-left: 5px;
+    touch-action: manipulation;
+  }
+  .account-tab {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    min-height: 42px;
+    align-items: center;
+    justify-content: center;
+    padding: 6px 2px 8px;
+    font-size: 10px;
+    line-height: 1.15;
+    text-align: center;
+    white-space: normal;
+  }
+  .account-tab-order-history {
+    flex-direction: column;
+    gap: 0;
+  }
+  .account-tab-order-history span + span::before { content: ""; }
+  .account-view-body {
+    padding: 12px;
+    padding-bottom: calc(18px + env(safe-area-inset-bottom, 0px));
+  }
+  .account-summary {
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 12px;
+    padding: 2px 2px 13px;
+  }
+  .account-summary strong { font-size: 20px; }
+  .account-summary-meta { font-size: 10px; }
+  .account-table-wrap {
+    overflow: visible;
+    border: 0;
+    border-radius: 0;
+    background: transparent;
+  }
+  .account-table {
+    display: block;
+    width: 100%;
+    min-width: 0;
+    table-layout: auto;
+  }
+  .account-table thead { display: none; }
+  .account-table tbody {
+    display: flex;
+    gap: 12px;
+    overflow-x: auto;
+    overflow-y: hidden;
+    scroll-snap-type: x mandatory;
+    overscroll-behavior-x: contain;
+    -webkit-overflow-scrolling: touch;
+    padding: 0 0 6px;
+    scrollbar-width: none;
+  }
+  .account-table tbody::-webkit-scrollbar { display: none; }
+  .account-table tr {
+    display: block;
+    flex: 0 0 90%;
+    width: auto;
+    min-width: 0;
+    scroll-snap-align: start;
+    padding: 2px 12px;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: #11161d;
+  }
+  .account-table td,
+  .account-table td:nth-child(n) {
+    display: flex;
+    width: 100%;
+    min-width: 0;
+    min-height: 0;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 6px;
+    padding: 9px 0;
+    border-bottom: 1px solid #222a34;
+    text-align: right;
+    white-space: normal;
+    overflow-wrap: anywhere;
+  }
+  .account-table tbody tr:last-child td {
+    border-bottom: 1px solid #222a34;
+  }
+  .account-table tr td:last-child,
+  .account-table tbody tr:last-child td:last-child { border-bottom: 0; }
+  .account-table td::before {
+    content: attr(data-label);
+    margin-right: auto;
+    color: var(--muted);
+    font-size: 11px;
+    font-weight: 600;
+    line-height: 1;
+    text-align: left;
+    text-transform: uppercase;
+  }
+  .account-table td small {
+    display: inline;
+    flex: none;
+    margin-top: 0;
+    margin-left: 1px;
+  }
+  .account-table-account,
+  .account-table-symbol {
+    overflow: visible;
+    text-overflow: clip;
+  }
   .assets-summary {
     align-items: center;
     gap: 12px;
@@ -2862,10 +3338,10 @@ tr:last-child td { border-bottom: none; }
   .script-select-button { min-width: 0; }
   #script-refresh { width: auto; min-width: 42px; }
 
-  table thead { display: none; }
-  table { display: block; width: 100%; }
+  #sessions thead { display: none; }
+  #sessions { display: block; width: 100%; }
   /* swipe sideways through session cards instead of scrolling down */
-  tbody {
+  #sessions > tbody {
     display: flex;
     gap: 12px;
     overflow-x: auto;
@@ -2876,7 +3352,7 @@ tr:last-child td { border-bottom: none; }
     scrollbar-width: none;
   }
   #sessions > tbody::-webkit-scrollbar { display: none; }
-  tr {
+  #sessions > tbody > tr {
     display: block;
     flex: 0 0 90%;            /* ~one card per view, next card peeks */
     scroll-snap-align: start;
@@ -2885,7 +3361,7 @@ tr:last-child td { border-bottom: none; }
     padding: 2px 12px;
     background: var(--bg);
   }
-  td {
+  #sessions > tbody > tr > td {
     display: flex;
     width: 100%;
     align-items: center;
@@ -2897,19 +3373,19 @@ tr:last-child td { border-bottom: none; }
   }
   /* carousel: the last card is the last <tr>, so undo the global
      "tr:last-child td { border-bottom:none }" that would strip its dividers */
-  tr:last-child td { border-bottom: 1px solid var(--border); }
-  tr td:last-child { border-bottom: none; }
-  td::before {
+  #sessions > tbody > tr:last-child > td { border-bottom: 1px solid var(--border); }
+  #sessions > tbody > tr > td:last-child { border-bottom: none; }
+  #sessions > tbody > tr > td::before {
     content: attr(data-label);
     color: var(--muted);
     font-size: 12px;
     text-align: left;
     flex-shrink: 0;
   }
-  td.mono { word-break: break-all; }
+  #sessions td.mono { word-break: break-all; }
   /* keep the "Runner" label left-aligned like other rows; push buttons right */
-  td.runner-cell { justify-content: flex-start; gap: 6px; }
-  td.runner-cell::before { margin-right: auto; }
+  #sessions td.runner-cell { justify-content: flex-start; gap: 6px; }
+  #sessions td.runner-cell::before { margin-right: auto; }
   .runner-actions {
     flex-wrap: wrap;
     justify-content: flex-end;

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -26,6 +26,8 @@ body {
   .assets-body,
   .account-view-body,
   .account-table-wrap,
+  .history-import-log-list,
+  .history-import-select-options,
   .asset-transfer-body,
   .integrity-issues,
   .calendar-forecast-content,
@@ -40,6 +42,8 @@ body {
   .assets-body::-webkit-scrollbar,
   .account-view-body::-webkit-scrollbar,
   .account-table-wrap::-webkit-scrollbar,
+  .history-import-log-list::-webkit-scrollbar,
+  .history-import-select-options::-webkit-scrollbar,
   .asset-transfer-body::-webkit-scrollbar,
   .integrity-issues::-webkit-scrollbar,
   .calendar-forecast-content::-webkit-scrollbar,
@@ -54,6 +58,8 @@ body {
   .assets-body::-webkit-scrollbar-track,
   .account-view-body::-webkit-scrollbar-track,
   .account-table-wrap::-webkit-scrollbar-track,
+  .history-import-log-list::-webkit-scrollbar-track,
+  .history-import-select-options::-webkit-scrollbar-track,
   .asset-transfer-body::-webkit-scrollbar-track,
   .integrity-issues::-webkit-scrollbar-track,
   .calendar-forecast-content::-webkit-scrollbar-track,
@@ -67,6 +73,8 @@ body {
   .assets-body::-webkit-scrollbar-thumb,
   .account-view-body::-webkit-scrollbar-thumb,
   .account-table-wrap::-webkit-scrollbar-thumb,
+  .history-import-log-list::-webkit-scrollbar-thumb,
+  .history-import-select-options::-webkit-scrollbar-thumb,
   .asset-transfer-body::-webkit-scrollbar-thumb,
   .integrity-issues::-webkit-scrollbar-thumb,
   .calendar-forecast-content::-webkit-scrollbar-thumb,
@@ -82,6 +90,8 @@ body {
   .assets-body::-webkit-scrollbar-thumb:hover,
   .account-view-body::-webkit-scrollbar-thumb:hover,
   .account-table-wrap::-webkit-scrollbar-thumb:hover,
+  .history-import-log-list::-webkit-scrollbar-thumb:hover,
+  .history-import-select-options::-webkit-scrollbar-thumb:hover,
   .asset-transfer-body::-webkit-scrollbar-thumb:hover,
   .integrity-issues::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-content::-webkit-scrollbar-thumb:hover,
@@ -1611,6 +1621,10 @@ tr:last-child td { border-bottom: none; }
   display: flex;
   flex-direction: column;
 }
+#account-import-history-view {
+  display: flex;
+  flex-direction: column;
+}
 .assets-body {
   flex: 1;
   min-height: 0;
@@ -1625,6 +1639,12 @@ tr:last-child td { border-bottom: none; }
   overflow: auto;
   padding: 18px;
   overscroll-behavior: contain;
+}
+/* while the modal-box height animates between tabs, suppress the inner scroll so
+   a scrollbar doesn't briefly flash as the box grows into place */
+.assets-modal-box.flip-animating .account-view-body,
+.assets-modal-box.flip-animating .assets-body {
+  overflow: hidden;
 }
 .account-view-empty {
   display: flex;
@@ -1669,6 +1689,337 @@ tr:last-child td { border-bottom: none; }
   min-height: 0;
   flex-direction: column;
   overflow: hidden;
+}
+.history-import-body {
+  overflow-y: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.history-import-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+  padding: 0 2px 13px;
+  border-bottom: 1px solid var(--border);
+}
+.history-import-heading > div {
+  display: grid;
+  gap: 4px;
+}
+.history-import-heading strong {
+  color: #f2f5f8;
+  font-size: 13px;
+}
+.history-import-heading span {
+  color: var(--muted);
+  font-size: 11px;
+  line-height: 1.45;
+}
+.history-import-dropzone {
+  appearance: none;
+  width: 100%;
+  min-height: 96px;
+  display: grid;
+  place-items: center;
+  gap: 5px;
+  padding: 16px;
+  border: 1px dashed #3a4655;
+  border-radius: 7px;
+  background: #0d1117;
+  color: #d7dde5;
+  font: inherit;
+  cursor: pointer;
+  transition: border-color 120ms ease, background 120ms ease;
+}
+.history-import-dropzone:hover,
+.history-import-dropzone.dragover {
+  border-color: #58a6ff;
+  background: #111a25;
+}
+.history-import-dropzone:disabled {
+  opacity: .55;
+  cursor: default;
+}
+.history-import-dropzone .icon {
+  width: 22px;
+  height: 22px;
+  fill: none;
+  stroke: #58a6ff;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  stroke-width: 1.8;
+}
+.history-import-dropzone > span {
+  font-size: 12px;
+  font-weight: 650;
+}
+.history-import-dropzone > small {
+  color: var(--muted);
+  font-size: 10px;
+}
+.history-import-preview {
+  display: grid;
+  gap: 10px;
+  margin-top: 12px;
+}
+.history-import-file {
+  position: relative;
+  padding: 13px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #11161d;
+}
+.history-import-file > header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 14px;
+}
+.history-import-file > header > div {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+}
+.history-import-file > header > aside {
+  display: flex;
+  align-items: center;
+  flex: 0 0 auto;
+  gap: 7px;
+}
+.history-import-remove {
+  width: 22px;
+  height: 22px;
+  min-width: 22px;
+  padding: 0;
+  color: var(--muted);
+  font-size: 16px;
+  line-height: 1;
+}
+.history-import-remove:hover {
+  color: var(--danger);
+}
+.history-import-file > header strong {
+  overflow: hidden;
+  color: #f2f5f8;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.history-import-file > header span,
+.history-import-file > header b {
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.history-import-range {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  margin-top: 11px;
+  padding-top: 9px;
+  border-top: 1px solid #222a34;
+  color: var(--muted);
+  font-size: 10px;
+}
+.history-import-range strong {
+  color: #c8d0da;
+  font-weight: 500;
+  text-align: right;
+}
+.history-import-fields {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 11px;
+}
+.history-import-fields > label {
+  display: grid;
+  min-width: 0;
+  gap: 5px;
+  color: var(--muted);
+  font-size: 10px;
+}
+.history-import-select {
+  position: relative;
+  min-width: 0;
+}
+.history-import-select-button {
+  appearance: none;
+  width: 100%;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 0 10px;
+  border: 1px solid #303946;
+  border-radius: 5px;
+  background: #0d1117;
+  color: #d7dde5;
+  font: inherit;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+.history-import-select-button > span:first-child {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.history-import-select.open .history-import-select-button {
+  border-color: #58a6ff;
+}
+.history-import-select-options {
+  position: absolute;
+  z-index: 40;
+  top: calc(100% + 4px);
+  right: 0;
+  left: 0;
+  max-height: 190px;
+  overflow-y: auto;
+  padding: 4px;
+  border: 1px solid #384453;
+  border-radius: 6px;
+  background: #161b22;
+  box-shadow: 0 10px 28px rgba(0, 0, 0, .4);
+}
+.history-import-select-option {
+  appearance: none;
+  width: 100%;
+  min-height: 30px;
+  padding: 6px 8px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #cbd3dc;
+  font: inherit;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+.history-import-select-option:hover,
+.history-import-select-option.selected {
+  background: #26313e;
+  color: #f2f5f8;
+}
+.history-import-confirm {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 10px;
+  color: #aeb7c2;
+  font-size: 10px;
+  cursor: pointer;
+}
+.history-import-confirm input { accent-color: #58a6ff; }
+.history-import-warnings {
+  display: grid;
+  gap: 3px;
+  margin-top: 9px;
+  color: #f2cc60;
+  font-size: 10px;
+  line-height: 1.4;
+}
+.history-import-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+  margin-top: 12px;
+}
+.history-import-actions > span {
+  flex: 1;
+  min-width: 0;
+  color: var(--muted);
+  font-size: 10px;
+  text-align: right;
+}
+.history-import-actions .btn { min-width: 88px; }
+.history-import-log {
+  margin-top: 20px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.history-import-log-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.history-import-log-heading strong {
+  color: #f2f5f8;
+  font-size: 12px;
+}
+.history-import-log-heading span {
+  color: var(--muted);
+  font-size: 10px;
+}
+.history-import-log-list {
+  max-height: 260px;
+  overflow-y: auto;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #0d1117;
+}
+.history-import-log-row {
+  min-height: 62px;
+  display: grid;
+  grid-template-columns: 24px minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 11px;
+  border-bottom: 1px solid #222a34;
+}
+.history-import-log-row:last-child { border-bottom: 0; }
+.history-import-log-logo {
+  width: 22px;
+  height: 22px;
+}
+.history-import-log-logo .exchange-logo {
+  width: 22px;
+  height: 22px;
+}
+.history-import-log-row > span:nth-child(2) {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+.history-import-log-row strong {
+  overflow: hidden;
+  color: #dfe5ec;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.history-import-log-row small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.history-import-log-status {
+  color: #4ed69c;
+  font-size: 9px;
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+.history-import-log-status.partial { color: #f2cc60; }
+.history-import-log-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 7px;
+}
+.history-import-log-actions .btn-icon {
+  width: 28px;
+  height: 28px;
+}
+.history-import-log-actions .icon {
+  width: 14px;
+  height: 14px;
 }
 .pnl-summary-totals {
   display: grid;
@@ -3737,7 +4088,7 @@ tr:last-child td { border-bottom: none; }
   }
   .account-tabs {
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    grid-template-columns: repeat(6, minmax(0, 1fr));
     gap: 0;
     overflow: hidden;
     padding-right: 5px;
@@ -3771,6 +4122,27 @@ tr:last-child td { border-bottom: none; }
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
   }
+  .history-import-body { overflow-y: auto; }
+  .history-import-heading { margin-bottom: 11px; padding-bottom: 10px; }
+  .history-import-heading span { font-size: 10px; }
+  .history-import-dropzone { min-height: 88px; }
+  .history-import-fields { grid-template-columns: minmax(0, 1fr); }
+  .history-import-range { display: grid; gap: 4px; }
+  .history-import-range strong { text-align: left; }
+  .history-import-actions {
+    position: sticky;
+    z-index: 5;
+    bottom: 0;
+    padding: 10px 0 calc(2px + env(safe-area-inset-bottom, 0px));
+    background: linear-gradient(to bottom, rgba(22, 27, 34, 0), #161b22 16px);
+  }
+  .history-import-log-row {
+    grid-template-columns: 22px minmax(0, 1fr);
+  }
+  .history-import-log-status {
+    justify-self: start;
+  }
+  .history-import-log-actions { grid-column: 2; justify-content: flex-start; }
   .pnl-list {
     flex: none;
     height: auto;

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=69" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=82" />
 </head>
 <body>
   <header class="topbar">
@@ -31,12 +31,78 @@
       <button id="hub-menu-close" class="hub-menu-close" type="button" aria-label="Close menu">&times;</button>
     </div>
     <nav class="hub-menu-nav" aria-label="Hub menu">
-      <button id="hub-assets-open" class="hub-menu-item" type="button">
-        <span class="hub-menu-emoji" aria-hidden="true">&#x1f4b0;</span>
-        <span>Assets</span>
+      <button id="hub-account-toggle" class="hub-menu-item hub-menu-parent" type="button"
+              aria-expanded="false" aria-controls="hub-account-menu">
+        <span class="hub-menu-emoji" aria-hidden="true">
+          <svg class="hub-menu-glyph" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2" />
+            <circle cx="12" cy="7" r="4" />
+          </svg>
+        </span>
+        <span>Account</span>
+        <svg class="hub-menu-parent-chevron" viewBox="0 0 24 24" aria-hidden="true">
+          <path d="m9 18 6-6-6-6" />
+        </svg>
       </button>
+      <div id="hub-account-menu" class="hub-submenu hidden">
+        <button class="hub-submenu-item" type="button" data-account-view="assets">
+          <span class="hub-submenu-emoji" aria-hidden="true">
+            <svg class="hub-submenu-glyph" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M9 3h6l-1.3 3.3h-3.4z" />
+              <path d="M10 6.3C6 8.5 4 11.5 4 15A6 6 0 0 0 10 21H14A6 6 0 0 0 20 15C20 11.5 18 8.5 14 6.3" />
+              <path d="M13.4 11.4a2 2 0 0 0-3.4.5c0 1.7 3.4 1 3.4 2.7a2 2 0 0 1-3.4.5" />
+              <line x1="12" y1="9.7" x2="12" y2="16.3" />
+            </svg>
+          </span>
+          <span>Assets</span>
+        </button>
+        <button class="hub-submenu-item" type="button" data-account-view="positions">
+          <span class="hub-submenu-emoji" aria-hidden="true">
+            <svg class="hub-submenu-glyph" viewBox="0 0 24 24" aria-hidden="true">
+              <line x1="6" y1="20" x2="6" y2="14" />
+              <line x1="12" y1="20" x2="12" y2="4" />
+              <line x1="18" y1="20" x2="18" y2="10" />
+            </svg>
+          </span>
+          <span>Positions</span>
+        </button>
+        <button class="hub-submenu-item" type="button" data-account-view="pnl">
+          <span class="hub-submenu-emoji" aria-hidden="true">
+            <svg class="hub-submenu-glyph" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="3 17 9 11 13 15 21 7" />
+              <polyline points="15 7 21 7 21 13" />
+            </svg>
+          </span>
+          <span>PnL</span>
+        </button>
+        <button id="hub-history-toggle" class="hub-submenu-item hub-submenu-parent" type="button"
+                aria-expanded="false" aria-controls="hub-history-menu">
+          <span class="hub-submenu-emoji" aria-hidden="true">
+            <svg class="hub-submenu-glyph" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8" />
+              <path d="M3 3v5h5" />
+              <path d="M12 7v5l4 2" />
+            </svg>
+          </span>
+          <span>History</span>
+          <svg class="hub-submenu-parent-chevron" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="m9 18 6-6-6-6" />
+          </svg>
+        </button>
+        <div id="hub-history-menu" class="hub-subsubmenu hidden">
+          <button class="hub-subsubmenu-item" type="button" data-account-view="position-history">Position History</button>
+          <button class="hub-subsubmenu-item" type="button" data-account-view="orders">Order History</button>
+        </div>
+      </div>
       <button id="hub-calendar-open" class="hub-menu-item" type="button">
-        <span class="hub-menu-emoji" aria-hidden="true">&#x1f4c5;</span>
+        <span class="hub-menu-emoji" aria-hidden="true">
+          <svg class="hub-menu-glyph" viewBox="0 0 24 24" aria-hidden="true">
+            <rect x="3" y="4" width="18" height="18" rx="2" />
+            <line x1="3" y1="10" x2="21" y2="10" />
+            <line x1="8" y1="2" x2="8" y2="6" />
+            <line x1="16" y1="2" x2="16" y2="6" />
+          </svg>
+        </span>
         <span>Calendar</span>
       </button>
     </nav>
@@ -189,7 +255,7 @@
               <path d="m12 19-7-7 7-7" />
             </svg>
           </button>
-          <span id="assets-title">Assets</span>
+          <span id="assets-title">Account</span>
         </div>
         <div class="modal-actions">
           <button id="assets-refresh" class="btn btn-icon" type="button"
@@ -204,7 +270,18 @@
           <button id="assets-close" class="btn" type="button" title="Close" aria-label="Close">&times;</button>
         </div>
       </div>
-      <div class="assets-body">
+      <nav class="account-tabs" aria-label="Account views">
+        <button class="account-tab active" type="button" data-account-view="assets">Assets</button>
+        <button class="account-tab" type="button" data-account-view="positions">Positions</button>
+        <button class="account-tab" type="button" data-account-view="position-history">Position History</button>
+        <button class="account-tab account-tab-order-history" type="button" data-account-view="orders"
+                aria-label="Order History">
+          <span>Order</span><span>History</span>
+        </button>
+        <button class="account-tab" type="button" data-account-view="pnl">PnL</button>
+      </nav>
+      <section id="account-assets-view" class="account-view">
+        <div id="assets-body" class="assets-body">
         <section id="assets-summary" class="assets-summary hidden" aria-label="Asset summary">
           <div>
             <span class="assets-summary-label">Total assets</span>
@@ -215,7 +292,7 @@
             <span id="assets-updated"></span>
           </div>
         </section>
-        <div id="assets-loading" class="assets-state">
+        <div id="assets-loading" class="assets-state hidden">
           <span class="assets-spinner" aria-hidden="true"></span>
           <span>Loading account assets...</span>
         </div>
@@ -224,6 +301,74 @@
           No exchange accounts are configured in providers.toml.
         </div>
         <div id="assets-portfolios" class="assets-portfolios"></div>
+        </div>
+      </section>
+      <section id="account-positions-view" class="account-view hidden">
+        <div class="account-view-body">
+          <section id="positions-summary" class="account-summary hidden" aria-label="Position summary">
+            <div>
+              <span class="account-summary-label">Open positions</span>
+              <strong id="positions-open-count">0</strong>
+            </div>
+            <div class="account-summary-meta">
+              <span id="positions-account-count"></span>
+              <span id="positions-updated"></span>
+            </div>
+          </section>
+          <div id="positions-loading" class="assets-state">
+            <span class="assets-spinner" aria-hidden="true"></span>
+            <span>Loading positions...</span>
+          </div>
+          <div id="positions-error" class="assets-state assets-state-error hidden" role="alert"></div>
+          <div id="positions-empty" class="assets-state hidden">No open positions.</div>
+          <div id="positions-table-wrap" class="account-table-wrap hidden">
+            <table class="account-table">
+              <thead>
+                <tr>
+                  <th>Account</th>
+                  <th>Symbol</th>
+                  <th>Side</th>
+                  <th>Size</th>
+                  <th>Entry</th>
+                  <th>Mark</th>
+                  <th>Unrealized PnL</th>
+                  <th>Realized PnL</th>
+                  <th>Return</th>
+                  <th>Leverage</th>
+                  <th>Liquidation</th>
+                </tr>
+              </thead>
+              <tbody id="positions-table-body"></tbody>
+            </table>
+          </div>
+          <div id="positions-account-errors" class="account-errors hidden"></div>
+        </div>
+      </section>
+      <section id="account-position-history-view" class="account-view hidden">
+        <div class="account-view-body account-view-empty">No position history available.</div>
+      </section>
+      <section id="account-orders-view" class="account-view hidden">
+        <div class="account-view-body account-view-empty">No order history available.</div>
+      </section>
+      <section id="account-pnl-view" class="account-view hidden">
+        <div class="account-view-body account-view-empty">No PnL history available.</div>
+      </section>
+      <div id="position-pnl-popover" class="position-pnl-popover hidden" role="dialog"
+           aria-label="Realized PnL calculation">
+        <strong>Realized PnL</strong>
+        <div class="position-pnl-row">
+          <span>Total PnL</span>
+          <span id="position-pnl-gross" class="mono"></span>
+        </div>
+        <div class="position-pnl-row">
+          <span>Fees</span>
+          <span id="position-pnl-fees" class="mono"></span>
+        </div>
+        <div class="position-pnl-row position-pnl-net-row">
+          <span>Net PnL</span>
+          <span id="position-pnl-net" class="mono"></span>
+        </div>
+        <div id="position-pnl-note" class="position-pnl-note hidden"></div>
       </div>
     </div>
   </div>
@@ -479,6 +624,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=76"></script>
+  <script src="/static/dashboard.js?v=90"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=112" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=114" />
 </head>
 <body>
   <header class="topbar">
@@ -447,7 +447,20 @@
           <div class="history-import-heading">
             <div>
               <strong>Import exchange history</strong>
-              <span>Merge exported CSV history into Position History, Order History, and PnL.</span>
+              <span class="history-import-description">Merge exported CSV history into Position History, Order History, and PnL.
+                <span id="history-import-help" class="history-import-help">
+                  <button id="history-import-help-button" type="button" aria-label="Show recommended CSV files"
+                          aria-expanded="false" aria-controls="history-import-help-popover">?</button>
+                  <span id="history-import-help-popover" class="history-import-help-popover" role="tooltip">
+                    <strong>* Recommended for complete data</strong>
+                    <span>Binance: Position History, Order History, Trade History, and Transaction History</span>
+                    <span>Bitget: Futures Position History and Futures Order History</span>
+                    <span>Bybit: Closed P&amp;L, Order History, Trade History, and Transaction Log (import support pending)</span>
+                    <span>OKX: Position History, Order History, and Trade Details</span>
+                    <span>Hyperliquid: Trade History and Funding History; Order History is added automatically via API</span>
+                  </span>
+                </span>
+              </span>
             </div>
           </div>
           <input id="history-import-files" class="hidden" type="file" accept=".csv,text/csv" multiple />
@@ -495,6 +508,8 @@
             <button type="button" data-pnl-days="7" aria-pressed="false">7D</button>
             <button type="button" data-pnl-days="30" aria-pressed="false">30D</button>
             <button class="active" type="button" data-pnl-days="90" aria-pressed="true">90D</button>
+            <button type="button" data-pnl-days="180" aria-pressed="false">6M</button>
+            <button type="button" data-pnl-days="365" aria-pressed="false">1Y</button>
             <button type="button" data-pnl-days="all" aria-pressed="false">All</button>
           </div>
           <div id="pnl-loading" class="assets-state">
@@ -519,6 +534,10 @@
         <div class="position-pnl-row">
           <span>Fees</span>
           <span id="position-pnl-fees" class="mono"></span>
+        </div>
+        <div class="position-pnl-row">
+          <span>Funding</span>
+          <span id="position-pnl-funding" class="mono"></span>
         </div>
         <div class="position-pnl-row position-pnl-net-row">
           <span>Net PnL</span>
@@ -780,6 +799,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=120"></script>
+  <script src="/static/dashboard.js?v=124"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=84" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=103" />
 </head>
 <body>
   <header class="topbar">
@@ -267,7 +267,7 @@
               <path d="M3 21v-5h5" />
             </svg>
           </button>
-          <button id="assets-close" class="btn" type="button" title="Close" aria-label="Close">&times;</button>
+          <button id="assets-close" class="btn btn-icon" type="button" title="Close" aria-label="Close">&times;</button>
         </div>
       </div>
       <nav class="account-tabs" aria-label="Account views">
@@ -324,34 +324,118 @@
           </div>
           <div id="positions-error" class="assets-state assets-state-error hidden" role="alert"></div>
           <div id="positions-empty" class="assets-state hidden">No open positions.</div>
-          <div id="positions-table-wrap" class="account-table-wrap hidden">
-            <table class="account-table">
-              <thead>
-                <tr>
-                  <th>Account</th>
-                  <th>Symbol</th>
-                  <th>Side</th>
-                  <th>Size</th>
-                  <th>Entry</th>
-                  <th>Mark</th>
-                  <th>Unrealized PnL</th>
-                  <th>Realized PnL</th>
-                  <th>Return</th>
-                  <th>Leverage</th>
-                  <th>Liquidation</th>
-                </tr>
-              </thead>
-              <tbody id="positions-table-body"></tbody>
-            </table>
-          </div>
+          <div id="positions-list" class="account-history-record-list account-positions-list hidden"></div>
           <div id="positions-account-errors" class="account-errors hidden"></div>
         </div>
       </section>
-      <section id="account-position-history-view" class="account-view hidden">
-        <div class="account-view-body account-view-empty">No position history available.</div>
+      <section id="account-position-history-view" class="account-view account-history-view hidden">
+        <div class="account-view-body">
+          <div class="account-history-navigation">
+            <button id="position-history-back" class="btn btn-icon account-history-back hidden"
+                    type="button" title="Back" aria-label="Back">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M19 12H5"></path><path d="m12 19-7-7 7-7"></path>
+              </svg>
+            </button>
+            <div>
+              <strong id="position-history-navigation-title">Exchanges</strong>
+              <span id="position-history-navigation-subtitle">Choose an exchange</span>
+            </div>
+          </div>
+          <div id="position-history-groups" class="account-history-groups"></div>
+          <div id="position-history-loading" class="assets-state hidden">
+            <span class="assets-spinner" aria-hidden="true"></span>
+            <span>Loading position history...</span>
+          </div>
+          <div id="position-history-error" class="assets-state assets-state-error hidden" role="alert"></div>
+          <div id="position-history-empty" class="assets-state hidden">No position history.</div>
+          <div id="position-history-details" class="account-history-details hidden">
+          <form id="position-history-filters"
+                class="account-history-filters account-history-detail-filters">
+            <div class="script-select account-history-select" id="position-history-account-control">
+              <select id="position-history-account" class="script-native-select"
+                      tabindex="-1" aria-hidden="true">
+                <option value="">All accounts</option>
+              </select>
+              <button type="button" class="script-select-button" id="position-history-account-button"
+                      aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by account">
+                <span class="script-select-label" id="position-history-account-label">All accounts</span>
+                <span class="script-select-chevron" aria-hidden="true">&#9662;</span>
+              </button>
+              <div class="script-select-options hidden" id="position-history-account-options"
+                   role="listbox"></div>
+            </div>
+          </form>
+          <div id="position-history-meta" class="account-history-meta hidden"></div>
+          <div id="position-history-table-wrap" class="account-history-list-wrap hidden">
+            <div id="position-history-table-body" class="account-history-record-list"></div>
+          </div>
+          <div class="account-history-more">
+            <button id="position-history-more" class="btn hidden" type="button">Load more</button>
+          </div>
+          </div>
+        </div>
       </section>
-      <section id="account-orders-view" class="account-view hidden">
-        <div class="account-view-body account-view-empty">No order history available.</div>
+      <section id="account-orders-view" class="account-view account-history-view hidden">
+        <div class="account-view-body">
+          <div class="account-history-navigation">
+            <button id="order-history-back" class="btn btn-icon account-history-back hidden"
+                    type="button" title="Back" aria-label="Back">
+              <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                <path d="M19 12H5"></path><path d="m12 19-7-7 7-7"></path>
+              </svg>
+            </button>
+            <div>
+              <strong id="order-history-navigation-title">Exchanges</strong>
+              <span id="order-history-navigation-subtitle">Choose an exchange</span>
+            </div>
+          </div>
+          <div id="order-history-groups" class="account-history-groups"></div>
+          <div id="order-history-loading" class="assets-state hidden">
+            <span class="assets-spinner" aria-hidden="true"></span>
+            <span>Loading order history...</span>
+          </div>
+          <div id="order-history-error" class="assets-state assets-state-error hidden" role="alert"></div>
+          <div id="order-history-empty" class="assets-state hidden">No order history.</div>
+          <div id="order-history-details" class="account-history-details hidden">
+          <form id="order-history-filters"
+                class="account-history-filters account-history-detail-filters account-order-detail-filters">
+            <div class="script-select account-history-select" id="order-history-account-control">
+              <select id="order-history-account" class="script-native-select"
+                      tabindex="-1" aria-hidden="true">
+                <option value="">All accounts</option>
+              </select>
+              <button type="button" class="script-select-button" id="order-history-account-button"
+                      aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by account">
+                <span class="script-select-label" id="order-history-account-label">All accounts</span>
+                <span class="script-select-chevron" aria-hidden="true">&#9662;</span>
+              </button>
+              <div class="script-select-options hidden" id="order-history-account-options"
+                   role="listbox"></div>
+            </div>
+            <div class="script-select account-history-select" id="order-history-status-control">
+              <select id="order-history-status" class="script-native-select"
+                      tabindex="-1" aria-hidden="true">
+                <option value="">All statuses</option>
+              </select>
+              <button type="button" class="script-select-button" id="order-history-status-button"
+                      aria-haspopup="listbox" aria-expanded="false" aria-label="Filter by order status">
+                <span class="script-select-label" id="order-history-status-label">All statuses</span>
+                <span class="script-select-chevron" aria-hidden="true">&#9662;</span>
+              </button>
+              <div class="script-select-options hidden" id="order-history-status-options"
+                   role="listbox"></div>
+            </div>
+          </form>
+          <div id="order-history-meta" class="account-history-meta hidden"></div>
+          <div id="order-history-table-wrap" class="account-history-list-wrap hidden">
+            <div id="order-history-table-body" class="account-history-record-list"></div>
+          </div>
+          <div class="account-history-more">
+            <button id="order-history-more" class="btn hidden" type="button">Load more</button>
+          </div>
+          </div>
+        </div>
       </section>
       <section id="account-pnl-view" class="account-view hidden">
         <div class="account-view-body account-view-empty">No PnL history available.</div>
@@ -627,6 +711,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=92"></script>
+  <script src="/static/dashboard.js?v=111"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=110" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=112" />
 </head>
 <body>
   <header class="topbar">
@@ -92,6 +92,7 @@
         <div id="hub-history-menu" class="hub-subsubmenu" aria-hidden="true">
           <button class="hub-subsubmenu-item" type="button" data-account-view="position-history">Position History</button>
           <button class="hub-subsubmenu-item" type="button" data-account-view="orders">Order History</button>
+          <button class="hub-subsubmenu-item" type="button" data-account-view="import-history">Import History</button>
         </div>
       </div>
       <button id="hub-calendar-open" class="hub-menu-item" type="button">
@@ -281,6 +282,10 @@
                 aria-label="Order History">
           <span>Order</span><span>History</span>
         </button>
+        <button class="account-tab account-tab-history" type="button" data-account-view="import-history"
+                aria-label="Import History">
+          <span>Import</span><span>History</span>
+        </button>
         <button class="account-tab" type="button" data-account-view="pnl">PnL</button>
       </nav>
       <section id="account-assets-view" class="account-view">
@@ -437,6 +442,43 @@
           </div>
         </div>
       </section>
+      <section id="account-import-history-view" class="account-view account-history-import-view hidden">
+        <div class="account-view-body history-import-body">
+          <div class="history-import-heading">
+            <div>
+              <strong>Import exchange history</strong>
+              <span>Merge exported CSV history into Position History, Order History, and PnL.</span>
+            </div>
+          </div>
+          <input id="history-import-files" class="hidden" type="file" accept=".csv,text/csv" multiple />
+          <button id="history-import-dropzone" class="history-import-dropzone" type="button">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M12 16V4"></path><path d="m7 9 5-5 5 5"></path>
+              <path d="M5 20h14"></path>
+            </svg>
+            <span>Choose or drop CSV files</span>
+            <small>Binance, Bitget, OKX, and Hyperliquid exports</small>
+          </button>
+          <div id="history-import-loading" class="assets-state hidden">
+            <span class="assets-spinner" aria-hidden="true"></span>
+            <span id="history-import-loading-text">Inspecting CSV files...</span>
+          </div>
+          <div id="history-import-error" class="assets-state assets-state-error hidden" role="alert"></div>
+          <div id="history-import-preview" class="history-import-preview hidden"></div>
+          <div id="history-import-actions" class="history-import-actions hidden">
+            <span id="history-import-status" aria-live="polite"></span>
+            <button id="history-import-submit" class="btn btn-primary" type="button">Import</button>
+          </div>
+          <section class="history-import-log">
+            <div class="history-import-log-heading">
+              <strong>Previous imports</strong>
+              <span id="history-import-log-count"></span>
+            </div>
+            <div id="history-import-log-empty" class="assets-state hidden">No CSV history has been imported.</div>
+            <div id="history-import-log-list" class="history-import-log-list"></div>
+          </section>
+        </div>
+      </section>
       <section id="account-pnl-view" class="account-view hidden">
         <div class="account-view-body pnl-view-body">
           <section id="pnl-summary" class="account-summary pnl-summary hidden" aria-label="PnL summary">
@@ -453,6 +495,7 @@
             <button type="button" data-pnl-days="7" aria-pressed="false">7D</button>
             <button type="button" data-pnl-days="30" aria-pressed="false">30D</button>
             <button class="active" type="button" data-pnl-days="90" aria-pressed="true">90D</button>
+            <button type="button" data-pnl-days="all" aria-pressed="false">All</button>
           </div>
           <div id="pnl-loading" class="assets-state">
             <span class="assets-spinner" aria-hidden="true"></span>
@@ -737,6 +780,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=118"></script>
+  <script src="/static/dashboard.js?v=120"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=82" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=84" />
 </head>
 <body>
   <header class="topbar">
@@ -44,7 +44,7 @@
           <path d="m9 18 6-6-6-6" />
         </svg>
       </button>
-      <div id="hub-account-menu" class="hub-submenu hidden">
+      <div id="hub-account-menu" class="hub-submenu" aria-hidden="true">
         <button class="hub-submenu-item" type="button" data-account-view="assets">
           <span class="hub-submenu-emoji" aria-hidden="true">
             <svg class="hub-submenu-glyph" viewBox="0 0 24 24" aria-hidden="true">
@@ -89,7 +89,7 @@
             <path d="m9 18 6-6-6-6" />
           </svg>
         </button>
-        <div id="hub-history-menu" class="hub-subsubmenu hidden">
+        <div id="hub-history-menu" class="hub-subsubmenu" aria-hidden="true">
           <button class="hub-subsubmenu-item" type="button" data-account-view="position-history">Position History</button>
           <button class="hub-subsubmenu-item" type="button" data-account-view="orders">Order History</button>
         </div>
@@ -273,8 +273,11 @@
       <nav class="account-tabs" aria-label="Account views">
         <button class="account-tab active" type="button" data-account-view="assets">Assets</button>
         <button class="account-tab" type="button" data-account-view="positions">Positions</button>
-        <button class="account-tab" type="button" data-account-view="position-history">Position History</button>
-        <button class="account-tab account-tab-order-history" type="button" data-account-view="orders"
+        <button class="account-tab account-tab-history" type="button" data-account-view="position-history"
+                aria-label="Position History">
+          <span>Position</span><span>History</span>
+        </button>
+        <button class="account-tab account-tab-history" type="button" data-account-view="orders"
                 aria-label="Order History">
           <span>Order</span><span>History</span>
         </button>
@@ -624,6 +627,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=90"></script>
+  <script src="/static/dashboard.js?v=92"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=103" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=110" />
 </head>
 <body>
   <header class="topbar">
@@ -438,7 +438,33 @@
         </div>
       </section>
       <section id="account-pnl-view" class="account-view hidden">
-        <div class="account-view-body account-view-empty">No PnL history available.</div>
+        <div class="account-view-body pnl-view-body">
+          <section id="pnl-summary" class="account-summary pnl-summary hidden" aria-label="PnL summary">
+            <div>
+              <span class="account-summary-label">Net PnL</span>
+              <div id="pnl-summary-totals" class="pnl-summary-totals"></div>
+            </div>
+            <div class="account-summary-meta">
+              <span id="pnl-summary-counts"></span>
+              <span id="pnl-updated"></span>
+            </div>
+          </section>
+          <div class="pnl-period-control" role="group" aria-label="PnL period">
+            <button type="button" data-pnl-days="7" aria-pressed="false">7D</button>
+            <button type="button" data-pnl-days="30" aria-pressed="false">30D</button>
+            <button class="active" type="button" data-pnl-days="90" aria-pressed="true">90D</button>
+          </div>
+          <div id="pnl-loading" class="assets-state">
+            <span class="assets-spinner" aria-hidden="true"></span>
+            <span>Loading PnL...</span>
+          </div>
+          <div id="pnl-error" class="assets-state assets-state-error hidden" role="alert"></div>
+          <div id="pnl-empty" class="assets-state hidden">No PnL data.</div>
+          <div id="pnl-list" class="account-history-record-list pnl-list hidden"></div>
+          <div id="pnl-coverage-note" class="pnl-coverage-note hidden">
+            Funding and borrow interest are not included.
+          </div>
+        </div>
       </section>
       <div id="position-pnl-popover" class="position-pnl-popover hidden" role="dialog"
            aria-label="Realized PnL calculation">
@@ -711,6 +737,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=111"></script>
+  <script src="/static/dashboard.js?v=118"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -78,6 +78,7 @@
   let historyImportBusy = false;
   let historyImportJobTimer = null;
   let historyImportLogLoaded = false;
+  let historyImportLogPayload = { results: [], total: 0 };
   let historyImportStatusText = "";
   let positionHistoryRequestSeq = 0;
   let positionHistoryHaveData = false;
@@ -1939,7 +1940,13 @@
     button.dataset.positionPnl = JSON.stringify(
       breakdown && typeof breakdown === "object"
         ? breakdown
-        : { gross_pnl: null, fees: null, net_pnl: value, complete: false },
+        : {
+          gross_pnl: null,
+          fees: null,
+          funding: null,
+          net_pnl: value,
+          complete: false,
+        },
     );
     cell.removeAttribute("title");
   }
@@ -1974,6 +1981,10 @@
 
     const gross = Number(breakdown.gross_pnl);
     const fees = Number(breakdown.fees);
+    const fundingValue = breakdown.funding;
+    const funding = fundingValue === null || fundingValue === undefined
+      ? Number.NaN
+      : Number(fundingValue);
     const net = Number(breakdown.net_pnl);
     const complete = breakdown.complete === true
       && Number.isFinite(gross)
@@ -1989,13 +2000,33 @@
       el("position-pnl-fees"),
       `mono ${positionPnlClass(feeAdjustment)}`.trim(),
     );
+    setText(
+      el("position-pnl-funding"),
+      Number.isFinite(funding) ? formatSignedPositionNumber(funding) : "Unavailable",
+    );
+    setClass(
+      el("position-pnl-funding"),
+      `mono ${positionPnlClass(funding)}`.trim(),
+    );
     setText(el("position-pnl-net"), formatSignedPositionNumber(net));
     setClass(el("position-pnl-net"), `mono ${positionPnlClass(net)}`.trim());
-    el("position-pnl-note").classList.toggle("hidden", complete);
+    const fundingAvailable = Number.isFinite(funding);
+    const estimatedFunding = breakdown.funding_allocation === "estimated";
+    el("position-pnl-note").classList.toggle(
+      "hidden",
+      complete && fundingAvailable && !estimatedFunding,
+    );
     if (!complete) {
       setText(
         el("position-pnl-note"),
         "The exchange reports net realized PnL without a fee breakdown.",
+      );
+    } else if (!fundingAvailable) {
+      setText(el("position-pnl-note"), "Funding data is unavailable for this position.");
+    } else if (estimatedFunding) {
+      setText(
+        el("position-pnl-note"),
+        "Daily funding is allocated by position size and holding time.",
       );
     }
 
@@ -2750,6 +2781,14 @@
     renderHistoryImportActions();
   }
 
+  function setHistoryImportHelpOpen(open) {
+    const help = el("history-import-help");
+    const button = el("history-import-help-button");
+    if (!help || !button) return;
+    help.classList.toggle("show", open);
+    button.setAttribute("aria-expanded", String(open));
+  }
+
   function historyImportTypeLabel(value) {
     return String(value || "")
       .split("_")
@@ -2871,8 +2910,13 @@
 
   function renderHistoryImportLog(payload) {
     const results = payload && Array.isArray(payload.results) ? payload.results : [];
-    el("history-import-log-count").textContent = results.length
-      ? `${Number(payload.total || results.length).toLocaleString()} files`
+    historyImportLogPayload = {
+      ...(payload || {}),
+      results,
+      total: Number(payload && payload.total || results.length),
+    };
+    el("history-import-log-count").textContent = historyImportLogPayload.total
+      ? `${historyImportLogPayload.total.toLocaleString()} files`
       : "";
     el("history-import-log-empty").classList.toggle("hidden", results.length > 0);
     el("history-import-log-list").innerHTML = results.map((item) => {
@@ -2892,6 +2936,8 @@
           ? `<button type="button" class="btn btn-icon" data-history-import-retry="${esc(item.import_id)}" title="Retry Hyperliquid Order History" aria-label="Retry Hyperliquid Order History">`
             + `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12a9 9 0 0 1 15.7-6L21 8"></path><path d="M21 3v5h-5"></path><path d="M21 12a9 9 0 0 1-15.7 6L3 16"></path><path d="M3 21v-5h5"></path></svg></button>`
           : "")
+        + `<button type="button" class="btn btn-danger btn-icon" data-history-import-delete="${esc(item.import_id)}" title="Delete import record" aria-label="Delete import record">`
+        + `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 6h18"></path><path d="M8 6V4h8v2"></path><path d="M19 6l-1 14H6L5 6"></path><path d="M10 11v5M14 11v5"></path></svg></button>`
         + `</span></div>`;
     }).join("");
   }
@@ -3069,6 +3115,38 @@
     }
   }
 
+  async function deleteHistoryImport(importId, button) {
+    if (!importId || historyImportBusy) return;
+    const row = button && button.closest(".history-import-log-row");
+    el("history-import-error").classList.add("hidden");
+    if (button) button.disabled = true;
+    if (row) row.classList.add("is-deleting");
+    try {
+      await api(`/api/account/history/imports/${encodeURIComponent(importId)}`, {
+        method: "DELETE",
+      });
+      const results = (historyImportLogPayload.results || []).filter(
+        (item) => String(item && item.import_id || "") !== importId,
+      );
+      historyImportLogPayload = {
+        ...historyImportLogPayload,
+        results,
+        total: Math.max(0, Number(historyImportLogPayload.total || 0) - 1),
+      };
+      if (row) row.remove();
+      el("history-import-log-count").textContent = historyImportLogPayload.total
+        ? `${historyImportLogPayload.total.toLocaleString()} files`
+        : "";
+      el("history-import-log-empty").classList.toggle("hidden", results.length > 0);
+      historyImportLogLoaded = true;
+    } catch (error) {
+      if (button) button.disabled = false;
+      if (row) row.classList.remove("is-deleting");
+      el("history-import-error").textContent = error.message;
+      el("history-import-error").classList.remove("hidden");
+    }
+  }
+
   function formatAccountHistoryDate(value, includeSeconds = false, includeYear = false) {
     const timestamp = Date.parse(String(value || ""));
     if (!Number.isFinite(timestamp)) return "—";
@@ -3196,8 +3274,8 @@
     const metrics = document.createElement("div");
     metrics.className = "account-history-record-metrics";
     metrics.append(
-      createHistoryMetric("Opened", formatAccountHistoryDate(record.opened_at, true)),
-      createHistoryMetric("Closed", formatAccountHistoryDate(record.closed_at, true)),
+      createHistoryMetric("Opened", formatAccountHistoryDate(record.opened_at, true, true)),
+      createHistoryMetric("Closed", formatAccountHistoryDate(record.closed_at, true, true)),
       createHistoryMetric("Entry Price", formatPositionNumber(position.entry_price)),
       createHistoryMetric("Avg Close Price", formatPositionNumber(position.exit_price)),
       createHistoryMetric("Size", formatPositionNumber(position.quantity ?? position.contracts)),
@@ -3240,7 +3318,7 @@
         "Avg Price",
         formatPositionNumber(order.average_price ?? order.price),
       ),
-      createHistoryMetric("Created", formatAccountHistoryDate(record.created_at, true)),
+      createHistoryMetric("Created", formatAccountHistoryDate(record.created_at, true, true)),
     );
     row.appendChild(metrics);
     return row;
@@ -4852,6 +4930,10 @@
     el("history-import-dropzone").addEventListener("click", () => {
       if (!historyImportBusy) el("history-import-files").click();
     });
+    el("history-import-help-button").addEventListener("click", (event) => {
+      event.stopPropagation();
+      setHistoryImportHelpOpen(!el("history-import-help").classList.contains("show"));
+    });
     el("history-import-dropzone").addEventListener("dragover", (event) => {
       event.preventDefault();
       if (!historyImportBusy) el("history-import-dropzone").classList.add("dragover");
@@ -4916,6 +4998,16 @@
     });
     el("history-import-submit").addEventListener("click", submitHistoryImport);
     el("history-import-log-list").addEventListener("click", (event) => {
+      const deleteButton = event.target && event.target.closest
+        ? event.target.closest("[data-history-import-delete]")
+        : null;
+      if (deleteButton) {
+        deleteHistoryImport(
+          String(deleteButton.dataset.historyImportDelete || ""),
+          deleteButton,
+        );
+        return;
+      }
       const button = event.target && event.target.closest
         ? event.target.closest("[data-history-import-retry]")
         : null;
@@ -4925,6 +5017,9 @@
     document.addEventListener("click", (event) => {
       if (!event.target || !event.target.closest(".history-import-select")) {
         closeHistoryImportSelects();
+      }
+      if (!event.target || !event.target.closest("#history-import-help")) {
+        setHistoryImportHelpOpen(false);
       }
     });
     el("assets-close").addEventListener("click", closeAssets);

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -64,6 +64,30 @@
   let positionsHaveData = false;
   let positionsPayload = null;
   let positionsObservedAt = 0;
+  const historyCustomSelects = {};
+  let positionHistoryRequestSeq = 0;
+  let positionHistoryHaveData = false;
+  let positionHistoryRows = [];
+  let positionHistoryCursor = null;
+  let positionHistoryTotal = 0;
+  let positionHistoryGroupsHaveData = false;
+  const positionHistoryNavigation = {
+    level: "exchanges",
+    exchange: "",
+    symbol: "",
+  };
+  let orderHistoryRequestSeq = 0;
+  let orderHistoryHaveData = false;
+  let orderHistoryRows = [];
+  let orderHistoryCursor = null;
+  let orderHistoryTotal = 0;
+  let orderHistoryGroupsHaveData = false;
+  const orderHistoryNavigation = {
+    level: "exchanges",
+    exchange: "",
+    symbol: "",
+  };
+  const accountHistoryPageSize = 50;
   let accountPositionsWs = null;
   let accountPositionsReconnectTimer = null;
   let accountPositionsKeepaliveTimer = null;
@@ -511,9 +535,16 @@
   }
 
   async function openAccount(view = "assets") {
+    const wasOpen = isAssetsOpen();
     closeHubMenu();
     closeAiChat();
     if (view === "assets") selectedAssetExchange = null;
+    if (!wasOpen && accountView === view && view === "position-history") {
+      resetHistoryNavigation("position");
+    }
+    if (!wasOpen && accountView === view && view === "orders") {
+      resetHistoryNavigation("order");
+    }
     if (assetsCloseTimer !== null) {
       clearTimeout(assetsCloseTimer);
       assetsCloseTimer = null;
@@ -553,6 +584,8 @@
     assetsRequestSeq += 1;
     setAssetsLoading(false);
     positionsRequestSeq += 1;
+    positionHistoryRequestSeq += 1;
+    orderHistoryRequestSeq += 1;
     if (!mobileHubQuery.matches) {
       finishAssetsClose();
       return;
@@ -581,8 +614,51 @@
     pnl: "PnL",
   };
 
+  function accountViewIsDrilledIn(view) {
+    if (view === "assets") {
+      return Boolean(selectedAssetExchange);
+    }
+    if (view === "position-history") {
+      return positionHistoryNavigation.level !== "exchanges";
+    }
+    if (view === "orders") {
+      return orderHistoryNavigation.level !== "exchanges";
+    }
+    return false;
+  }
+
   async function switchAccountView(view, options = {}) {
     if (!Object.prototype.hasOwnProperty.call(accountViewTitles, view)) return;
+    const previousView = accountView;
+    // Desktop: capture the modal-box height before the view swap so we can
+    // animate it to the new view's height (avoids the snap between tabs).
+    const accountBox = document.querySelector(".assets-modal-box");
+    const animateAccountHeight = Boolean(options.animate)
+      && accountBox
+      && !el("assets-modal").classList.contains("hidden")
+      && !mobileHubQuery.matches
+      && !window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const accountStartHeight = animateAccountHeight ? accountBox.offsetHeight : 0;
+    // History views reset their content and refetch on switch, so the height
+    // right after the view swap is the (empty) reset state — animating to it
+    // then jumping to the loaded height is the snap the user sees. For those we
+    // hold the old height through the reload and tween once to the final height.
+    const isAccountHistoryView = view === "position-history" || view === "orders";
+    const deferAccountHeight = animateAccountHeight && isAccountHistoryView && Boolean(options.load);
+    const runAccountHeightTween = () => {
+      accountBox.style.height = "";
+      const endHeight = accountBox.offsetHeight;
+      if (Math.abs(endHeight - accountStartHeight) <= 1) return;
+      accountBox.style.height = `${accountStartHeight}px`;
+      void accountBox.offsetHeight; // reflow to lock the start height
+      accountBox.style.height = `${endHeight}px`;
+      const onHeightEnd = (event) => {
+        if (event.target !== accountBox || event.propertyName !== "height") return;
+        accountBox.removeEventListener("transitionend", onHeightEnd);
+        accountBox.style.height = "";
+      };
+      accountBox.addEventListener("transitionend", onHeightEnd);
+    };
     if (accountView === "assets" && view !== "assets") {
       clearAssetsRefreshTimer();
       assetsRequestSeq += 1;
@@ -592,6 +668,22 @@
       positionsRequestSeq += 1;
       closeAccountPositionsSocket();
       closePositionPnlPopover();
+    }
+    if (accountView === "position-history" && view !== "position-history") {
+      positionHistoryRequestSeq += 1;
+    }
+    if (accountView === "orders" && view !== "orders") {
+      orderHistoryRequestSeq += 1;
+    }
+    if (previousView !== view && view === "position-history") {
+      resetHistoryNavigation("position");
+    }
+    if (previousView !== view && view === "orders") {
+      resetHistoryNavigation("order");
+    }
+    if (previousView === view && accountViewIsDrilledIn(view)) {
+      if (view === "assets") selectedAssetExchange = null;
+      else resetHistoryNavigation(view === "position-history" ? "position" : "order");
     }
     accountView = view;
     document.querySelectorAll("[data-account-view]").forEach((button) => {
@@ -603,16 +695,28 @@
     Object.keys(accountViewTitles).forEach((name) => {
       el(`account-${name}-view`).classList.toggle("hidden", name !== view);
     });
+    if (animateAccountHeight) {
+      if (deferAccountHeight) {
+        // hold the old height while the history content resets and reloads
+        accountBox.style.height = `${accountStartHeight}px`;
+      } else {
+        runAccountHeightTween();
+      }
+    }
 
     const assetsSelected = view === "assets" && selectedAssetExchange;
     el("assets-back").classList.toggle("hidden", !assetsSelected);
     el("assets-refresh").classList.toggle(
       "hidden",
-      !new Set(["assets", "positions"]).has(view),
+      !new Set(["assets", "positions", "position-history", "orders"]).has(view),
     );
-    el("assets-refresh").title = view === "positions"
-      ? "Refresh positions"
-      : "Refresh assets";
+    const refreshTitles = {
+      assets: "Refresh assets",
+      positions: "Refresh positions",
+      "position-history": "Refresh position history",
+      orders: "Refresh order history",
+    };
+    el("assets-refresh").title = refreshTitles[view] || "Refresh";
     el("assets-refresh").setAttribute("aria-label", el("assets-refresh").title);
     el("assets-title").textContent = accountViewTitles[view];
     if (view === "assets" && assetsPayload) renderAssetsView();
@@ -624,6 +728,12 @@
     else if (view === "positions") {
       await loadPositions(false);
       connectAccountPositions();
+    }
+    else if (view === "position-history") await loadPositionHistory(false);
+    else if (view === "orders") await loadOrderHistory(false);
+    if (deferAccountHeight) {
+      if (isAssetsOpen() && accountView === view) runAccountHeightTween();
+      else accountBox.style.height = ""; // switched away or closed mid-load
     }
   }
 
@@ -1720,8 +1830,11 @@
   }
 
   function formatSignedPositionNumber(value, maximumFractionDigits = 4) {
+    if (value === null || value === undefined || value === "" || typeof value === "boolean") {
+      return "—";
+    }
     const number = Number(value);
-    if (!Number.isFinite(number)) return "Unavailable";
+    if (!Number.isFinite(number)) return "—";
     return `${number > 0 ? "+" : ""}${formatPositionNumber(number, maximumFractionDigits)}`;
   }
 
@@ -1752,7 +1865,7 @@
       button = document.createElement("button");
       button.className = "position-pnl-value";
       button.type = "button";
-      button.title = "Show realized PnL calculation";
+      button.setAttribute("aria-label", "Show realized PnL calculation");
       button.setAttribute("aria-haspopup", "dialog");
       button.setAttribute("aria-expanded", "false");
       cell.replaceChildren(button);
@@ -1764,10 +1877,12 @@
         ? breakdown
         : { gross_pnl: null, fees: null, net_pnl: value, complete: false },
     );
-    cell.title = button.textContent;
+    cell.removeAttribute("title");
   }
 
   let activePositionPnlButton = null;
+  let positionPnlPress = null;
+  let suppressPositionPnlClickUntil = 0;
 
   function closePositionPnlPopover() {
     if (activePositionPnlButton) {
@@ -1800,8 +1915,16 @@
       && Number.isFinite(gross)
       && Number.isFinite(fees)
       && Number.isFinite(net);
+    const feeAdjustment = complete ? -fees : Number.NaN;
     setText(el("position-pnl-gross"), complete ? formatSignedPositionNumber(gross) : "Unavailable");
-    setText(el("position-pnl-fees"), complete ? formatPositionNumber(fees, 4) : "Unavailable");
+    setText(
+      el("position-pnl-fees"),
+      complete ? formatSignedPositionNumber(feeAdjustment) : "Unavailable",
+    );
+    setClass(
+      el("position-pnl-fees"),
+      `mono ${positionPnlClass(feeAdjustment)}`.trim(),
+    );
     setText(el("position-pnl-net"), formatSignedPositionNumber(net));
     setClass(el("position-pnl-net"), `mono ${positionPnlClass(net)}`.trim());
     el("position-pnl-note").classList.toggle("hidden", complete);
@@ -1991,28 +2114,23 @@
       ? "No exchange accounts are configured in providers.toml."
       : "No open positions.";
     el("positions-empty").classList.toggle("hidden", positions.length !== 0);
-    el("positions-table-wrap").classList.toggle("hidden", positions.length === 0);
+    el("positions-list").classList.toggle("hidden", positions.length === 0);
 
-    const tableBody = el("positions-table-body");
+    const list = el("positions-list");
     const existingRows = new Map(
-      Array.from(tableBody.children).map((row) => [row.dataset.positionKey || "", row]),
+      Array.from(list.children).map((row) => [row.dataset.positionKey || "", row]),
     );
     positions.forEach((position, index) => {
       const key = positionRowKey(position);
       let row = existingRows.get(key);
-      if (!row) row = createPositionRow();
+      if (!row) row = createPositionListRow();
       row.dataset.positionKey = key;
-      updatePositionRow(row, position);
-      const currentRow = tableBody.children[index];
-      if (currentRow !== row) tableBody.insertBefore(row, currentRow || null);
+      updatePositionListRow(row, position);
+      const currentRow = list.children[index];
+      if (currentRow !== row) list.insertBefore(row, currentRow || null);
       existingRows.delete(key);
     });
-    existingRows.forEach((row) => {
-      if (activePositionPnlButton && row.contains(activePositionPnlButton)) {
-        closePositionPnlPopover();
-      }
-      row.remove();
-    });
+    existingRows.forEach((row) => row.remove());
 
     const errorContainer = el("positions-account-errors");
     errorContainer.replaceChildren();
@@ -2022,6 +2140,103 @@
       errorContainer.appendChild(item);
     });
     errorContainer.classList.toggle("hidden", errors.length === 0);
+  }
+
+  function createPositionListRow() {
+    const row = document.createElement("article");
+    row.className = "account-history-record account-position-live-record";
+    const header = document.createElement("div");
+    header.className = "account-history-record-header";
+    const identity = document.createElement("div");
+    identity.className = "account-history-record-identity";
+    const logo = document.createElement("span");
+    logo.className = "account-position-live-logo";
+    const copy = document.createElement("div");
+    copy.className = "account-history-record-copy";
+    const symbolLine = document.createElement("div");
+    symbolLine.className = "account-history-record-symbol";
+    const symbol = document.createElement("strong");
+    const side = document.createElement("span");
+    symbolLine.append(symbol, side);
+    const account = document.createElement("small");
+    copy.append(symbolLine, account);
+    identity.append(logo, copy);
+    const trailing = document.createElement("div");
+    trailing.className = "account-history-record-trailing";
+    const trailingLabel = document.createElement("span");
+    trailingLabel.textContent = "Unrealized PnL";
+    const trailingValue = document.createElement("strong");
+    trailing.append(trailingLabel, trailingValue);
+    header.append(identity, trailing);
+    const metrics = document.createElement("div");
+    metrics.className = "account-history-record-metrics";
+    const makeMetric = (label) => {
+      const metric = document.createElement("div");
+      metric.className = "account-history-record-metric";
+      const labelNode = document.createElement("span");
+      labelNode.textContent = label;
+      const valueNode = document.createElement("strong");
+      metric.append(labelNode, valueNode);
+      metrics.appendChild(metric);
+      return valueNode;
+    };
+    row.positionListNodes = {
+      logo,
+      symbol,
+      side,
+      account,
+      trailingValue,
+      size: makeMetric("Size"),
+      entry: makeMetric("Entry Price"),
+      mark: makeMetric("Mark Price"),
+      ret: makeMetric("Return"),
+      leverage: makeMetric("Leverage"),
+      realized: makeMetric("Realized PnL"),
+      liquidation: makeMetric("Liquidation"),
+    };
+    row.append(header, metrics);
+    return row;
+  }
+
+  function updatePositionListRow(row, position) {
+    const nodes = row.positionListNodes;
+    const exchangeName = String(position.exchange || "").toUpperCase();
+    const logoIdentity = `${position.exchange_logo_url || ""}|${exchangeName}`;
+    if (nodes.logo.dataset.identity !== logoIdentity) {
+      setHTML(nodes.logo, logoImg(position.exchange_logo_url, exchangeName, "exchange-logo"));
+      nodes.logo.querySelectorAll("[title]").forEach((n) => n.removeAttribute("title"));
+      nodes.logo.dataset.identity = logoIdentity;
+    }
+    nodes.symbol.textContent = String(position.symbol || "—");
+    const sideText = String(position.side || "—");
+    nodes.side.textContent = sideText;
+    nodes.side.className = sideText.toLowerCase() === "long"
+      ? "account-position-long"
+      : sideText.toLowerCase() === "short" ? "account-position-short" : "";
+    const scope = String(position.market_scope || position.dex || "");
+    nodes.account.textContent = [position.account || "—", scope].filter(Boolean).join(" · ");
+
+    const pnl = position.unrealized_pnl === null || position.unrealized_pnl === undefined
+      ? Number.NaN : Number(position.unrealized_pnl);
+    const pnlClass = positionPnlClass(pnl);
+    nodes.trailingValue.textContent = Number.isFinite(pnl)
+      ? `${pnl > 0 ? "+" : ""}${formatPositionNumber(pnl, 4)}` : "—";
+    nodes.trailingValue.className = pnlClass;
+
+    nodes.size.textContent = formatPositionNumber(position.quantity ?? position.contracts);
+    nodes.entry.textContent = formatPositionNumber(position.entry_price);
+    nodes.mark.textContent = formatPositionNumber(position.mark_price);
+    const percentage = position.percentage === null || position.percentage === undefined
+      ? Number.NaN : Number(position.percentage);
+    nodes.ret.textContent = Number.isFinite(percentage)
+      ? `${percentage > 0 ? "+" : ""}${formatPositionNumber(percentage, 2)}%` : "—";
+    nodes.ret.className = pnlClass;
+    nodes.leverage.textContent = position.leverage !== null
+      && position.leverage !== undefined
+      && Number.isFinite(Number(position.leverage))
+      ? `${formatPositionNumber(position.leverage, 2)}x` : "—";
+    updatePositionRealizedPnlCell(nodes.realized, position);
+    nodes.liquidation.textContent = formatPositionNumber(position.liquidation_price);
   }
 
   function setPositionsLoading(loading, preserveContent = false) {
@@ -2035,9 +2250,9 @@
       positionsPayload = null;
       el("positions-summary").classList.add("hidden");
       el("positions-empty").classList.add("hidden");
-      el("positions-table-wrap").classList.add("hidden");
+      el("positions-list").classList.add("hidden");
       el("positions-account-errors").classList.add("hidden");
-      el("positions-table-body").replaceChildren();
+      el("positions-list").replaceChildren();
     }
   }
 
@@ -2055,11 +2270,847 @@
       el("positions-error").classList.remove("hidden");
       if (!preserveContent) {
         el("positions-summary").classList.add("hidden");
-        el("positions-table-wrap").classList.add("hidden");
+        el("positions-list").classList.add("hidden");
       }
     } finally {
       if (seq === positionsRequestSeq) setPositionsLoading(false);
     }
+  }
+
+  function formatAccountHistoryDate(value, includeSeconds = false) {
+    const timestamp = Date.parse(String(value || ""));
+    if (!Number.isFinite(timestamp)) return "—";
+    const options = {
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      hour12: false,
+    };
+    if (includeSeconds) options.second = "2-digit";
+    return new Date(timestamp).toLocaleString("en-US", options);
+  }
+
+  function formatAccountHistoryDuration(openedAt, closedAt) {
+    const opened = Date.parse(String(openedAt || ""));
+    const closed = Date.parse(String(closedAt || ""));
+    if (!Number.isFinite(opened) || !Number.isFinite(closed) || closed < opened) return "—";
+    let seconds = Math.floor((closed - opened) / 1000);
+    const days = Math.floor(seconds / 86400);
+    seconds %= 86400;
+    const hours = Math.floor(seconds / 3600);
+    seconds %= 3600;
+    const minutes = Math.floor(seconds / 60);
+    if (days) return `${days}d ${hours}h`;
+    if (hours) return `${hours}h ${minutes}m`;
+    if (minutes) return `${minutes}m`;
+    return `${seconds}s`;
+  }
+
+  function createHistoryMetric(label, value, className = "") {
+    const metric = document.createElement("div");
+    metric.className = "account-history-record-metric";
+    const labelNode = document.createElement("span");
+    labelNode.textContent = label;
+    const valueNode = document.createElement("strong");
+    valueNode.textContent = value;
+    if (className) valueNode.className = className;
+    metric.append(labelNode, valueNode);
+    return metric;
+  }
+
+  function createHistoryRecordHeader(
+    record,
+    detailParts,
+    trailingLabel,
+    trailingValue,
+    trailingClass = "",
+  ) {
+    const header = document.createElement("div");
+    header.className = "account-history-record-header";
+
+    const identity = document.createElement("div");
+    identity.className = "account-history-record-identity";
+    const exchangeName = String(record.exchange || "").toUpperCase();
+    setHTML(identity, logoImg(record.exchange_logo_url, exchangeName, "exchange-logo"));
+    identity.querySelectorAll("[title]").forEach((node) => node.removeAttribute("title"));
+
+    const copy = document.createElement("div");
+    copy.className = "account-history-record-copy";
+    const symbolLine = document.createElement("div");
+    symbolLine.className = "account-history-record-symbol";
+    const symbol = document.createElement("strong");
+    symbol.textContent = String(record.symbol || "—");
+    symbolLine.appendChild(symbol);
+    detailParts.filter(Boolean).forEach(({ text, className = "" }) => {
+      const detail = document.createElement("span");
+      detail.textContent = text;
+      if (className) detail.className = className;
+      symbolLine.appendChild(detail);
+    });
+    const account = document.createElement("small");
+    const scope = String(record.market_scope || record.dex || "");
+    account.textContent = [record.account || "—", scope].filter(Boolean).join(" · ");
+    copy.append(symbolLine, account);
+    identity.appendChild(copy);
+
+    header.appendChild(identity);
+    if (trailingValue !== null && trailingValue !== undefined) {
+      const trailing = document.createElement("div");
+      trailing.className = "account-history-record-trailing";
+      if (trailingLabel) {
+        const trailingLabelNode = document.createElement("span");
+        trailingLabelNode.textContent = trailingLabel;
+        trailing.appendChild(trailingLabelNode);
+      }
+      const trailingNode = document.createElement("strong");
+      trailingNode.textContent = trailingValue;
+      if (trailingClass) trailingNode.className = trailingClass;
+      trailing.appendChild(trailingNode);
+      header.appendChild(trailing);
+    }
+    return header;
+  }
+
+  function createPositionHistoryRow(record) {
+    const position = record.position && typeof record.position === "object"
+      ? record.position
+      : {};
+    const row = document.createElement("article");
+    row.className = "account-history-record account-position-history-record";
+    const side = String(record.side || position.side || "—");
+    const sideClass = side.toLowerCase() === "long"
+      ? "account-position-long"
+      : side.toLowerCase() === "short" ? "account-position-short" : "";
+    const partiallyClosed = record.close_status === "partially_closed";
+    const closeStatus = partiallyClosed ? "Partially closed" : "Fully closed";
+    const closeStatusClass = partiallyClosed
+      ? "account-position-close-status account-position-partially-closed"
+      : "account-position-close-status account-position-fully-closed";
+    const header = createHistoryRecordHeader(
+      record,
+      [
+        { text: side, className: sideClass },
+        { text: closeStatus, className: closeStatusClass },
+      ],
+      "Realized PnL",
+      formatSignedPositionNumber(position.realized_pnl),
+      positionPnlClass(position.realized_pnl),
+    );
+    const realizedNode = header.querySelector(".account-history-record-trailing > strong");
+    if (realizedNode) updatePositionRealizedPnlCell(realizedNode, position);
+    row.appendChild(header);
+    const metrics = document.createElement("div");
+    metrics.className = "account-history-record-metrics";
+    metrics.append(
+      createHistoryMetric("Opened", formatAccountHistoryDate(record.opened_at, true)),
+      createHistoryMetric("Closed", formatAccountHistoryDate(record.closed_at, true)),
+      createHistoryMetric("Entry Price", formatPositionNumber(position.entry_price)),
+      createHistoryMetric("Avg Close Price", formatPositionNumber(position.exit_price)),
+      createHistoryMetric("Size", formatPositionNumber(position.quantity ?? position.contracts)),
+      createHistoryMetric(
+        "Duration",
+        formatAccountHistoryDuration(record.opened_at, record.closed_at),
+      ),
+    );
+    row.appendChild(metrics);
+    return row;
+  }
+
+  function createOrderHistoryRow(record) {
+    const order = record.order && typeof record.order === "object" ? record.order : {};
+    const row = document.createElement("article");
+    row.className = "account-history-record account-order-history-record";
+    const side = String(record.side || order.side || "—");
+    const sideClass = side.toLowerCase() === "buy"
+      ? "account-position-long"
+      : side.toLowerCase() === "sell" ? "account-position-short" : "";
+    const status = String(record.status || order.status || "—");
+    const statusClass = `account-order-status account-order-status-${status
+      .toLowerCase().replace(/[^a-z0-9]+/g, "-")}`;
+    row.appendChild(createHistoryRecordHeader(
+      record,
+      [
+        { text: String(record.order_type || order.type || "—") },
+        { text: side, className: sideClass },
+      ],
+      "",
+      null,
+    ));
+    const metrics = document.createElement("div");
+    metrics.className = "account-history-record-metrics";
+    metrics.append(
+      createHistoryMetric("Status", status, statusClass),
+      createHistoryMetric("Amount", formatPositionNumber(order.amount)),
+      createHistoryMetric("Filled", formatPositionNumber(order.filled)),
+      createHistoryMetric(
+        "Avg Price",
+        formatPositionNumber(order.average_price ?? order.price),
+      ),
+      createHistoryMetric("Created", formatAccountHistoryDate(record.created_at, true)),
+    );
+    row.appendChild(metrics);
+    return row;
+  }
+
+  function historyNavigation(kind) {
+    return kind === "position" ? positionHistoryNavigation : orderHistoryNavigation;
+  }
+
+  function historyPrefix(kind) {
+    return kind === "position" ? "position-history" : "order-history";
+  }
+
+  function updateHistoryNavigation(kind) {
+    const prefix = historyPrefix(kind);
+    const navigation = historyNavigation(kind);
+    const isDetails = navigation.level === "details";
+    el(`${prefix}-groups`).classList.toggle("hidden", isDetails);
+    el(`${prefix}-details`).classList.toggle("hidden", !isDetails);
+    el(`${prefix}-back`).classList.toggle(
+      "hidden",
+      navigation.level === "exchanges",
+    );
+
+    let title = "Exchanges";
+    let subtitle = "Choose an exchange";
+    if (navigation.level === "symbols") {
+      title = navigation.exchange.toUpperCase();
+      subtitle = "Choose a symbol";
+    } else if (isDetails) {
+      title = navigation.symbol || "History";
+      subtitle = navigation.exchange.toUpperCase();
+    }
+    el(`${prefix}-navigation-title`).textContent = title;
+    el(`${prefix}-navigation-subtitle`).textContent = subtitle;
+  }
+
+  function historyQuery(prefix, navigation, cursor, includeStatus = false) {
+    const params = new URLSearchParams({ limit: String(accountHistoryPageSize) });
+    if (cursor) params.set("cursor", cursor);
+    const account = String(el(`${prefix}-account`).value || "").trim();
+    if (account) params.set("account", account);
+    if (navigation.exchange) params.set("exchange", navigation.exchange);
+    if (navigation.symbol) params.set("symbol", navigation.symbol);
+    params.set("exact_market", "true");
+    if (includeStatus) {
+      const status = String(el(`${prefix}-status`).value || "").trim();
+      if (status) params.set("status", status);
+    }
+    return params;
+  }
+
+  async function refreshAccountHistory(kind) {
+    const navigation = historyNavigation(kind);
+    const prefix = historyPrefix(kind);
+    const account = navigation.level === "details"
+      ? String(el(`${prefix}-account`).value || "").trim()
+      : "";
+    await api("/api/account/history/refresh", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        kind,
+        account,
+        exchange: navigation.exchange,
+        symbol: navigation.symbol,
+      }),
+    });
+  }
+
+  function historyGroupRow(kind, group, level) {
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "account-history-group-row";
+    const exchange = String(group.exchange || "");
+    const symbol = String(group.symbol || "");
+    const label = level === "exchanges" ? exchange.toUpperCase() : symbol;
+    row.setAttribute("aria-label", `Show ${label} history`);
+
+    const identity = document.createElement("span");
+    identity.className = "account-history-group-identity";
+    if (level === "exchanges") {
+      const logo = document.createElement("span");
+      setHTML(logo, logoImg(group.exchange_logo_url, label, "exchange-logo"));
+      logo.querySelectorAll("[title]").forEach((node) => node.removeAttribute("title"));
+      identity.appendChild(logo);
+    }
+    const copy = document.createElement("span");
+    copy.className = "account-history-group-copy";
+    const name = document.createElement("strong");
+    name.textContent = label || "Unknown";
+    const accounts = document.createElement("small");
+    const accountCount = Number(group.account_count || 0);
+    accounts.textContent = `${accountCount} account${accountCount === 1 ? "" : "s"}`;
+    copy.append(name, accounts);
+    identity.appendChild(copy);
+
+    const summary = document.createElement("span");
+    summary.className = "account-history-group-summary";
+    const count = document.createElement("span");
+    const recordCount = Number(group.record_count || 0);
+    count.textContent = `${recordCount.toLocaleString()} record${recordCount === 1 ? "" : "s"}`;
+    const latest = document.createElement("small");
+    latest.textContent = `Latest ${formatAccountHistoryDate(group.latest_at)}`;
+    summary.append(count, latest);
+
+    const chevron = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    chevron.classList.add("account-history-group-chevron");
+    chevron.setAttribute("viewBox", "0 0 24 24");
+    chevron.setAttribute("aria-hidden", "true");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "m9 18 6-6-6-6");
+    chevron.appendChild(path);
+    row.append(identity, summary, chevron);
+    row.addEventListener("click", () => openHistoryGroup(kind, group));
+    return row;
+  }
+
+  // Smoothly animate the modal-box height across a history content change
+  // (navigation between exchange/symbol/detail levels, or a filter reload).
+  // begin() pins the current height before the swap; commit() (called from the
+  // render) releases to the natural height and transitions between the two.
+  let historyFlipHeight = null;
+  let historyFlipTimer = null;
+
+  function historyFlipBegin() {
+    const box = document.querySelector(".assets-modal-box");
+    if (!box
+      || mobileHubQuery.matches
+      || window.matchMedia("(prefers-reduced-motion: reduce)").matches
+      || el("assets-modal").classList.contains("hidden")) {
+      return;
+    }
+    historyFlipHeight = box.offsetHeight;
+    box.style.height = `${historyFlipHeight}px`;
+    if (historyFlipTimer !== null) clearTimeout(historyFlipTimer);
+    historyFlipTimer = window.setTimeout(() => {
+      historyFlipTimer = null;
+      historyFlipHeight = null;
+      box.style.height = "";
+    }, 2000);
+  }
+
+  function historyFlipCommit() {
+    if (historyFlipHeight === null) return;
+    if (historyFlipTimer !== null) {
+      clearTimeout(historyFlipTimer);
+      historyFlipTimer = null;
+    }
+    const box = document.querySelector(".assets-modal-box");
+    const start = historyFlipHeight;
+    historyFlipHeight = null;
+    if (!box) return;
+    box.style.height = "";
+    const end = box.offsetHeight;
+    if (Math.abs(end - start) <= 1) return;
+    box.style.height = `${start}px`;
+    void box.offsetHeight; // reflow to lock the start height
+    box.style.height = `${end}px`;
+    const onEnd = (event) => {
+      if (event.target !== box || event.propertyName !== "height") return;
+      box.removeEventListener("transitionend", onEnd);
+      box.style.height = "";
+    };
+    box.addEventListener("transitionend", onEnd);
+  }
+
+  function renderHistoryGroups(kind, payload) {
+    const prefix = historyPrefix(kind);
+    const navigation = historyNavigation(kind);
+    updateHistoryNavigation(kind);
+    const groups = Array.isArray(payload.results) ? payload.results : [];
+    const container = el(`${prefix}-groups`);
+    const list = document.createElement("div");
+    list.className = "account-history-group-list";
+    groups.forEach((group) => {
+      list.appendChild(historyGroupRow(kind, group, navigation.level));
+    });
+    container.replaceChildren(list);
+    if (kind === "position") positionHistoryGroupsHaveData = true;
+    else orderHistoryGroupsHaveData = true;
+
+    const summary = payload.summary || {};
+    const groupLabel = navigation.level === "exchanges" ? "exchanges" : "symbols";
+    el(`${prefix}-navigation-subtitle`).textContent = groups.length
+      ? `${groups.length} ${groupLabel} · ${Number(summary.total || 0).toLocaleString()} records`
+      : navigation.level === "exchanges" ? "Choose an exchange" : "Choose a symbol";
+    el(`${prefix}-empty`).textContent = navigation.level === "exchanges"
+      ? `No ${kind === "position" ? "position" : "order"} history.`
+      : `No history found for ${navigation.exchange.toUpperCase()}.`;
+    el(`${prefix}-empty`).classList.toggle("hidden", groups.length !== 0);
+    el(`${prefix}-meta`).classList.add("hidden");
+    el(`${prefix}-loading`).classList.add("hidden");
+    historyFlipCommit();
+  }
+
+  function openHistoryGroup(kind, group) {
+    historyFlipBegin();
+    const navigation = historyNavigation(kind);
+    if (navigation.level === "exchanges") {
+      navigation.level = "symbols";
+      navigation.exchange = String(group.exchange || "");
+      navigation.symbol = "";
+      if (kind === "position") positionHistoryGroupsHaveData = false;
+      else orderHistoryGroupsHaveData = false;
+    } else if (navigation.level === "symbols") {
+      navigation.level = "details";
+      navigation.symbol = String(group.symbol || "");
+      if (kind === "position") {
+        el("position-history-account").value = "";
+        resetPositionHistory();
+      } else {
+        el("order-history-account").value = "";
+        el("order-history-status").value = "";
+        resetOrderHistory();
+      }
+    }
+    updateHistoryNavigation(kind);
+    if (kind === "position") loadPositionHistory(false);
+    else loadOrderHistory(false);
+  }
+
+  function navigateHistoryBack(kind) {
+    historyFlipBegin();
+    const navigation = historyNavigation(kind);
+    if (navigation.level === "details") {
+      navigation.level = "symbols";
+      navigation.symbol = "";
+    } else if (navigation.level === "symbols") {
+      navigation.level = "exchanges";
+      navigation.exchange = "";
+    } else {
+      return;
+    }
+    if (kind === "position") {
+      resetPositionHistory();
+      positionHistoryGroupsHaveData = false;
+    } else {
+      resetOrderHistory();
+      orderHistoryGroupsHaveData = false;
+    }
+    updateHistoryNavigation(kind);
+    if (kind === "position") loadPositionHistory(false);
+    else loadOrderHistory(false);
+  }
+
+  function resetHistoryNavigation(kind) {
+    const navigation = historyNavigation(kind);
+    navigation.level = "exchanges";
+    navigation.exchange = "";
+    navigation.symbol = "";
+    if (kind === "position") {
+      positionHistoryGroupsHaveData = false;
+      el("position-history-account").value = "";
+      resetPositionHistory();
+    } else {
+      orderHistoryGroupsHaveData = false;
+      el("order-history-account").value = "";
+      el("order-history-status").value = "";
+      resetOrderHistory();
+    }
+    updateHistoryNavigation(kind);
+  }
+
+  function fillHistorySelect(selectEl, values, allLabel) {
+    const current = selectEl.value;
+    const seen = [];
+    values.forEach((value) => {
+      const text = String(value || "").trim();
+      if (text && !seen.includes(text)) seen.push(text);
+    });
+    seen.sort((a, b) => a.localeCompare(b));
+    selectEl.replaceChildren();
+    const allOption = document.createElement("option");
+    allOption.value = "";
+    allOption.textContent = allLabel;
+    selectEl.appendChild(allOption);
+    seen.forEach((text) => {
+      const option = document.createElement("option");
+      option.value = text;
+      option.textContent = text;
+      selectEl.appendChild(option);
+    });
+    selectEl.value = seen.includes(current) ? current : "";
+    const custom = historyCustomSelects[selectEl.id];
+    if (custom) custom.sync();
+  }
+
+  // Custom dropdown skin over a native <select>, matching the Add-session
+  // script selector. Reads its options from the native select and dispatches a
+  // native "change" event on choose (so existing filter handlers still fire).
+  function setupHistoryCustomSelect(selectId) {
+    const select = el(selectId);
+    const control = el(`${selectId}-control`);
+    const button = el(`${selectId}-button`);
+    const label = el(`${selectId}-label`);
+    const optionsBox = el(`${selectId}-options`);
+    if (!select || !control || !button || !label || !optionsBox) return;
+    let activeIndex = -1;
+
+    const sync = () => {
+      const selected = select.options[select.selectedIndex];
+      const text = selected ? selected.textContent : "";
+      label.textContent = text;
+      button.title = text;
+      optionsBox.querySelectorAll(".script-select-option").forEach((opt, index) => {
+        const on = opt.dataset.value === select.value;
+        opt.classList.toggle("selected", on);
+        opt.classList.toggle("active", index === activeIndex);
+        opt.setAttribute("aria-selected", on ? "true" : "false");
+      });
+    };
+    const render = () => {
+      const opts = Array.from(select.options);
+      if (!opts.length) {
+        optionsBox.innerHTML = `<div class="script-select-empty">No options</div>`;
+        return;
+      }
+      optionsBox.innerHTML = opts.map((option, index) => {
+        const on = option.value === select.value;
+        const active = index === activeIndex;
+        return `<button type="button" role="option" `
+          + `class="script-select-option${on ? " selected" : ""}${active ? " active" : ""}" `
+          + `data-value="${esc(option.value)}" aria-selected="${on ? "true" : "false"}" `
+          + `title="${esc(option.textContent)}">${esc(option.textContent)}</button>`;
+      }).join("");
+    };
+    const open = () => {
+      activeIndex = Math.max(0, select.selectedIndex);
+      render();
+      control.classList.add("open");
+      button.setAttribute("aria-expanded", "true");
+      optionsBox.classList.remove("hidden");
+    };
+    const close = () => {
+      control.classList.remove("open");
+      button.setAttribute("aria-expanded", "false");
+      optionsBox.classList.add("hidden");
+    };
+    const choose = (value) => {
+      close();
+      if (select.value === value) return;
+      select.value = value;
+      select.dispatchEvent(new Event("change", { bubbles: true }));
+    };
+    const move = (delta) => {
+      const count = select.options.length;
+      if (!count) return;
+      activeIndex = Math.max(0, Math.min((activeIndex < 0 ? 0 : activeIndex) + delta, count - 1));
+      render();
+      const active = optionsBox.querySelector(".script-select-option.active");
+      if (active) active.scrollIntoView({ block: "nearest" });
+    };
+    const commit = () => {
+      if (activeIndex < 0 || activeIndex >= select.options.length) return;
+      choose(select.options[activeIndex].value);
+      button.focus();
+    };
+
+    button.addEventListener("click", (event) => {
+      event.preventDefault();
+      if (optionsBox.classList.contains("hidden")) open();
+      else close();
+    });
+    button.addEventListener("keydown", (event) => {
+      const isOpen = !optionsBox.classList.contains("hidden");
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        if (!isOpen) open();
+        else move(event.key === "ArrowDown" ? 1 : -1);
+      } else if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        if (isOpen) commit();
+        else open();
+      } else if (event.key === "Escape") {
+        close();
+      }
+    });
+    optionsBox.addEventListener("click", (event) => {
+      const opt = event.target && event.target.closest
+        ? event.target.closest(".script-select-option")
+        : null;
+      if (!opt) return;
+      choose(opt.dataset.value || "");
+      button.focus();
+    });
+    optionsBox.addEventListener("keydown", (event) => {
+      if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+        event.preventDefault();
+        move(event.key === "ArrowDown" ? 1 : -1);
+      } else if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        commit();
+      } else if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+        button.focus();
+      }
+    });
+    document.addEventListener("click", (event) => {
+      if (event.target && !control.contains(event.target)) close();
+    });
+    select.addEventListener("change", sync);
+
+    historyCustomSelects[selectId] = { sync, close };
+    sync();
+  }
+
+  function renderPositionHistory(payload, append) {
+    const incoming = Array.isArray(payload.results) ? payload.results : [];
+    positionHistoryRows = append ? positionHistoryRows.concat(incoming) : incoming;
+    positionHistoryCursor = payload.next_cursor || null;
+    positionHistoryTotal = Number(payload.summary && payload.summary.total || 0);
+    positionHistoryHaveData = true;
+    if (!append && !el("position-history-account").value) {
+      fillHistorySelect(
+        el("position-history-account"),
+        positionHistoryRows.map((row) => row.account),
+        "All accounts",
+      );
+    }
+    updateHistoryNavigation("position");
+    const body = el("position-history-table-body");
+    closePositionPnlPopover();
+    body.replaceChildren(...positionHistoryRows.map(createPositionHistoryRow));
+    el("position-history-table-wrap").classList.toggle("hidden", positionHistoryRows.length === 0);
+    el("position-history-empty").classList.toggle("hidden", positionHistoryRows.length !== 0);
+    el("position-history-meta").textContent = positionHistoryRows.length
+      ? `${positionHistoryRows.length} of ${positionHistoryTotal} records`
+      : "";
+    el("position-history-meta").classList.toggle("hidden", positionHistoryRows.length === 0);
+    el("position-history-more").classList.toggle("hidden", !positionHistoryCursor);
+    el("position-history-loading").classList.add("hidden");
+    historyFlipCommit();
+  }
+
+  function renderOrderHistory(payload, append) {
+    const incoming = Array.isArray(payload.results) ? payload.results : [];
+    orderHistoryRows = append ? orderHistoryRows.concat(incoming) : incoming;
+    orderHistoryCursor = payload.next_cursor || null;
+    orderHistoryTotal = Number(payload.summary && payload.summary.total || 0);
+    orderHistoryHaveData = true;
+    if (!append) {
+      if (!el("order-history-account").value) {
+        fillHistorySelect(
+          el("order-history-account"),
+          orderHistoryRows.map((row) => row.account),
+          "All accounts",
+        );
+      }
+      if (!el("order-history-status").value) {
+        fillHistorySelect(
+          el("order-history-status"),
+          orderHistoryRows.map((row) => row.status),
+          "All statuses",
+        );
+      }
+    }
+    updateHistoryNavigation("order");
+    const body = el("order-history-table-body");
+    body.replaceChildren(...orderHistoryRows.map(createOrderHistoryRow));
+    el("order-history-table-wrap").classList.toggle("hidden", orderHistoryRows.length === 0);
+    el("order-history-empty").classList.toggle("hidden", orderHistoryRows.length !== 0);
+    el("order-history-meta").textContent = orderHistoryRows.length
+      ? `${orderHistoryRows.length} of ${orderHistoryTotal} records`
+      : "";
+    el("order-history-meta").classList.toggle("hidden", orderHistoryRows.length === 0);
+    el("order-history-more").classList.toggle("hidden", !orderHistoryCursor);
+    el("order-history-loading").classList.add("hidden");
+    historyFlipCommit();
+  }
+
+  function setPositionHistoryLoading(loading, preserveContent, append) {
+    if (accountView === "position-history") {
+      el("assets-refresh").disabled = loading;
+      el("assets-refresh").classList.toggle("assets-refreshing", loading);
+    }
+    el("position-history-loading").classList.toggle("hidden", !loading || preserveContent);
+    el("position-history-more").disabled = loading;
+    el("position-history-more").textContent = loading && append ? "Loading..." : "Load more";
+    if (loading) el("position-history-error").classList.add("hidden");
+    if (loading && !preserveContent) {
+      el("position-history-meta").classList.add("hidden");
+      el("position-history-empty").classList.add("hidden");
+      el("position-history-table-wrap").classList.add("hidden");
+      el("position-history-more").classList.add("hidden");
+      el("position-history-table-body").replaceChildren();
+      if (positionHistoryNavigation.level !== "details") {
+        el("position-history-groups").replaceChildren();
+      }
+    }
+  }
+
+  function setOrderHistoryLoading(loading, preserveContent, append) {
+    if (accountView === "orders") {
+      el("assets-refresh").disabled = loading;
+      el("assets-refresh").classList.toggle("assets-refreshing", loading);
+    }
+    el("order-history-loading").classList.toggle("hidden", !loading || preserveContent);
+    el("order-history-more").disabled = loading;
+    el("order-history-more").textContent = loading && append ? "Loading..." : "Load more";
+    if (loading) el("order-history-error").classList.add("hidden");
+    if (loading && !preserveContent) {
+      el("order-history-meta").classList.add("hidden");
+      el("order-history-empty").classList.add("hidden");
+      el("order-history-table-wrap").classList.add("hidden");
+      el("order-history-more").classList.add("hidden");
+      el("order-history-table-body").replaceChildren();
+      if (orderHistoryNavigation.level !== "details") {
+        el("order-history-groups").replaceChildren();
+      }
+    }
+  }
+
+  async function loadPositionHistoryGroups(force = false) {
+    const seq = ++positionHistoryRequestSeq;
+    const level = positionHistoryNavigation.level;
+    const exchange = positionHistoryNavigation.exchange;
+    const preserveContent = positionHistoryGroupsHaveData;
+    setPositionHistoryLoading(true, preserveContent, false);
+    updateHistoryNavigation("position");
+    const params = new URLSearchParams();
+    if (level === "symbols" && exchange) params.set("exchange", exchange);
+    try {
+      if (force) await refreshAccountHistory("position");
+      const query = params.toString();
+      const suffix = query ? `?${query}` : "";
+      const payload = await api(`/api/account/position-history/groups${suffix}`);
+      if (
+        seq !== positionHistoryRequestSeq
+        || !isAssetsOpen()
+        || accountView !== "position-history"
+        || positionHistoryNavigation.level !== level
+        || positionHistoryNavigation.exchange !== exchange
+      ) return;
+      renderHistoryGroups("position", payload);
+    } catch (error) {
+      if (seq !== positionHistoryRequestSeq || accountView !== "position-history") return;
+      el("position-history-error").textContent = `${error.message}\nUse refresh to try again.`;
+      el("position-history-error").classList.remove("hidden");
+    } finally {
+      if (seq === positionHistoryRequestSeq) {
+        setPositionHistoryLoading(false, positionHistoryGroupsHaveData, false);
+      }
+    }
+  }
+
+  async function loadOrderHistoryGroups(force = false) {
+    const seq = ++orderHistoryRequestSeq;
+    const level = orderHistoryNavigation.level;
+    const exchange = orderHistoryNavigation.exchange;
+    const preserveContent = orderHistoryGroupsHaveData;
+    setOrderHistoryLoading(true, preserveContent, false);
+    updateHistoryNavigation("order");
+    const params = new URLSearchParams();
+    if (level === "symbols" && exchange) params.set("exchange", exchange);
+    try {
+      if (force) await refreshAccountHistory("order");
+      const query = params.toString();
+      const suffix = query ? `?${query}` : "";
+      const payload = await api(`/api/account/orders/groups${suffix}`);
+      if (
+        seq !== orderHistoryRequestSeq
+        || !isAssetsOpen()
+        || accountView !== "orders"
+        || orderHistoryNavigation.level !== level
+        || orderHistoryNavigation.exchange !== exchange
+      ) return;
+      renderHistoryGroups("order", payload);
+    } catch (error) {
+      if (seq !== orderHistoryRequestSeq || accountView !== "orders") return;
+      el("order-history-error").textContent = `${error.message}\nUse refresh to try again.`;
+      el("order-history-error").classList.remove("hidden");
+    } finally {
+      if (seq === orderHistoryRequestSeq) {
+        setOrderHistoryLoading(false, orderHistoryGroupsHaveData, false);
+      }
+    }
+  }
+
+  async function loadPositionHistory(append = false, force = false) {
+    if (positionHistoryNavigation.level !== "details") {
+      await loadPositionHistoryGroups(force);
+      return;
+    }
+    if (append && !positionHistoryCursor) return;
+    const seq = ++positionHistoryRequestSeq;
+    const preserveContent = positionHistoryHaveData || append;
+    setPositionHistoryLoading(true, preserveContent, append);
+    try {
+      if (force) await refreshAccountHistory("position");
+      const query = historyQuery(
+        "position-history",
+        positionHistoryNavigation,
+        append ? positionHistoryCursor : null,
+      );
+      const payload = await api(`/api/account/position-history?${query}`);
+      if (
+        seq !== positionHistoryRequestSeq
+        || !isAssetsOpen()
+        || accountView !== "position-history"
+      ) return;
+      renderPositionHistory(payload, append);
+    } catch (error) {
+      if (
+        seq !== positionHistoryRequestSeq
+        || !isAssetsOpen()
+        || accountView !== "position-history"
+      ) return;
+      el("position-history-error").textContent = `${error.message}\nUse refresh to try again.`;
+      el("position-history-error").classList.remove("hidden");
+    } finally {
+      if (seq === positionHistoryRequestSeq) {
+        setPositionHistoryLoading(false, positionHistoryHaveData, append);
+      }
+    }
+  }
+
+  async function loadOrderHistory(append = false, force = false) {
+    if (orderHistoryNavigation.level !== "details") {
+      await loadOrderHistoryGroups(force);
+      return;
+    }
+    if (append && !orderHistoryCursor) return;
+    const seq = ++orderHistoryRequestSeq;
+    const preserveContent = orderHistoryHaveData || append;
+    setOrderHistoryLoading(true, preserveContent, append);
+    try {
+      if (force) await refreshAccountHistory("order");
+      const query = historyQuery(
+        "order-history",
+        orderHistoryNavigation,
+        append ? orderHistoryCursor : null,
+        true,
+      );
+      const payload = await api(`/api/account/orders?${query}`);
+      if (seq !== orderHistoryRequestSeq || !isAssetsOpen() || accountView !== "orders") return;
+      renderOrderHistory(payload, append);
+    } catch (error) {
+      if (seq !== orderHistoryRequestSeq || !isAssetsOpen() || accountView !== "orders") return;
+      el("order-history-error").textContent = `${error.message}\nUse refresh to try again.`;
+      el("order-history-error").classList.remove("hidden");
+    } finally {
+      if (seq === orderHistoryRequestSeq) {
+        setOrderHistoryLoading(false, orderHistoryHaveData, append);
+      }
+    }
+  }
+
+  function resetPositionHistory() {
+    positionHistoryRequestSeq += 1;
+    positionHistoryHaveData = false;
+    positionHistoryRows = [];
+    positionHistoryCursor = null;
+    positionHistoryTotal = 0;
+  }
+
+  function resetOrderHistory() {
+    orderHistoryRequestSeq += 1;
+    orderHistoryHaveData = false;
+    orderHistoryRows = [];
+    orderHistoryCursor = null;
+    orderHistoryTotal = 0;
   }
 
   function clearAccountPositionsTimers() {
@@ -2770,12 +3821,28 @@
     el("hub-menu-close").addEventListener("click", closeHubMenu);
     el("hub-menu-backdrop").addEventListener("click", closeHubMenu);
     el("hub-calendar-open").addEventListener("click", openCalendar);
+    // Expand/collapse an accordion section to its exact content height so the
+    // easing settles on-screen instead of being cut off mid-curve (which reads
+    // as an abrupt "snap"). scrollHeight ignores the max-height clamp, so it
+    // always reports the true content height in either state.
+    const setSectionOpen = (menu, open) => {
+      if (open) {
+        menu.classList.add("open");
+        menu.style.maxHeight = `${menu.scrollHeight}px`;
+      } else {
+        menu.style.maxHeight = `${menu.scrollHeight}px`;
+        void menu.offsetHeight; // lock the current height before collapsing to 0
+        menu.classList.remove("open");
+        menu.style.maxHeight = "0px";
+      }
+    };
     el("hub-account-toggle").addEventListener("click", () => {
       const menu = el("hub-account-menu");
-      const expanded = el("hub-account-toggle").getAttribute("aria-expanded") === "true";
-      el("hub-account-toggle").setAttribute("aria-expanded", String(!expanded));
-      menu.classList.toggle("open", !expanded);
-      menu.setAttribute("aria-hidden", String(expanded));
+      const toggle = el("hub-account-toggle");
+      const willOpen = toggle.getAttribute("aria-expanded") !== "true";
+      toggle.setAttribute("aria-expanded", String(willOpen));
+      menu.setAttribute("aria-hidden", String(!willOpen));
+      setSectionOpen(menu, willOpen);
     });
     el("hub-account-menu").addEventListener("click", (event) => {
       const button = event.target && event.target.closest
@@ -2786,10 +3853,14 @@
     });
     el("hub-history-toggle").addEventListener("click", () => {
       const menu = el("hub-history-menu");
-      const expanded = el("hub-history-toggle").getAttribute("aria-expanded") === "true";
-      el("hub-history-toggle").setAttribute("aria-expanded", String(!expanded));
-      menu.classList.toggle("open", !expanded);
-      menu.setAttribute("aria-hidden", String(expanded));
+      const toggle = el("hub-history-toggle");
+      const willOpen = toggle.getAttribute("aria-expanded") !== "true";
+      toggle.setAttribute("aria-expanded", String(willOpen));
+      menu.setAttribute("aria-hidden", String(!willOpen));
+      // release the account submenu's fixed clamp so it grows/shrinks to fit the
+      // nested History section as it animates
+      el("hub-account-menu").style.maxHeight = "none";
+      setSectionOpen(menu, willOpen);
     });
     el("hub-update-button").addEventListener("click", checkForUpdate);
     el("update-close").addEventListener("click", closeUpdateModal);
@@ -2925,6 +3996,8 @@
     initMobileHubMenuSwipe();
     initMobileCalendarGestures();
     const accountTabs = document.querySelector(".account-tabs");
+    let accountTabGesture = null;
+    let suppressAccountTabClickUntil = 0;
     function accountTabFromEvent(event) {
       return event.target && event.target.closest
         ? event.target.closest("[data-account-view]")
@@ -2934,13 +4007,52 @@
       if (!event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
       const button = accountTabFromEvent(event);
       if (!button) return;
-      switchAccountView(String(button.dataset.accountView || "assets"), { load: true });
+      if (event.pointerType === "mouse") return;
+      accountTabGesture = {
+        id: event.pointerId,
+        button,
+        startX: event.clientX,
+        startY: event.clientY,
+        moved: false,
+      };
+    });
+    accountTabs.addEventListener("pointermove", (event) => {
+      if (!accountTabGesture || event.pointerId !== accountTabGesture.id) return;
+      if (
+        Math.abs(event.clientX - accountTabGesture.startX) > 8
+        || Math.abs(event.clientY - accountTabGesture.startY) > 8
+      ) {
+        accountTabGesture.moved = true;
+      }
+    }, { passive: true });
+    accountTabs.addEventListener("pointerup", (event) => {
+      if (!accountTabGesture || event.pointerId !== accountTabGesture.id) return;
+      const gesture = accountTabGesture;
+      accountTabGesture = null;
+      if (gesture.moved) return;
+      event.preventDefault();
+      event.stopPropagation();
+      suppressAccountTabClickUntil = Date.now() + 400;
+      const view = String(gesture.button.dataset.accountView || "assets");
+      if (view !== accountView || accountViewIsDrilledIn(view)) {
+        switchAccountView(view, { load: true, animate: true });
+      }
+    });
+    accountTabs.addEventListener("pointercancel", () => {
+      accountTabGesture = null;
     });
     accountTabs.addEventListener("click", (event) => {
+      if (Date.now() < suppressAccountTabClickUntil) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
       const button = accountTabFromEvent(event);
       if (!button) return;
       const view = String(button.dataset.accountView || "assets");
-      if (view !== accountView) switchAccountView(view, { load: true });
+      if (view !== accountView || accountViewIsDrilledIn(view)) {
+        switchAccountView(view, { load: true, animate: true });
+      }
     });
     el("assets-close").addEventListener("click", closeAssets);
     el("assets-back").addEventListener("click", () => {
@@ -2950,100 +4062,109 @@
     });
     el("assets-refresh").addEventListener("click", () => {
       if (accountView === "positions") loadPositions(true);
+      else if (accountView === "position-history") loadPositionHistory(false, true);
+      else if (accountView === "orders") loadOrderHistory(false, true);
       else if (accountView === "assets") loadAssets(true);
     });
-    const assetsModal = el("assets-modal");
-    assetsModal.addEventListener("click", (event) => {
-      if (event.target === assetsModal) closeAssets();
+    el("position-history-filters").addEventListener("submit", (event) => {
+      event.preventDefault();
+      resetPositionHistory();
+      loadPositionHistory(false);
     });
-    const positionsTableBody = el("positions-table-body");
-    let positionPnlGesture = null;
-    let suppressPositionPnlClick = false;
-    let suppressPositionPnlClickTimer = null;
-
-    function togglePositionPnlPopover(button) {
-      if (activePositionPnlButton) closePositionPnlPopover();
-      else showPositionPnlPopover(button);
-    }
-
-    function suppressNextPositionPnlClick() {
-      suppressPositionPnlClick = true;
-      if (suppressPositionPnlClickTimer !== null) {
-        clearTimeout(suppressPositionPnlClickTimer);
-      }
-      suppressPositionPnlClickTimer = window.setTimeout(() => {
-        suppressPositionPnlClick = false;
-        suppressPositionPnlClickTimer = null;
-      }, 500);
-    }
-
-    positionsTableBody.addEventListener("pointerdown", (event) => {
-      if (!event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
-      const button = event.target && event.target.closest
-        ? event.target.closest(".position-pnl-value")
-        : null;
+    el("position-history-account").addEventListener("change", () => {
+      historyFlipBegin();
+      resetPositionHistory();
+      loadPositionHistory(false);
+    });
+    el("position-history-back").addEventListener("click", () => {
+      navigateHistoryBack("position");
+    });
+    el("position-history-more").addEventListener("click", () => {
+      loadPositionHistory(true);
+    });
+    el("order-history-filters").addEventListener("submit", (event) => {
+      event.preventDefault();
+      resetOrderHistory();
+      loadOrderHistory(false);
+    });
+    ["account", "status"].forEach((field) => {
+      el(`order-history-${field}`).addEventListener("change", () => {
+        historyFlipBegin();
+        resetOrderHistory();
+        loadOrderHistory(false);
+      });
+    });
+    setupHistoryCustomSelect("position-history-account");
+    setupHistoryCustomSelect("order-history-account");
+    setupHistoryCustomSelect("order-history-status");
+    el("order-history-back").addEventListener("click", () => {
+      navigateHistoryBack("order");
+    });
+    el("order-history-more").addEventListener("click", () => {
+      loadOrderHistory(true);
+    });
+    const assetsModal = el("assets-modal");
+    assetsModal.addEventListener("pointerdown", (event) => {
+      const target = event.target && event.target.closest ? event.target : null;
+      const button = target && target.closest(".position-pnl-value");
       if (!button) return;
-      event.stopPropagation();
-      positionPnlGesture = {
+      positionPnlPress = {
         button,
         pointerId: event.pointerId,
         startedAt: performance.now(),
-        startX: event.clientX,
-        startY: event.clientY,
+        x: event.clientX,
+        y: event.clientY,
         moved: false,
       };
-    });
-    positionsTableBody.addEventListener("pointermove", (event) => {
-      const gesture = positionPnlGesture;
-      if (!gesture || gesture.pointerId !== event.pointerId || gesture.moved) return;
-      if (
-        Math.abs(event.clientX - gesture.startX) > 10
-        || Math.abs(event.clientY - gesture.startY) > 10
-      ) {
-        gesture.moved = true;
-        closePositionPnlPopover();
+    }, { passive: true });
+    assetsModal.addEventListener("pointermove", (event) => {
+      if (!positionPnlPress || positionPnlPress.pointerId !== event.pointerId) return;
+      if (Math.hypot(
+        event.clientX - positionPnlPress.x,
+        event.clientY - positionPnlPress.y,
+      ) > 8) {
+        positionPnlPress.moved = true;
       }
     }, { passive: true });
-    positionsTableBody.addEventListener("pointerup", (event) => {
-      const gesture = positionPnlGesture;
-      if (!gesture || gesture.pointerId !== event.pointerId) return;
-      positionPnlGesture = null;
-      suppressNextPositionPnlClick();
-      if (gesture.moved || performance.now() - gesture.startedAt > 450) return;
-      event.preventDefault();
-      event.stopPropagation();
-      togglePositionPnlPopover(gesture.button);
-    });
-    positionsTableBody.addEventListener("pointercancel", (event) => {
-      if (positionPnlGesture && positionPnlGesture.pointerId === event.pointerId) {
-        positionPnlGesture = null;
+    assetsModal.addEventListener("pointerup", (event) => {
+      if (!positionPnlPress || positionPnlPress.pointerId !== event.pointerId) return;
+      if (positionPnlPress.moved || performance.now() - positionPnlPress.startedAt > 450) {
+        suppressPositionPnlClickUntil = Date.now() + 500;
       }
-    });
-    positionsTableBody.addEventListener("click", (event) => {
-      const button = event.target && event.target.closest
-        ? event.target.closest(".position-pnl-value")
-        : null;
-      if (!button) return;
-      event.preventDefault();
-      event.stopPropagation();
-      if (suppressPositionPnlClick) {
-        suppressPositionPnlClick = false;
-        if (suppressPositionPnlClickTimer !== null) {
-          clearTimeout(suppressPositionPnlClickTimer);
-          suppressPositionPnlClickTimer = null;
+      positionPnlPress = null;
+    }, { passive: true });
+    assetsModal.addEventListener("pointercancel", () => {
+      positionPnlPress = null;
+      suppressPositionPnlClickUntil = Date.now() + 500;
+    }, { passive: true });
+    assetsModal.addEventListener("click", (event) => {
+      if (Date.now() < suppressAccountTabClickUntil) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      const target = event.target && event.target.closest ? event.target : null;
+      const pnlButton = target && target.closest(".position-pnl-value");
+      if (pnlButton) {
+        event.preventDefault();
+        event.stopPropagation();
+        if (Date.now() >= suppressPositionPnlClickUntil) {
+          showPositionPnlPopover(pnlButton);
         }
         return;
       }
-      togglePositionPnlPopover(button);
+      if (event.target === assetsModal) closeAssets();
     });
-    positionsTableBody.addEventListener("scroll", () => {
-      if (positionPnlGesture) positionPnlGesture.moved = true;
-      closePositionPnlPopover();
-    }, { passive: true });
     document.addEventListener("pointerdown", (event) => {
       if (!activePositionPnlButton) return;
       const target = event.target && event.target.closest ? event.target : null;
-      if (target && target.closest("#position-pnl-popover")) return;
+      if (
+        target
+        && (
+          target.closest("#position-pnl-popover")
+          || target.closest(".position-pnl-value")
+        )
+      ) return;
       closePositionPnlPopover();
     }, { passive: true });
     window.addEventListener("resize", closePositionPnlPopover, { passive: true });

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -52,11 +52,22 @@
     hyperliquid: new Set(["spot", "swap"]),
   };
   let assetsRequestSeq = 0;
+  const assetsRefreshIntervalMs = 10000;
+  let assetsRefreshTimer = null;
   let assetsOpenTimer = null;
   let assetsCloseTimer = null;
   let assetsHaveData = false;
   let assetsPayload = null;
   let selectedAssetExchange = null;
+  let accountView = "assets";
+  let positionsRequestSeq = 0;
+  let positionsHaveData = false;
+  let positionsPayload = null;
+  let positionsObservedAt = 0;
+  let accountPositionsWs = null;
+  let accountPositionsReconnectTimer = null;
+  let accountPositionsKeepaliveTimer = null;
+  let accountPositionsGeneration = 0;
   let assetTransferRequestSeq = 0;
   let assetTransferContext = null;
   let assetTransferReview = null;
@@ -450,6 +461,26 @@
     return !el("assets-modal").classList.contains("hidden");
   }
 
+  function clearAssetsRefreshTimer() {
+    if (assetsRefreshTimer === null) return;
+    clearTimeout(assetsRefreshTimer);
+    assetsRefreshTimer = null;
+  }
+
+  function scheduleAssetsRefresh() {
+    clearAssetsRefreshTimer();
+    if (
+      !isAssetsOpen()
+      || accountView !== "assets"
+      || document.visibilityState !== "visible"
+    ) return;
+    assetsRefreshTimer = window.setTimeout(() => {
+      assetsRefreshTimer = null;
+      if (!isAssetsOpen() || accountView !== "assets") return;
+      loadAssets(true);
+    }, assetsRefreshIntervalMs);
+  }
+
   function finishAssetsOpening() {
     if (assetsOpenTimer !== null) {
       clearTimeout(assetsOpenTimer);
@@ -472,17 +503,17 @@
     box.style.transform = "";
     box.style.transition = "";
     modal.setAttribute("aria-hidden", "true");
+    clearAssetsRefreshTimer();
+    closeAccountPositionsSocket();
     assetsCloseTimer = null;
     assetsOpenTimer = null;
     unlockBodyScroll();
   }
 
-  async function openAssets() {
+  async function openAccount(view = "assets") {
     closeHubMenu();
     closeAiChat();
-    selectedAssetExchange = null;
-    el("assets-title").textContent = "Assets";
-    el("assets-back").classList.add("hidden");
+    if (view === "assets") selectedAssetExchange = null;
     if (assetsCloseTimer !== null) {
       clearTimeout(assetsCloseTimer);
       assetsCloseTimer = null;
@@ -507,17 +538,21 @@
     box.style.transition = "";
     modal.setAttribute("aria-hidden", "false");
     lockBodyScroll();
-    await loadAssets(false);
+    await switchAccountView(view, { load: true });
   }
 
   function closeAssets(options = {}) {
     if (!isAssetsOpen()) return;
     closeAssetTransfer();
+    closePositionPnlPopover();
     const modal = el("assets-modal");
     if (modal.classList.contains("assets-closing")) return;
     const fromDrag = options && options.fromDrag === true;
     finishAssetsOpening();
+    clearAssetsRefreshTimer();
     assetsRequestSeq += 1;
+    setAssetsLoading(false);
+    positionsRequestSeq += 1;
     if (!mobileHubQuery.matches) {
       finishAssetsClose();
       return;
@@ -536,6 +571,60 @@
     }
     modal.classList.add("assets-closing");
     assetsCloseTimer = window.setTimeout(finishAssetsClose, 220);
+  }
+
+  const accountViewTitles = {
+    assets: "Assets",
+    positions: "Positions",
+    "position-history": "Position History",
+    orders: "Order History",
+    pnl: "PnL",
+  };
+
+  async function switchAccountView(view, options = {}) {
+    if (!Object.prototype.hasOwnProperty.call(accountViewTitles, view)) return;
+    if (accountView === "assets" && view !== "assets") {
+      clearAssetsRefreshTimer();
+      assetsRequestSeq += 1;
+      setAssetsLoading(false);
+    }
+    if (accountView === "positions" && view !== "positions") {
+      positionsRequestSeq += 1;
+      closeAccountPositionsSocket();
+      closePositionPnlPopover();
+    }
+    accountView = view;
+    document.querySelectorAll("[data-account-view]").forEach((button) => {
+      if (!button.classList.contains("account-tab")) return;
+      const active = button.dataset.accountView === view;
+      button.classList.toggle("active", active);
+      button.setAttribute("aria-selected", String(active));
+    });
+    Object.keys(accountViewTitles).forEach((name) => {
+      el(`account-${name}-view`).classList.toggle("hidden", name !== view);
+    });
+
+    const assetsSelected = view === "assets" && selectedAssetExchange;
+    el("assets-back").classList.toggle("hidden", !assetsSelected);
+    el("assets-refresh").classList.toggle(
+      "hidden",
+      !new Set(["assets", "positions"]).has(view),
+    );
+    el("assets-refresh").title = view === "positions"
+      ? "Refresh positions"
+      : "Refresh assets";
+    el("assets-refresh").setAttribute("aria-label", el("assets-refresh").title);
+    el("assets-title").textContent = accountViewTitles[view];
+    if (view === "assets" && assetsPayload) renderAssetsView();
+    if (!options.load) {
+      if (view === "assets") scheduleAssetsRefresh();
+      return;
+    }
+    if (view === "assets") await loadAssets(false);
+    else if (view === "positions") {
+      await loadPositions(false);
+      connectAccountPositions();
+    }
   }
 
   function formatAssetValue(value, currency, compact = false) {
@@ -1566,8 +1655,10 @@
   }
 
   function setAssetsLoading(loading, preserveContent = false) {
-    el("assets-refresh").disabled = loading;
-    el("assets-refresh").classList.toggle("assets-refreshing", loading);
+    if (accountView === "assets") {
+      el("assets-refresh").disabled = loading;
+      el("assets-refresh").classList.toggle("assets-refreshing", loading);
+    }
     el("assets-loading").classList.toggle("hidden", !loading || preserveContent);
     if (loading) el("assets-error").classList.add("hidden");
     if (loading && !preserveContent) {
@@ -1579,15 +1670,16 @@
   }
 
   async function loadAssets(force) {
+    clearAssetsRefreshTimer();
     const seq = ++assetsRequestSeq;
-    const preserveContent = Boolean(force && assetsHaveData);
+    const preserveContent = assetsHaveData;
     setAssetsLoading(true, preserveContent);
     try {
-      const payload = await api(`/api/assets${force ? "?refresh=true" : ""}`);
-      if (seq !== assetsRequestSeq || !isAssetsOpen()) return;
+      const payload = await api(`/api/account/assets${force ? "?refresh=true" : ""}`);
+      if (seq !== assetsRequestSeq || !isAssetsOpen() || accountView !== "assets") return;
       renderAssets(payload);
     } catch (error) {
-      if (seq !== assetsRequestSeq || !isAssetsOpen()) return;
+      if (seq !== assetsRequestSeq || !isAssetsOpen() || accountView !== "assets") return;
       const errorElement = el("assets-error");
       errorElement.textContent = `${error.message}\nUse refresh to try again.`;
       errorElement.classList.remove("hidden");
@@ -1596,8 +1688,384 @@
         el("assets-portfolios").replaceChildren();
       }
     } finally {
-      if (seq === assetsRequestSeq) setAssetsLoading(false);
+      if (seq === assetsRequestSeq) {
+        setAssetsLoading(false);
+        scheduleAssetsRefresh();
+      }
     }
+  }
+
+  function formatPositionNumber(value, maximumFractionDigits = 6) {
+    if (value === null || value === undefined || value === "" || typeof value === "boolean") {
+      return "—";
+    }
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "—";
+    return number.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits,
+    });
+  }
+
+  function positionTableCell(text, className = "", label = "") {
+    const cell = document.createElement("td");
+    cell.textContent = text;
+    if (className) cell.className = className;
+    if (label) cell.dataset.label = label;
+    cell.title = text;
+    return cell;
+  }
+
+  function formatSignedPositionNumber(value, maximumFractionDigits = 4) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "Unavailable";
+    return `${number > 0 ? "+" : ""}${formatPositionNumber(number, maximumFractionDigits)}`;
+  }
+
+  function positionPnlClass(value) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "";
+    return number > 0
+      ? "account-pnl-positive"
+      : number < 0 ? "account-pnl-negative" : "";
+  }
+
+  function positionRealizedPnlCell(position) {
+    const value = position.realized_pnl === null || position.realized_pnl === undefined
+      ? Number.NaN
+      : Number(position.realized_pnl);
+    if (!Number.isFinite(value)) return positionTableCell("—", "", "Realized PnL");
+    const cell = positionTableCell("", positionPnlClass(value), "Realized PnL");
+    const button = document.createElement("button");
+    button.className = "position-pnl-value";
+    button.type = "button";
+    button.textContent = formatSignedPositionNumber(value);
+    button.title = "Show realized PnL calculation";
+    button.setAttribute("aria-haspopup", "dialog");
+    button.setAttribute("aria-expanded", "false");
+    const breakdown = position.realized_pnl_breakdown;
+    button.dataset.positionPnl = JSON.stringify(
+      breakdown && typeof breakdown === "object"
+        ? breakdown
+        : { gross_pnl: null, fees: null, net_pnl: value, complete: false },
+    );
+    cell.appendChild(button);
+    return cell;
+  }
+
+  let activePositionPnlButton = null;
+
+  function closePositionPnlPopover() {
+    if (activePositionPnlButton) {
+      activePositionPnlButton.setAttribute("aria-expanded", "false");
+      activePositionPnlButton = null;
+    }
+    const popover = el("position-pnl-popover");
+    if (popover) popover.classList.add("hidden");
+  }
+
+  function showPositionPnlPopover(button) {
+    if (activePositionPnlButton === button) {
+      closePositionPnlPopover();
+      return;
+    }
+    let breakdown;
+    try {
+      breakdown = JSON.parse(button.dataset.positionPnl || "{}");
+    } catch {
+      breakdown = {};
+    }
+    closePositionPnlPopover();
+    activePositionPnlButton = button;
+    button.setAttribute("aria-expanded", "true");
+
+    const gross = Number(breakdown.gross_pnl);
+    const fees = Number(breakdown.fees);
+    const net = Number(breakdown.net_pnl);
+    const complete = breakdown.complete === true
+      && Number.isFinite(gross)
+      && Number.isFinite(fees)
+      && Number.isFinite(net);
+    setText(el("position-pnl-gross"), complete ? formatSignedPositionNumber(gross) : "Unavailable");
+    setText(el("position-pnl-fees"), complete ? formatPositionNumber(fees, 4) : "Unavailable");
+    setText(el("position-pnl-net"), formatSignedPositionNumber(net));
+    setClass(el("position-pnl-net"), `mono ${positionPnlClass(net)}`.trim());
+    el("position-pnl-note").classList.toggle("hidden", complete);
+    if (!complete) {
+      setText(
+        el("position-pnl-note"),
+        "The exchange reports net realized PnL without a fee breakdown.",
+      );
+    }
+
+    const popover = el("position-pnl-popover");
+    popover.classList.remove("hidden");
+    const buttonRect = button.getBoundingClientRect();
+    const popoverRect = popover.getBoundingClientRect();
+    const left = Math.min(
+      Math.max(12, buttonRect.right - popoverRect.width),
+      window.innerWidth - popoverRect.width - 12,
+    );
+    let top = buttonRect.bottom + 8;
+    if (top + popoverRect.height > window.innerHeight - 12) {
+      top = Math.max(12, buttonRect.top - popoverRect.height - 8);
+    }
+    popover.style.left = `${left}px`;
+    popover.style.top = `${top}px`;
+  }
+
+  function renderPositions(payload) {
+    const observedAt = Date.parse(payload.collected_at || "");
+    if (Number.isFinite(observedAt) && observedAt < positionsObservedAt) return;
+    if (Number.isFinite(observedAt)) positionsObservedAt = observedAt;
+    positionsPayload = payload;
+    positionsHaveData = true;
+    const results = Array.isArray(payload.results) ? payload.results : [];
+    const positions = [];
+    const errors = [];
+    results.forEach((result) => {
+      if (result && result.status === "ok") {
+        (Array.isArray(result.positions) ? result.positions : []).forEach((position) => {
+          positions.push({
+            ...position,
+            account: result.account || "",
+            exchange: result.exchange || "",
+            exchange_logo_url: result.exchange_logo_url || "",
+          });
+        });
+        return;
+      }
+      const error = result && result.error && result.error.message;
+      errors.push(
+        `${result && result.account || "Unknown account"}: ${error || "Position data unavailable"}`,
+      );
+    });
+
+    const summary = payload.summary || {};
+    el("positions-open-count").textContent = String(positions.length);
+    el("positions-account-count").textContent =
+      `${Number(summary.succeeded || 0)} of ${Number(summary.accounts || 0)} accounts`;
+    el("positions-updated").textContent = Number.isFinite(observedAt)
+      ? `Updated ${new Date(observedAt).toLocaleString("en-US", {
+          month: "short",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        })}${payload.live ? " · live" : payload.cached ? " · cached" : ""}`
+      : "";
+    el("positions-summary").classList.remove("hidden");
+    el("positions-empty").textContent = Number(summary.accounts || 0) === 0
+      ? "No exchange accounts are configured in providers.toml."
+      : "No open positions.";
+    el("positions-empty").classList.toggle("hidden", positions.length !== 0);
+    el("positions-table-wrap").classList.toggle("hidden", positions.length === 0);
+
+    const tableBody = el("positions-table-body");
+    tableBody.replaceChildren();
+    positions.forEach((position) => {
+      const row = document.createElement("tr");
+      const accountName = String(position.account || "—");
+      const exchangeName = String(position.exchange || "").toUpperCase();
+      const account = positionTableCell("", "account-table-account", "Account");
+      account.title = accountName;
+      const exchangeLogo = logoImg(
+        position.exchange_logo_url,
+        exchangeName,
+        "exchange-logo",
+      );
+      setHTML(
+        account,
+        `${exchangeLogo}<span class="account-table-account-name">${esc(accountName)}</span>`,
+      );
+      account.dataset.label = "Account";
+
+      const symbol = positionTableCell(
+        String(position.symbol || "—"),
+        "account-table-symbol",
+        "Symbol",
+      );
+      const scopeText = String(position.market_scope || position.dex || "");
+      if (scopeText) {
+        const scope = document.createElement("small");
+        scope.textContent = scopeText;
+        symbol.appendChild(scope);
+      }
+
+      const sideText = String(position.side || "—");
+      const sideClass = sideText.toLowerCase() === "long"
+        ? "account-position-long"
+        : sideText.toLowerCase() === "short" ? "account-position-short" : "";
+      const pnl = position.unrealized_pnl === null || position.unrealized_pnl === undefined
+        ? Number.NaN
+        : Number(position.unrealized_pnl);
+      const pnlClass = positionPnlClass(pnl);
+      const percentage = position.percentage === null || position.percentage === undefined
+        ? Number.NaN
+        : Number(position.percentage);
+      const percentageText = Number.isFinite(percentage)
+        ? `${percentage > 0 ? "+" : ""}${formatPositionNumber(percentage, 2)}%`
+        : "—";
+
+      row.append(
+        account,
+        symbol,
+        positionTableCell(sideText, sideClass, "Side"),
+        positionTableCell(
+          formatPositionNumber(position.quantity ?? position.contracts),
+          "",
+          "Size",
+        ),
+        positionTableCell(formatPositionNumber(position.entry_price), "", "Entry"),
+        positionTableCell(formatPositionNumber(position.mark_price), "", "Mark"),
+        positionTableCell(
+          Number.isFinite(pnl)
+            ? `${pnl > 0 ? "+" : ""}${formatPositionNumber(pnl, 4)}`
+            : "—",
+          pnlClass,
+          "Unrealized PnL",
+        ),
+        positionRealizedPnlCell(position),
+        positionTableCell(percentageText, pnlClass, "Return"),
+        positionTableCell(
+          position.leverage !== null
+            && position.leverage !== undefined
+            && Number.isFinite(Number(position.leverage))
+            ? `${formatPositionNumber(position.leverage, 2)}x`
+            : "—",
+          "",
+          "Leverage",
+        ),
+        positionTableCell(
+          formatPositionNumber(position.liquidation_price),
+          "",
+          "Liquidation",
+        ),
+      );
+      tableBody.appendChild(row);
+    });
+
+    const errorContainer = el("positions-account-errors");
+    errorContainer.replaceChildren();
+    errors.forEach((message) => {
+      const item = document.createElement("div");
+      item.textContent = message;
+      errorContainer.appendChild(item);
+    });
+    errorContainer.classList.toggle("hidden", errors.length === 0);
+  }
+
+  function setPositionsLoading(loading, preserveContent = false) {
+    if (accountView === "positions") {
+      el("assets-refresh").disabled = loading;
+      el("assets-refresh").classList.toggle("assets-refreshing", loading);
+    }
+    el("positions-loading").classList.toggle("hidden", !loading || preserveContent);
+    if (loading) el("positions-error").classList.add("hidden");
+    if (loading && !preserveContent) {
+      positionsPayload = null;
+      el("positions-summary").classList.add("hidden");
+      el("positions-empty").classList.add("hidden");
+      el("positions-table-wrap").classList.add("hidden");
+      el("positions-account-errors").classList.add("hidden");
+      el("positions-table-body").replaceChildren();
+    }
+  }
+
+  async function loadPositions(force) {
+    const seq = ++positionsRequestSeq;
+    const preserveContent = positionsHaveData;
+    setPositionsLoading(true, preserveContent);
+    try {
+      const payload = await api(`/api/account/positions${force ? "?refresh=true" : ""}`);
+      if (seq !== positionsRequestSeq || !isAssetsOpen() || accountView !== "positions") return;
+      renderPositions(payload);
+    } catch (error) {
+      if (seq !== positionsRequestSeq || !isAssetsOpen() || accountView !== "positions") return;
+      el("positions-error").textContent = `${error.message}\nUse refresh to try again.`;
+      el("positions-error").classList.remove("hidden");
+      if (!preserveContent) {
+        el("positions-summary").classList.add("hidden");
+        el("positions-table-wrap").classList.add("hidden");
+      }
+    } finally {
+      if (seq === positionsRequestSeq) setPositionsLoading(false);
+    }
+  }
+
+  function clearAccountPositionsTimers() {
+    if (accountPositionsReconnectTimer !== null) {
+      clearTimeout(accountPositionsReconnectTimer);
+      accountPositionsReconnectTimer = null;
+    }
+    if (accountPositionsKeepaliveTimer !== null) {
+      clearInterval(accountPositionsKeepaliveTimer);
+      accountPositionsKeepaliveTimer = null;
+    }
+  }
+
+  function closeAccountPositionsSocket() {
+    accountPositionsGeneration += 1;
+    clearAccountPositionsTimers();
+    const ws = accountPositionsWs;
+    accountPositionsWs = null;
+    if (ws) {
+      ws.onopen = null;
+      ws.onmessage = null;
+      ws.onclose = null;
+      ws.onerror = null;
+      if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+        try { ws.close(); } catch {}
+      }
+    }
+  }
+
+  function connectAccountPositions(generation = accountPositionsGeneration) {
+    if (
+      generation !== accountPositionsGeneration
+      || !isAssetsOpen()
+      || accountView !== "positions"
+      || document.visibilityState === "hidden"
+    ) return;
+    if (
+      accountPositionsWs
+      && [WebSocket.OPEN, WebSocket.CONNECTING].includes(accountPositionsWs.readyState)
+    ) return;
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    const ws = new WebSocket(`${proto}//${location.host}/ws/account`);
+    accountPositionsWs = ws;
+    ws.onopen = () => {
+      if (ws !== accountPositionsWs || generation !== accountPositionsGeneration) return;
+      accountPositionsKeepaliveTimer = setInterval(() => {
+        if (ws === accountPositionsWs && ws.readyState === WebSocket.OPEN) ws.send("ping");
+      }, 15000);
+    };
+    ws.onmessage = (event) => {
+      if (
+        ws !== accountPositionsWs
+        || generation !== accountPositionsGeneration
+        || !isAssetsOpen()
+        || accountView !== "positions"
+      ) return;
+      try {
+        const message = JSON.parse(event.data);
+        if (message.type === "account.positions" && message.payload) {
+          renderPositions(message.payload);
+        }
+      } catch {}
+    };
+    ws.onclose = () => {
+      if (ws !== accountPositionsWs || generation !== accountPositionsGeneration) return;
+      accountPositionsWs = null;
+      clearAccountPositionsTimers();
+      if (!isAssetsOpen() || accountView !== "positions") return;
+      accountPositionsReconnectTimer = setTimeout(
+        () => connectAccountPositions(generation),
+        1500,
+      );
+    };
+    ws.onerror = () => {
+      try { ws.close(); } catch {}
+    };
   }
 
   async function loadCalendarEvents() {
@@ -2232,7 +2700,25 @@
     el("hub-menu-close").addEventListener("click", closeHubMenu);
     el("hub-menu-backdrop").addEventListener("click", closeHubMenu);
     el("hub-calendar-open").addEventListener("click", openCalendar);
-    el("hub-assets-open").addEventListener("click", openAssets);
+    el("hub-account-toggle").addEventListener("click", () => {
+      const menu = el("hub-account-menu");
+      const expanded = el("hub-account-toggle").getAttribute("aria-expanded") === "true";
+      el("hub-account-toggle").setAttribute("aria-expanded", String(!expanded));
+      menu.classList.toggle("hidden", expanded);
+    });
+    el("hub-account-menu").addEventListener("click", (event) => {
+      const button = event.target && event.target.closest
+        ? event.target.closest("[data-account-view]")
+        : null;
+      if (!button) return;
+      openAccount(String(button.dataset.accountView || "assets"));
+    });
+    el("hub-history-toggle").addEventListener("click", () => {
+      const menu = el("hub-history-menu");
+      const expanded = el("hub-history-toggle").getAttribute("aria-expanded") === "true";
+      el("hub-history-toggle").setAttribute("aria-expanded", String(!expanded));
+      menu.classList.toggle("hidden", expanded);
+    });
     el("hub-update-button").addEventListener("click", checkForUpdate);
     el("update-close").addEventListener("click", closeUpdateModal);
     el("update-cancel").addEventListener("click", closeUpdateModal);
@@ -2366,17 +2852,129 @@
     }
     initMobileHubMenuSwipe();
     initMobileCalendarGestures();
+    const accountTabs = document.querySelector(".account-tabs");
+    function accountTabFromEvent(event) {
+      return event.target && event.target.closest
+        ? event.target.closest("[data-account-view]")
+        : null;
+    }
+    accountTabs.addEventListener("pointerdown", (event) => {
+      if (!event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
+      const button = accountTabFromEvent(event);
+      if (!button) return;
+      switchAccountView(String(button.dataset.accountView || "assets"), { load: true });
+    });
+    accountTabs.addEventListener("click", (event) => {
+      const button = accountTabFromEvent(event);
+      if (!button) return;
+      const view = String(button.dataset.accountView || "assets");
+      if (view !== accountView) switchAccountView(view, { load: true });
+    });
     el("assets-close").addEventListener("click", closeAssets);
     el("assets-back").addEventListener("click", () => {
       selectedAssetExchange = null;
       renderAssetsView();
       el("assets-body").scrollTop = 0;
     });
-    el("assets-refresh").addEventListener("click", () => loadAssets(true));
+    el("assets-refresh").addEventListener("click", () => {
+      if (accountView === "positions") loadPositions(true);
+      else if (accountView === "assets") loadAssets(true);
+    });
     const assetsModal = el("assets-modal");
     assetsModal.addEventListener("click", (event) => {
       if (event.target === assetsModal) closeAssets();
     });
+    const positionsTableBody = el("positions-table-body");
+    let positionPnlGesture = null;
+    let suppressPositionPnlClick = false;
+    let suppressPositionPnlClickTimer = null;
+
+    function togglePositionPnlPopover(button) {
+      if (activePositionPnlButton) closePositionPnlPopover();
+      else showPositionPnlPopover(button);
+    }
+
+    function suppressNextPositionPnlClick() {
+      suppressPositionPnlClick = true;
+      if (suppressPositionPnlClickTimer !== null) {
+        clearTimeout(suppressPositionPnlClickTimer);
+      }
+      suppressPositionPnlClickTimer = window.setTimeout(() => {
+        suppressPositionPnlClick = false;
+        suppressPositionPnlClickTimer = null;
+      }, 500);
+    }
+
+    positionsTableBody.addEventListener("pointerdown", (event) => {
+      if (!event.isPrimary || (event.pointerType === "mouse" && event.button !== 0)) return;
+      const button = event.target && event.target.closest
+        ? event.target.closest(".position-pnl-value")
+        : null;
+      if (!button) return;
+      event.stopPropagation();
+      positionPnlGesture = {
+        button,
+        pointerId: event.pointerId,
+        startedAt: performance.now(),
+        startX: event.clientX,
+        startY: event.clientY,
+        moved: false,
+      };
+    });
+    positionsTableBody.addEventListener("pointermove", (event) => {
+      const gesture = positionPnlGesture;
+      if (!gesture || gesture.pointerId !== event.pointerId || gesture.moved) return;
+      if (
+        Math.abs(event.clientX - gesture.startX) > 10
+        || Math.abs(event.clientY - gesture.startY) > 10
+      ) {
+        gesture.moved = true;
+        closePositionPnlPopover();
+      }
+    }, { passive: true });
+    positionsTableBody.addEventListener("pointerup", (event) => {
+      const gesture = positionPnlGesture;
+      if (!gesture || gesture.pointerId !== event.pointerId) return;
+      positionPnlGesture = null;
+      suppressNextPositionPnlClick();
+      if (gesture.moved || performance.now() - gesture.startedAt > 450) return;
+      event.preventDefault();
+      event.stopPropagation();
+      togglePositionPnlPopover(gesture.button);
+    });
+    positionsTableBody.addEventListener("pointercancel", (event) => {
+      if (positionPnlGesture && positionPnlGesture.pointerId === event.pointerId) {
+        positionPnlGesture = null;
+      }
+    });
+    positionsTableBody.addEventListener("click", (event) => {
+      const button = event.target && event.target.closest
+        ? event.target.closest(".position-pnl-value")
+        : null;
+      if (!button) return;
+      event.preventDefault();
+      event.stopPropagation();
+      if (suppressPositionPnlClick) {
+        suppressPositionPnlClick = false;
+        if (suppressPositionPnlClickTimer !== null) {
+          clearTimeout(suppressPositionPnlClickTimer);
+          suppressPositionPnlClickTimer = null;
+        }
+        return;
+      }
+      togglePositionPnlPopover(button);
+    });
+    positionsTableBody.addEventListener("scroll", () => {
+      if (positionPnlGesture) positionPnlGesture.moved = true;
+      closePositionPnlPopover();
+    }, { passive: true });
+    document.addEventListener("pointerdown", (event) => {
+      if (!activePositionPnlButton) return;
+      const target = event.target && event.target.closest ? event.target : null;
+      if (target && target.closest("#position-pnl-popover")) return;
+      closePositionPnlPopover();
+    }, { passive: true });
+    window.addEventListener("resize", closePositionPnlPopover, { passive: true });
     el("asset-transfer-close").addEventListener("click", closeAssetTransfer);
     el("asset-transfer-back").addEventListener("click", () => {
       if (assetTransferMode === "review") {
@@ -5642,10 +6240,20 @@
   }
 
   document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "visible") rebuildHub();
-    else closeForBackground();
+    if (document.visibilityState === "visible") {
+      rebuildHub();
+      connectAccountPositions();
+      scheduleAssetsRefresh();
+    } else {
+      clearAssetsRefreshTimer();
+      closeForBackground();
+      closeAccountPositionsSocket();
+    }
   });
-  window.addEventListener("online", rebuildHub);
+  window.addEventListener("online", () => {
+    rebuildHub();
+    connectAccountPositions();
+  });
 
   initHubMenuCalendar();
   initSessionReordering();

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -477,7 +477,7 @@
     assetsRefreshTimer = window.setTimeout(() => {
       assetsRefreshTimer = null;
       if (!isAssetsOpen() || accountView !== "assets") return;
-      loadAssets(true);
+      loadAssets(true, true);
     }, assetsRefreshIntervalMs);
   }
 
@@ -1669,13 +1669,16 @@
     }
   }
 
-  async function loadAssets(force) {
+  async function loadAssets(force, autoRefresh = false) {
     clearAssetsRefreshTimer();
     const seq = ++assetsRequestSeq;
     const preserveContent = assetsHaveData;
     setAssetsLoading(true, preserveContent);
     try {
-      const payload = await api(`/api/account/assets${force ? "?refresh=true" : ""}`);
+      const query = force
+        ? `?refresh=true${autoRefresh ? "&auto_refresh=true" : ""}`
+        : "";
+      const payload = await api(`/api/account/assets${query}`);
       if (seq !== assetsRequestSeq || !isAssetsOpen() || accountView !== "assets") return;
       renderAssets(payload);
     } catch (error) {

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -64,6 +64,14 @@
   let positionsHaveData = false;
   let positionsPayload = null;
   let positionsObservedAt = 0;
+  let pnlRequestSeq = 0;
+  let pnlHaveData = false;
+  let pnlPayload = null;
+  let selectedPnlExchange = null;
+  let pnlPeriodDays = 90;
+  const pnlRefreshIntervalMs = 10000;
+  let pnlRefreshTimer = null;
+  let pnlListSizeFrame = null;
   const historyCustomSelects = {};
   let positionHistoryRequestSeq = 0;
   let positionHistoryHaveData = false;
@@ -505,6 +513,26 @@
     }, assetsRefreshIntervalMs);
   }
 
+  function clearPnlRefreshTimer() {
+    if (pnlRefreshTimer === null) return;
+    clearTimeout(pnlRefreshTimer);
+    pnlRefreshTimer = null;
+  }
+
+  function schedulePnlRefresh() {
+    clearPnlRefreshTimer();
+    if (
+      !isAssetsOpen()
+      || accountView !== "pnl"
+      || document.visibilityState !== "visible"
+    ) return;
+    pnlRefreshTimer = window.setTimeout(() => {
+      pnlRefreshTimer = null;
+      if (!isAssetsOpen() || accountView !== "pnl") return;
+      loadPnl();
+    }, pnlRefreshIntervalMs);
+  }
+
   function finishAssetsOpening() {
     if (assetsOpenTimer !== null) {
       clearTimeout(assetsOpenTimer);
@@ -528,6 +556,7 @@
     box.style.transition = "";
     modal.setAttribute("aria-hidden", "true");
     clearAssetsRefreshTimer();
+    clearPnlRefreshTimer();
     closeAccountPositionsSocket();
     assetsCloseTimer = null;
     assetsOpenTimer = null;
@@ -539,6 +568,7 @@
     closeHubMenu();
     closeAiChat();
     if (view === "assets") selectedAssetExchange = null;
+    if (view === "pnl") selectedPnlExchange = null;
     if (!wasOpen && accountView === view && view === "position-history") {
       resetHistoryNavigation("position");
     }
@@ -581,11 +611,14 @@
     const fromDrag = options && options.fromDrag === true;
     finishAssetsOpening();
     clearAssetsRefreshTimer();
+    clearPnlRefreshTimer();
     assetsRequestSeq += 1;
     setAssetsLoading(false);
     positionsRequestSeq += 1;
     positionHistoryRequestSeq += 1;
     orderHistoryRequestSeq += 1;
+    pnlRequestSeq += 1;
+    setPnlLoading(false);
     if (!mobileHubQuery.matches) {
       finishAssetsClose();
       return;
@@ -624,6 +657,9 @@
     if (view === "orders") {
       return orderHistoryNavigation.level !== "exchanges";
     }
+    if (view === "pnl") {
+      return Boolean(selectedPnlExchange);
+    }
     return false;
   }
 
@@ -643,7 +679,11 @@
     // right after the view swap is the (empty) reset state — animating to it
     // then jumping to the loaded height is the snap the user sees. For those we
     // hold the old height through the reload and tween once to the final height.
-    const isAccountHistoryView = view === "position-history" || view === "orders";
+    const isAccountHistoryView = (
+      view === "position-history"
+      || view === "orders"
+      || view === "pnl"
+    );
     const deferAccountHeight = animateAccountHeight && isAccountHistoryView && Boolean(options.load);
     const runAccountHeightTween = () => {
       accountBox.style.height = "";
@@ -675,6 +715,11 @@
     if (accountView === "orders" && view !== "orders") {
       orderHistoryRequestSeq += 1;
     }
+    if (accountView === "pnl" && view !== "pnl") {
+      clearPnlRefreshTimer();
+      pnlRequestSeq += 1;
+      setPnlLoading(false);
+    }
     if (previousView !== view && view === "position-history") {
       resetHistoryNavigation("position");
     }
@@ -683,6 +728,7 @@
     }
     if (previousView === view && accountViewIsDrilledIn(view)) {
       if (view === "assets") selectedAssetExchange = null;
+      else if (view === "pnl") selectedPnlExchange = null;
       else resetHistoryNavigation(view === "position-history" ? "position" : "order");
     }
     accountView = view;
@@ -704,24 +750,30 @@
       }
     }
 
-    const assetsSelected = view === "assets" && selectedAssetExchange;
-    el("assets-back").classList.toggle("hidden", !assetsSelected);
+    const accountDetailSelected = (
+      (view === "assets" && selectedAssetExchange)
+      || (view === "pnl" && selectedPnlExchange)
+    );
+    el("assets-back").classList.toggle("hidden", !accountDetailSelected);
     el("assets-refresh").classList.toggle(
       "hidden",
-      !new Set(["assets", "positions", "position-history", "orders"]).has(view),
+      !new Set(["assets", "positions", "position-history", "orders", "pnl"]).has(view),
     );
     const refreshTitles = {
       assets: "Refresh assets",
       positions: "Refresh positions",
       "position-history": "Refresh position history",
       orders: "Refresh order history",
+      pnl: "Refresh PnL",
     };
     el("assets-refresh").title = refreshTitles[view] || "Refresh";
     el("assets-refresh").setAttribute("aria-label", el("assets-refresh").title);
     el("assets-title").textContent = accountViewTitles[view];
     if (view === "assets" && assetsPayload) renderAssetsView();
+    if (view === "pnl" && pnlPayload) renderPnlView();
     if (!options.load) {
       if (view === "assets") scheduleAssetsRefresh();
+      if (view === "pnl") schedulePnlRefresh();
       return;
     }
     if (view === "assets") await loadAssets(false);
@@ -731,6 +783,7 @@
     }
     else if (view === "position-history") await loadPositionHistory(false);
     else if (view === "orders") await loadOrderHistory(false);
+    else if (view === "pnl") await loadPnl();
     if (deferAccountHeight) {
       if (isAssetsOpen() && accountView === view) runAccountHeightTween();
       else accountBox.style.height = ""; // switched away or closed mid-load
@@ -1758,7 +1811,7 @@
           day: "numeric",
           hour: "2-digit",
           minute: "2-digit",
-        })}${payload.cached ? " · cached" : ""}`
+        })}`
       : "";
     renderAssetsView();
     assetsHaveData = true;
@@ -2277,6 +2330,399 @@
     }
   }
 
+  function formatPnlValue(value, currency) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "—";
+    return `${number > 0 ? "+" : ""}${number.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: Math.abs(number) > 0 && Math.abs(number) < 1 ? 6 : 2,
+    })} ${currency || ""}`.trim();
+  }
+
+  function pnlRowKey(record) {
+    return [record.exchange, record.account, record.currency].join("|");
+  }
+
+  function syncPnlTotals(container, totals, className = "pnl-summary-value") {
+    const existing = new Map(
+      Array.from(container.children).map((node) => [node.dataset.currency || "", node]),
+    );
+    totals.forEach((total, index) => {
+      const currency = String(total.currency || "UNKNOWN");
+      let value = existing.get(currency);
+      if (!value) {
+        value = document.createElement("strong");
+        value.dataset.currency = currency;
+      }
+      value.className = `${className} ${positionPnlClass(total.net_pnl)}`.trim();
+      value.textContent = `${formatPnlValue(total.net_pnl, currency)}${
+        total.complete === true ? "" : "*"
+      }`;
+      const current = container.children[index];
+      if (current !== value) container.insertBefore(value, current || null);
+      existing.delete(currency);
+    });
+    existing.forEach((node) => node.remove());
+  }
+
+  function groupPnlByExchange(results) {
+    const groups = new Map();
+    results.forEach((record) => {
+      const exchange = String(record.exchange || "unknown");
+      let group = groups.get(exchange);
+      if (!group) {
+        group = {
+          exchange,
+          exchange_logo_url: record.exchange_logo_url || "",
+          accounts: new Set(),
+          rows: [],
+          totals: new Map(),
+        };
+        groups.set(exchange, group);
+      }
+      group.accounts.add(String(record.account || ""));
+      group.rows.push(record);
+      const currency = String(record.currency || "UNKNOWN");
+      let total = group.totals.get(currency);
+      if (!total) {
+        total = { currency, net_pnl: 0, complete: true };
+        group.totals.set(currency, total);
+      }
+      const net = Number(record.net_pnl);
+      if (Number.isFinite(net)) total.net_pnl += net;
+      else total.complete = false;
+      total.complete = total.complete && record.complete === true;
+    });
+    return Array.from(groups.values())
+      .map((group) => ({
+        ...group,
+        account_count: Array.from(group.accounts).filter(Boolean).length,
+        totals: Array.from(group.totals.values()).sort((left, right) => (
+          left.currency.localeCompare(right.currency)
+        )),
+      }))
+      .sort((left, right) => left.exchange.localeCompare(right.exchange));
+  }
+
+  function createPnlExchangeRow() {
+    const row = document.createElement("button");
+    row.type = "button";
+    row.className = "pnl-exchange-row";
+    const identity = document.createElement("span");
+    identity.className = "pnl-exchange-identity";
+    const logo = document.createElement("span");
+    logo.className = "pnl-exchange-logo";
+    const copy = document.createElement("span");
+    copy.className = "assets-exchange-identity";
+    const title = document.createElement("span");
+    title.className = "assets-exchange-title";
+    const accounts = document.createElement("span");
+    accounts.className = "assets-exchange-accounts";
+    copy.append(title, accounts);
+    identity.append(logo, copy);
+    const totals = document.createElement("span");
+    totals.className = "pnl-exchange-totals";
+    const chevron = document.createElementNS("http://www.w3.org/2000/svg", "svg");
+    chevron.classList.add("assets-exchange-chevron");
+    chevron.setAttribute("viewBox", "0 0 24 24");
+    chevron.setAttribute("aria-hidden", "true");
+    const path = document.createElementNS("http://www.w3.org/2000/svg", "path");
+    path.setAttribute("d", "m9 18 6-6-6-6");
+    chevron.appendChild(path);
+    row.append(identity, totals, chevron);
+    row.pnlNodes = { logo, title, accounts, totals };
+    row.addEventListener("click", () => {
+      selectedPnlExchange = row.dataset.pnlExchange || null;
+      renderPnlView();
+      scrollPnlToTop();
+    });
+    return row;
+  }
+
+  function updatePnlExchangeRow(row, group) {
+    row.dataset.pnlKey = `exchange:${group.exchange}`;
+    row.dataset.pnlExchange = group.exchange;
+    row.setAttribute("aria-label", `Show ${assetExchangeLabel(group.exchange)} PnL details`);
+    const nodes = row.pnlNodes;
+    const exchangeName = String(group.exchange || "").toUpperCase();
+    const logoIdentity = `${group.exchange_logo_url || ""}|${exchangeName}`;
+    if (nodes.logo.dataset.identity !== logoIdentity) {
+      setHTML(nodes.logo, logoImg(group.exchange_logo_url, exchangeName, "exchange-logo"));
+      nodes.logo.querySelectorAll("[title]").forEach((node) => node.removeAttribute("title"));
+      nodes.logo.dataset.identity = logoIdentity;
+    }
+    nodes.title.textContent = assetExchangeLabel(group.exchange);
+    nodes.accounts.textContent =
+      `${group.account_count} account${group.account_count === 1 ? "" : "s"}`;
+    syncPnlTotals(nodes.totals, group.totals, "pnl-exchange-total");
+  }
+
+  function createPnlRecord() {
+    const row = document.createElement("article");
+    row.className = "account-history-record account-pnl-record";
+
+    const header = document.createElement("div");
+    header.className = "account-history-record-header";
+    const identity = document.createElement("div");
+    identity.className = "account-history-record-identity";
+    const logo = document.createElement("span");
+    logo.className = "account-position-live-logo";
+    identity.appendChild(logo);
+    const copy = document.createElement("div");
+    copy.className = "account-history-record-copy";
+    const account = document.createElement("div");
+    account.className = "account-history-record-symbol";
+    const accountName = document.createElement("strong");
+    const currency = document.createElement("span");
+    account.append(accountName, currency);
+    const partial = document.createElement("span");
+    partial.className = "account-pnl-partial hidden";
+    partial.textContent = "Partial data";
+    account.appendChild(partial);
+    const exchange = document.createElement("small");
+    copy.append(account, exchange);
+    identity.appendChild(copy);
+
+    const trailing = document.createElement("div");
+    trailing.className = "account-history-record-trailing";
+    const trailingLabel = document.createElement("span");
+    trailingLabel.textContent = "Net PnL";
+    const trailingValue = document.createElement("strong");
+    trailing.append(trailingLabel, trailingValue);
+    header.append(identity, trailing);
+
+    const metrics = document.createElement("div");
+    metrics.className = "account-history-record-metrics";
+    const makeMetric = (label) => {
+      const metric = createHistoryMetric(label, "");
+      metrics.appendChild(metric);
+      return metric.querySelector("strong");
+    };
+    row.pnlNodes = {
+      logo,
+      accountName,
+      currency,
+      partial,
+      exchange,
+      trailingValue,
+      realized: makeMetric("Realized"),
+      unrealized: makeMetric("Unrealized"),
+      fees: makeMetric("Fees"),
+      closed: makeMetric("Closed"),
+      open: makeMetric("Open"),
+    };
+    row.append(header, metrics);
+    return row;
+  }
+
+  function updatePnlRecord(row, record) {
+    row.dataset.pnlKey = `account:${pnlRowKey(record)}`;
+    const nodes = row.pnlNodes;
+    const exchangeName = String(record.exchange || "").toUpperCase();
+    const logoIdentity = `${record.exchange_logo_url || ""}|${exchangeName}`;
+    if (nodes.logo.dataset.identity !== logoIdentity) {
+      setHTML(nodes.logo, logoImg(record.exchange_logo_url, exchangeName, "exchange-logo"));
+      nodes.logo.querySelectorAll("[title]").forEach((node) => node.removeAttribute("title"));
+      nodes.logo.dataset.identity = logoIdentity;
+    }
+    nodes.accountName.textContent = String(record.account || "—");
+    nodes.currency.textContent = String(record.currency || "");
+    nodes.partial.classList.toggle("hidden", record.complete === true);
+    nodes.exchange.textContent = exchangeName || "—";
+    nodes.trailingValue.textContent = formatPnlValue(record.net_pnl, record.currency);
+    nodes.trailingValue.className = positionPnlClass(record.net_pnl);
+    const feeAdjustment = record.fees === null || record.fees === undefined
+      ? null
+      : -Number(record.fees);
+    const values = [
+      [nodes.realized, record.realized_pnl, formatPnlValue(record.realized_pnl, record.currency)],
+      [nodes.unrealized, record.unrealized_pnl, formatPnlValue(record.unrealized_pnl, record.currency)],
+      [
+        nodes.fees,
+        feeAdjustment,
+        feeAdjustment === null ? "—" : formatPnlValue(feeAdjustment, record.currency),
+      ],
+    ];
+    values.forEach(([node, value, text]) => {
+      node.textContent = text;
+      node.className = value === null ? "" : positionPnlClass(value);
+    });
+    nodes.closed.textContent = formatPositionNumber(record.closed_positions, 0);
+    nodes.open.textContent = formatPositionNumber(record.open_positions, 0);
+  }
+
+  function syncPnlList(items, keyFor, createRow, updateRow) {
+    const list = el("pnl-list");
+    const existing = new Map(
+      Array.from(list.children).map((row) => [row.dataset.pnlKey || "", row]),
+    );
+    items.forEach((item, index) => {
+      const key = keyFor(item);
+      let row = existing.get(key);
+      if (!row) row = createRow();
+      updateRow(row, item);
+      const current = list.children[index];
+      if (current !== row) list.insertBefore(row, current || null);
+      existing.delete(key);
+    });
+    existing.forEach((row) => row.remove());
+  }
+
+  function scrollPnlToTop() {
+    el("pnl-list").scrollTop = 0;
+    const body = el("account-pnl-view").querySelector(".account-view-body");
+    if (body) body.scrollTop = 0;
+  }
+
+  function updatePnlListSizing() {
+    const list = el("pnl-list");
+    if (!list) return;
+    if (
+      mobileHubQuery.matches
+      || !isAssetsOpen()
+      || accountView !== "pnl"
+      || list.classList.contains("hidden")
+    ) {
+      list.classList.remove("pnl-list-sized", "pnl-list-scrollable");
+      list.style.removeProperty("--pnl-list-height");
+      return;
+    }
+    const rows = Array.from(list.children);
+    if (!rows.length) {
+      list.classList.remove("pnl-list-sized", "pnl-list-scrollable");
+      list.style.removeProperty("--pnl-list-height");
+      return;
+    }
+    const visibleRows = rows.slice(0, 5);
+    const style = getComputedStyle(list);
+    const borders = Number.parseFloat(style.borderTopWidth || "0")
+      + Number.parseFloat(style.borderBottomWidth || "0");
+    const height = visibleRows.reduce((sum, row) => sum + row.offsetHeight, borders);
+    list.classList.add("pnl-list-sized");
+    list.classList.toggle("pnl-list-scrollable", rows.length > 5);
+    list.style.setProperty("--pnl-list-height", `${Math.ceil(height)}px`);
+  }
+
+  function schedulePnlListSizing() {
+    if (pnlListSizeFrame !== null) cancelAnimationFrame(pnlListSizeFrame);
+    pnlListSizeFrame = requestAnimationFrame(() => {
+      pnlListSizeFrame = null;
+      updatePnlListSizing();
+    });
+  }
+
+  function renderPnlView() {
+    if (!pnlPayload) return;
+    const results = Array.isArray(pnlPayload.results) ? pnlPayload.results : [];
+    const groups = groupPnlByExchange(results);
+    let selected = selectedPnlExchange
+      ? groups.find((group) => group.exchange === selectedPnlExchange)
+      : null;
+    if (selectedPnlExchange && !selected) {
+      selectedPnlExchange = null;
+      selected = null;
+    }
+    const visibleResults = selected ? selected.rows : results;
+    const totals = selected
+      ? selected.totals
+      : (Array.isArray(pnlPayload.totals) ? pnlPayload.totals : []);
+    const totalsElement = el("pnl-summary-totals");
+    syncPnlTotals(totalsElement, totals);
+    const accountCount = selected
+      ? selected.account_count
+      : Number((pnlPayload.summary || {}).accounts || 0);
+    el("pnl-summary-counts").textContent =
+      `${selected ? "" : `${groups.length} exchanges · `}${accountCount} accounts`;
+    const collectedAt = Date.parse(pnlPayload.collected_at || "");
+    el("pnl-updated").textContent = Number.isFinite(collectedAt)
+      ? `Updated ${new Date(collectedAt).toLocaleString("en-US", {
+          month: "short",
+          day: "numeric",
+          hour: "2-digit",
+          minute: "2-digit",
+        })}`
+      : "";
+    el("assets-back").classList.toggle("hidden", !selected);
+    el("assets-title").textContent = selected
+      ? `${assetExchangeLabel(selected.exchange)} PnL`
+      : "PnL";
+    el("pnl-summary").classList.toggle("hidden", results.length === 0);
+    el("pnl-empty").classList.toggle("hidden", results.length !== 0);
+    el("pnl-list").classList.toggle("hidden", results.length === 0);
+    el("pnl-list").classList.toggle("pnl-exchange-overview", !selected);
+    if (selected) {
+      syncPnlList(
+        visibleResults,
+        (record) => `account:${pnlRowKey(record)}`,
+        createPnlRecord,
+        updatePnlRecord,
+      );
+    } else {
+      syncPnlList(
+        groups,
+        (group) => `exchange:${group.exchange}`,
+        createPnlExchangeRow,
+        updatePnlExchangeRow,
+      );
+    }
+    const partial = visibleResults.some((result) => result && result.complete !== true);
+    el("pnl-coverage-note").textContent = partial
+      ? "* Unavailable PnL values are excluded. Funding and borrow interest are not included."
+      : "Funding and borrow interest are not included.";
+    el("pnl-coverage-note").classList.toggle("hidden", results.length === 0);
+    el("pnl-loading").classList.add("hidden");
+    updatePnlListSizing();
+    historyFlipCommit();
+  }
+
+  function renderPnl(payload) {
+    pnlPayload = payload;
+    pnlHaveData = true;
+    renderPnlView();
+  }
+
+  function setPnlLoading(loading, preserveContent = false) {
+    if (accountView === "pnl") {
+      el("assets-refresh").disabled = loading;
+      el("assets-refresh").classList.toggle("assets-refreshing", loading);
+    }
+    el("pnl-loading").classList.toggle("hidden", !loading || preserveContent);
+    if (loading) el("pnl-error").classList.add("hidden");
+    if (loading && !preserveContent) {
+      pnlPayload = null;
+      el("pnl-summary").classList.add("hidden");
+      el("pnl-empty").classList.add("hidden");
+      el("pnl-list").classList.add("hidden");
+      el("pnl-coverage-note").classList.add("hidden");
+      el("pnl-list").replaceChildren();
+    }
+  }
+
+  async function loadPnl() {
+    clearPnlRefreshTimer();
+    const seq = ++pnlRequestSeq;
+    const preserveContent = pnlHaveData;
+    setPnlLoading(true, preserveContent);
+    try {
+      const payload = await api(`/api/account/pnl?days=${pnlPeriodDays}`);
+      if (seq !== pnlRequestSeq || !isAssetsOpen() || accountView !== "pnl") return;
+      renderPnl(payload);
+    } catch (error) {
+      if (seq !== pnlRequestSeq || !isAssetsOpen() || accountView !== "pnl") return;
+      el("pnl-error").textContent = `${error.message}\nUse refresh to try again.`;
+      el("pnl-error").classList.remove("hidden");
+      if (!preserveContent) {
+        el("pnl-summary").classList.add("hidden");
+        el("pnl-list").classList.add("hidden");
+      }
+    } finally {
+      if (seq === pnlRequestSeq) {
+        setPnlLoading(false);
+        schedulePnlRefresh();
+      }
+    }
+  }
+
   function formatAccountHistoryDate(value, includeSeconds = false) {
     const timestamp = Date.parse(String(value || ""));
     if (!Number.isFinite(timestamp)) return "—";
@@ -2566,10 +3012,10 @@
     return row;
   }
 
-  // Smoothly animate the modal-box height across a history content change
-  // (navigation between exchange/symbol/detail levels, or a filter reload).
-  // begin() pins the current height before the swap; commit() (called from the
-  // render) releases to the natural height and transitions between the two.
+  // Smoothly animate the modal-box height across an account content change
+  // (history exchange/symbol/detail navigation, a history filter reload, or a
+  // PnL period change). begin() pins the current height before the swap;
+  // commit() (from the render) releases to the natural height and transitions.
   let historyFlipHeight = null;
   let historyFlipTimer = null;
 
@@ -4056,6 +4502,12 @@
     });
     el("assets-close").addEventListener("click", closeAssets);
     el("assets-back").addEventListener("click", () => {
+      if (accountView === "pnl") {
+        selectedPnlExchange = null;
+        renderPnlView();
+        scrollPnlToTop();
+        return;
+      }
       selectedAssetExchange = null;
       renderAssetsView();
       el("assets-body").scrollTop = 0;
@@ -4064,7 +4516,24 @@
       if (accountView === "positions") loadPositions(true);
       else if (accountView === "position-history") loadPositionHistory(false, true);
       else if (accountView === "orders") loadOrderHistory(false, true);
+      else if (accountView === "pnl") loadPnl();
       else if (accountView === "assets") loadAssets(true);
+    });
+    document.querySelectorAll("[data-pnl-days]").forEach((button) => {
+      button.addEventListener("click", () => {
+        const days = Number(button.dataset.pnlDays);
+        if (!Number.isInteger(days) || days === pnlPeriodDays) return;
+        pnlPeriodDays = days;
+        // keep the current rows (preserveContent) so the list updates in place
+        // via syncPnlList's keyed diff instead of clearing → no empty flash
+        document.querySelectorAll("[data-pnl-days]").forEach((candidate) => {
+          const active = Number(candidate.dataset.pnlDays) === pnlPeriodDays;
+          candidate.classList.toggle("active", active);
+          candidate.setAttribute("aria-pressed", String(active));
+        });
+        historyFlipBegin();
+        loadPnl();
+      });
     });
     el("position-history-filters").addEventListener("submit", (event) => {
       event.preventDefault();
@@ -4168,6 +4637,7 @@
       closePositionPnlPopover();
     }, { passive: true });
     window.addEventListener("resize", closePositionPnlPopover, { passive: true });
+    window.addEventListener("resize", schedulePnlListSizing, { passive: true });
     el("asset-transfer-close").addEventListener("click", closeAssetTransfer);
     el("asset-transfer-back").addEventListener("click", () => {
       if (assetTransferMode === "review") {
@@ -7437,8 +7907,10 @@
       rebuildHub();
       connectAccountPositions();
       scheduleAssetsRefresh();
+      schedulePnlRefresh();
     } else {
       clearAssetsRefreshTimer();
+      clearPnlRefreshTimer();
       closeForBackground();
       closeAccountPositionsSocket();
     }

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -73,6 +73,12 @@
   let pnlRefreshTimer = null;
   let pnlListSizeFrame = null;
   const historyCustomSelects = {};
+  let historyImportPreview = null;
+  let historyImportSelections = {};
+  let historyImportBusy = false;
+  let historyImportJobTimer = null;
+  let historyImportLogLoaded = false;
+  let historyImportStatusText = "";
   let positionHistoryRequestSeq = 0;
   let positionHistoryHaveData = false;
   let positionHistoryRows = [];
@@ -644,6 +650,7 @@
     positions: "Positions",
     "position-history": "Position History",
     orders: "Order History",
+    "import-history": "Import History",
     pnl: "PnL",
   };
 
@@ -682,6 +689,7 @@
     const isAccountHistoryView = (
       view === "position-history"
       || view === "orders"
+      || view === "import-history"
       || view === "pnl"
     );
     const deferAccountHeight = animateAccountHeight && isAccountHistoryView && Boolean(options.load);
@@ -691,10 +699,12 @@
       if (Math.abs(endHeight - accountStartHeight) <= 1) return;
       accountBox.style.height = `${accountStartHeight}px`;
       void accountBox.offsetHeight; // reflow to lock the start height
+      accountBox.classList.add("flip-animating");
       accountBox.style.height = `${endHeight}px`;
       const onHeightEnd = (event) => {
         if (event.target !== accountBox || event.propertyName !== "height") return;
         accountBox.removeEventListener("transitionend", onHeightEnd);
+        accountBox.classList.remove("flip-animating");
         accountBox.style.height = "";
       };
       accountBox.addEventListener("transitionend", onHeightEnd);
@@ -783,6 +793,7 @@
     }
     else if (view === "position-history") await loadPositionHistory(false);
     else if (view === "orders") await loadOrderHistory(false);
+    else if (view === "import-history") await loadHistoryImports(true);
     else if (view === "pnl") await loadPnl();
     if (deferAccountHeight) {
       if (isAssetsOpen() && accountView === view) runAccountHeightTween();
@@ -2666,10 +2677,18 @@
       );
     }
     const partial = visibleResults.some((result) => result && result.complete !== true);
-    el("pnl-coverage-note").textContent = partial
-      ? "* Unavailable PnL values are excluded. Funding and borrow interest are not included."
-      : "Funding and borrow interest are not included.";
-    el("pnl-coverage-note").classList.toggle("hidden", results.length === 0);
+    const coverage = pnlPayload.summary || {};
+    const unavailable = [];
+    if (coverage.funding_available !== true) unavailable.push("funding");
+    if (coverage.borrow_interest_available !== true) unavailable.push("borrow interest");
+    const notes = [];
+    if (partial) notes.push("Unavailable PnL values are excluded");
+    if (unavailable.length) notes.push(`${unavailable.join(" and ")} are not included`);
+    el("pnl-coverage-note").textContent = notes.length ? `* ${notes.join(". ")}.` : "";
+    el("pnl-coverage-note").classList.toggle(
+      "hidden",
+      results.length === 0 || notes.length === 0,
+    );
     el("pnl-loading").classList.add("hidden");
     updatePnlListSizing();
     historyFlipCommit();
@@ -2723,7 +2742,334 @@
     }
   }
 
-  function formatAccountHistoryDate(value, includeSeconds = false) {
+  function setHistoryImportLoading(loading, text = "") {
+    historyImportBusy = loading;
+    el("history-import-loading").classList.toggle("hidden", !loading);
+    if (text) el("history-import-loading-text").textContent = text;
+    el("history-import-dropzone").disabled = loading;
+    renderHistoryImportActions();
+  }
+
+  function historyImportTypeLabel(value) {
+    return String(value || "")
+      .split("_")
+      .filter(Boolean)
+      .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+      .join(" ");
+  }
+
+  function historyImportSelectMarkup(fileId, field, options, selected, emptyLabel) {
+    const selectedLabel = options.includes(selected) ? selected : emptyLabel;
+    const optionMarkup = options.length
+      ? options.map((value) => (
+        `<button type="button" class="history-import-select-option${value === selected ? " selected" : ""}" `
+        + `data-history-import-option="${esc(fileId)}" data-field="${esc(field)}" `
+        + `data-value="${esc(value)}" role="option" aria-selected="${value === selected}">`
+        + `${esc(value)}</button>`
+      )).join("")
+      : `<div class="script-select-empty">${esc(emptyLabel)}</div>`;
+    return `<div class="history-import-select" data-history-import-select-wrap="${esc(fileId)}:${esc(field)}">`
+      + `<button type="button" class="history-import-select-button" `
+      + `data-history-import-select="${esc(fileId)}" data-field="${esc(field)}" `
+      + `aria-haspopup="listbox" aria-expanded="false">`
+      + `<span>${esc(selectedLabel)}</span><span aria-hidden="true">&#9662;</span></button>`
+      + `<div class="history-import-select-options hidden" role="listbox">${optionMarkup}</div>`
+      + `</div>`;
+  }
+
+  function closeHistoryImportSelects(except = null) {
+    document.querySelectorAll(".history-import-select").forEach((control) => {
+      if (control === except) return;
+      control.classList.remove("open");
+      const button = control.querySelector(".history-import-select-button");
+      const options = control.querySelector(".history-import-select-options");
+      if (button) button.setAttribute("aria-expanded", "false");
+      if (options) options.classList.add("hidden");
+    });
+  }
+
+  function historyImportReady() {
+    if (!historyImportPreview || historyImportBusy) return false;
+    const files = Array.isArray(historyImportPreview.files) ? historyImportPreview.files : [];
+    return files.length > 0 && files.every((file) => {
+      const selection = historyImportSelections[file.file_id] || {};
+      return Boolean(
+        selection.account
+        && selection.source_timezone
+        && selection.timezone_confirmed,
+      );
+    });
+  }
+
+  function renderHistoryImportActions() {
+    const hasPreview = Boolean(
+      historyImportPreview
+      && Array.isArray(historyImportPreview.files)
+      && historyImportPreview.files.length,
+    );
+    el("history-import-actions").classList.toggle("hidden", !hasPreview);
+    el("history-import-submit").disabled = !historyImportReady();
+    el("history-import-status").textContent = historyImportStatusText;
+  }
+
+  function renderHistoryImportPreview() {
+    const container = el("history-import-preview");
+    const files = historyImportPreview && Array.isArray(historyImportPreview.files)
+      ? historyImportPreview.files
+      : [];
+    container.classList.toggle("hidden", !files.length);
+    if (!files.length) {
+      container.replaceChildren();
+      renderHistoryImportActions();
+      return;
+    }
+    const timezoneOptions = Array.isArray(historyImportPreview.timezone_options)
+      ? historyImportPreview.timezone_options
+      : [];
+    container.innerHTML = files.map((file) => {
+      const selection = historyImportSelections[file.file_id] || {};
+      const accounts = Array.isArray(file.account_candidates) ? file.account_candidates : [];
+      const warnings = Array.isArray(file.warnings) ? file.warnings : [];
+      const range = file.first_occurred_at && file.last_occurred_at
+        ? `${formatAccountHistoryDate(file.first_occurred_at, false, true)} – ${formatAccountHistoryDate(file.last_occurred_at, false, true)}`
+        : "No dated rows";
+      return `<article class="history-import-file" data-history-import-file="${esc(file.file_id)}">`
+        + `<header><div><strong title="${esc(file.name)}">${esc(file.name)}</strong>`
+        + `<span>${esc(file.exchange)} · ${esc(historyImportTypeLabel(file.file_type))}</span></div>`
+        + `<aside><b>${Number(file.row_count || 0).toLocaleString()} rows</b>`
+        + `<button type="button" class="btn btn-icon history-import-remove" `
+        + `data-history-import-remove="${esc(file.file_id)}" title="Remove file" aria-label="Remove file">&times;</button>`
+        + `</aside></header>`
+        + `<div class="history-import-range"><span>Coverage</span><strong>${esc(range)}</strong></div>`
+        + `<div class="history-import-fields">`
+        + `<label><span>Account</span>${historyImportSelectMarkup(
+          file.file_id,
+          "account",
+          accounts,
+          selection.account || "",
+          accounts.length ? "Select account" : "No configured account",
+        )}</label>`
+        + `<label><span>Source timezone</span>${historyImportSelectMarkup(
+          file.file_id,
+          "source_timezone",
+          timezoneOptions,
+          selection.source_timezone || "",
+          "Select timezone",
+        )}</label>`
+        + `</div>`
+        + `<label class="history-import-confirm"><input type="checkbox" `
+        + `data-history-import-timezone-confirm="${esc(file.file_id)}" `
+        + `${selection.timezone_confirmed ? "checked" : ""} />`
+        + `<span>Timezone confirmed as ${esc(selection.source_timezone || "not selected")}</span></label>`
+        + (warnings.length
+          ? `<div class="history-import-warnings">${warnings.map((warning) => `<span>${esc(warning)}</span>`).join("")}</div>`
+          : "")
+        + `</article>`;
+    }).join("");
+    renderHistoryImportActions();
+  }
+
+  function renderHistoryImportLog(payload) {
+    const results = payload && Array.isArray(payload.results) ? payload.results : [];
+    el("history-import-log-count").textContent = results.length
+      ? `${Number(payload.total || results.length).toLocaleString()} files`
+      : "";
+    el("history-import-log-empty").classList.toggle("hidden", results.length > 0);
+    el("history-import-log-list").innerHTML = results.map((item) => {
+      const warningCount = Array.isArray(item.warnings) ? item.warnings.length : 0;
+      const coverage = item.first_occurred_at && item.last_occurred_at
+        ? `${formatAccountHistoryDate(item.first_occurred_at, false, true)} – ${formatAccountHistoryDate(item.last_occurred_at, false, true)}`
+        : "No dated rows";
+      return `<div class="history-import-log-row">`
+        + `<span class="history-import-log-logo">${logoImg(item.exchange_logo_url, item.exchange, "exchange-logo")}</span>`
+        + `<span><strong title="${esc(item.original_name)}">${esc(item.original_name)}</strong>`
+        + `<small>${esc(item.account)} · ${esc(historyImportTypeLabel(item.file_type))} · ${Number(item.row_count || 0).toLocaleString()} rows</small>`
+        + `<small>${esc(coverage)}</small></span>`
+        + `<span class="history-import-log-actions"><span class="history-import-log-status ${item.status === "partial" ? "partial" : ""}">`
+        + `${esc(item.status || "imported")}${warningCount ? ` · ${warningCount} warning${warningCount === 1 ? "" : "s"}` : ""}`
+        + `</span>`
+        + (item.enrichment_retry_available
+          ? `<button type="button" class="btn btn-icon" data-history-import-retry="${esc(item.import_id)}" title="Retry Hyperliquid Order History" aria-label="Retry Hyperliquid Order History">`
+            + `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M3 12a9 9 0 0 1 15.7-6L21 8"></path><path d="M21 3v5h-5"></path><path d="M21 12a9 9 0 0 1-15.7 6L3 16"></path><path d="M3 21v-5h5"></path></svg></button>`
+          : "")
+        + `</span></div>`;
+    }).join("");
+  }
+
+  async function loadHistoryImports(force = false) {
+    if (historyImportLogLoaded && !force) return;
+    try {
+      const payload = await api("/api/account/history/imports?limit=100");
+      historyImportLogLoaded = true;
+      renderHistoryImportLog(payload);
+      const activeJobs = Array.isArray(payload.active_jobs) ? payload.active_jobs : [];
+      if (activeJobs.length && historyImportJobTimer === null && !historyImportBusy) {
+        const job = activeJobs[activeJobs.length - 1];
+        const mode = job.kind === "enrichment" ? "enrichment" : "import";
+        historyImportStatusText = mode === "enrichment"
+          ? "Refreshing Hyperliquid Order History..."
+          : "Merging history into the account cache...";
+        setHistoryImportLoading(true, historyImportStatusText);
+        pollHistoryImportJob(job.job_id, mode);
+      }
+    } catch (error) {
+      el("history-import-error").textContent = error.message;
+      el("history-import-error").classList.remove("hidden");
+    }
+  }
+
+  async function previewHistoryImport(fileList) {
+    const files = Array.from(fileList || []);
+    if (!files.length || historyImportBusy) return;
+    historyImportPreview = null;
+    historyImportSelections = {};
+    historyImportStatusText = "";
+    el("history-import-error").classList.add("hidden");
+    renderHistoryImportPreview();
+    setHistoryImportLoading(true, "Inspecting CSV files...");
+    const body = new FormData();
+    files.forEach((file) => body.append("files", file, file.name));
+    try {
+      const payload = await api("/api/account/history/import/preview", {
+        method: "POST",
+        body,
+      });
+      historyImportPreview = payload;
+      (payload.files || []).forEach((file) => {
+        historyImportSelections[file.file_id] = {
+          account: file.suggested_account || "",
+          source_timezone: file.source_timezone || "",
+          timezone_confirmed: false,
+        };
+      });
+      renderHistoryImportPreview();
+    } catch (error) {
+      el("history-import-error").textContent = error.message;
+      el("history-import-error").classList.remove("hidden");
+    } finally {
+      el("history-import-files").value = "";
+      setHistoryImportLoading(false);
+    }
+  }
+
+  async function removeHistoryImportPreviewFile(fileId) {
+    if (!historyImportPreview || historyImportBusy || !fileId) return;
+    el("history-import-error").classList.add("hidden");
+    setHistoryImportLoading(true, "Removing CSV file...");
+    try {
+      await api(
+        `/api/account/history/import/previews/${encodeURIComponent(historyImportPreview.preview_id)}`
+          + `/files/${encodeURIComponent(fileId)}`,
+        { method: "DELETE" },
+      );
+      historyImportPreview.files = (historyImportPreview.files || []).filter(
+        (file) => file.file_id !== fileId,
+      );
+      delete historyImportSelections[fileId];
+      if (!historyImportPreview.files.length) historyImportPreview = null;
+      historyImportStatusText = "";
+      renderHistoryImportPreview();
+    } catch (error) {
+      el("history-import-error").textContent = error.message;
+      el("history-import-error").classList.remove("hidden");
+    } finally {
+      setHistoryImportLoading(false);
+    }
+  }
+
+  function pollHistoryImportJob(jobId, mode = "import") {
+    if (historyImportJobTimer !== null) clearTimeout(historyImportJobTimer);
+    historyImportJobTimer = window.setTimeout(async () => {
+      historyImportJobTimer = null;
+      try {
+        const job = await api(`/api/account/history/import/jobs/${encodeURIComponent(jobId)}`);
+        if (job.status === "completed") {
+          const summary = job.summary || {};
+          historyImportStatusText = mode === "enrichment"
+            ? `${Number(summary.orders || 0).toLocaleString()} Hyperliquid orders refreshed`
+            : `${Number(summary.imported || 0)} imported · ${Number(summary.already_imported || 0)} already imported`;
+          setHistoryImportLoading(false);
+          if (mode === "import") {
+            historyImportPreview = null;
+            historyImportSelections = {};
+            historyImportStatusText = "";
+            renderHistoryImportPreview();
+          }
+          historyImportLogLoaded = false;
+          positionHistoryGroupsHaveData = false;
+          orderHistoryGroupsHaveData = false;
+          pnlHaveData = false;
+          await loadHistoryImports(true);
+          return;
+        }
+        if (job.status === "failed") {
+          throw new Error(job.error || "History import failed");
+        }
+        historyImportStatusText = job.status === "queued"
+          ? "Waiting for Account Worker..."
+          : mode === "enrichment"
+            ? "Refreshing Hyperliquid Order History..."
+            : "Merging history into the account cache...";
+        renderHistoryImportActions();
+        pollHistoryImportJob(jobId, mode);
+      } catch (error) {
+        historyImportStatusText = "";
+        setHistoryImportLoading(false);
+        el("history-import-error").textContent = error.message;
+        el("history-import-error").classList.remove("hidden");
+      }
+    }, 900);
+  }
+
+  async function submitHistoryImport() {
+    if (!historyImportReady()) return;
+    historyImportStatusText = "Preparing normalized history...";
+    el("history-import-error").classList.add("hidden");
+    setHistoryImportLoading(true, "Preparing import...");
+    try {
+      const payload = await api("/api/account/history/import/commit", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          preview_id: historyImportPreview.preview_id,
+          files: historyImportPreview.files.map((file) => ({
+            file_id: file.file_id,
+            ...historyImportSelections[file.file_id],
+          })),
+        }),
+      });
+      historyImportStatusText = "Waiting for Account Worker...";
+      el("history-import-loading-text").textContent = "Importing history...";
+      renderHistoryImportActions();
+      pollHistoryImportJob(payload.job_id);
+    } catch (error) {
+      setHistoryImportLoading(false);
+      historyImportStatusText = "";
+      el("history-import-error").textContent = error.message;
+      el("history-import-error").classList.remove("hidden");
+    }
+  }
+
+  async function retryHistoryImportEnrichment(importId) {
+    if (!importId || historyImportBusy) return;
+    historyImportStatusText = "Preparing Hyperliquid Order History refresh...";
+    el("history-import-error").classList.add("hidden");
+    setHistoryImportLoading(true, "Refreshing Hyperliquid Order History...");
+    try {
+      const payload = await api(
+        `/api/account/history/imports/${encodeURIComponent(importId)}/retry-enrichment`,
+        { method: "POST" },
+      );
+      pollHistoryImportJob(payload.job_id, "enrichment");
+    } catch (error) {
+      setHistoryImportLoading(false);
+      historyImportStatusText = "";
+      el("history-import-error").textContent = error.message;
+      el("history-import-error").classList.remove("hidden");
+    }
+  }
+
+  function formatAccountHistoryDate(value, includeSeconds = false, includeYear = false) {
     const timestamp = Date.parse(String(value || ""));
     if (!Number.isFinite(timestamp)) return "—";
     const options = {
@@ -2733,6 +3079,7 @@
       minute: "2-digit",
       hour12: false,
     };
+    if (includeYear) options.year = "numeric";
     if (includeSeconds) options.second = "2-digit";
     return new Date(timestamp).toLocaleString("en-US", options);
   }
@@ -3052,10 +3399,12 @@
     if (Math.abs(end - start) <= 1) return;
     box.style.height = `${start}px`;
     void box.offsetHeight; // reflow to lock the start height
+    box.classList.add("flip-animating");
     box.style.height = `${end}px`;
     const onEnd = (event) => {
       if (event.target !== box || event.propertyName !== "height") return;
       box.removeEventListener("transitionend", onEnd);
+      box.classList.remove("flip-animating");
       box.style.height = "";
     };
     box.addEventListener("transitionend", onEnd);
@@ -4500,6 +4849,84 @@
         switchAccountView(view, { load: true, animate: true });
       }
     });
+    el("history-import-dropzone").addEventListener("click", () => {
+      if (!historyImportBusy) el("history-import-files").click();
+    });
+    el("history-import-dropzone").addEventListener("dragover", (event) => {
+      event.preventDefault();
+      if (!historyImportBusy) el("history-import-dropzone").classList.add("dragover");
+    });
+    el("history-import-dropzone").addEventListener("dragleave", () => {
+      el("history-import-dropzone").classList.remove("dragover");
+    });
+    el("history-import-dropzone").addEventListener("drop", (event) => {
+      event.preventDefault();
+      el("history-import-dropzone").classList.remove("dragover");
+      if (!historyImportBusy) previewHistoryImport(event.dataTransfer && event.dataTransfer.files);
+    });
+    el("history-import-files").addEventListener("change", (event) => {
+      previewHistoryImport(event.target.files);
+    });
+    el("history-import-preview").addEventListener("click", (event) => {
+      const removeButton = event.target && event.target.closest
+        ? event.target.closest("[data-history-import-remove]")
+        : null;
+      if (removeButton) {
+        removeHistoryImportPreviewFile(String(removeButton.dataset.historyImportRemove || ""));
+        return;
+      }
+      const option = event.target && event.target.closest
+        ? event.target.closest("[data-history-import-option]")
+        : null;
+      if (option) {
+        const fileId = String(option.dataset.historyImportOption || "");
+        const field = String(option.dataset.field || "");
+        if (historyImportSelections[fileId] && ["account", "source_timezone"].includes(field)) {
+          historyImportSelections[fileId][field] = String(option.dataset.value || "");
+          if (field === "source_timezone") {
+            historyImportSelections[fileId].timezone_confirmed = false;
+          }
+          closeHistoryImportSelects();
+          renderHistoryImportPreview();
+        }
+        return;
+      }
+      const button = event.target && event.target.closest
+        ? event.target.closest("[data-history-import-select]")
+        : null;
+      if (!button) return;
+      const control = button.closest(".history-import-select");
+      const options = control && control.querySelector(".history-import-select-options");
+      if (!control || !options) return;
+      const willOpen = options.classList.contains("hidden");
+      closeHistoryImportSelects(control);
+      control.classList.toggle("open", willOpen);
+      options.classList.toggle("hidden", !willOpen);
+      button.setAttribute("aria-expanded", String(willOpen));
+    });
+    el("history-import-preview").addEventListener("change", (event) => {
+      const checkbox = event.target && event.target.closest
+        ? event.target.closest("[data-history-import-timezone-confirm]")
+        : null;
+      if (!checkbox) return;
+      const fileId = String(checkbox.dataset.historyImportTimezoneConfirm || "");
+      if (!historyImportSelections[fileId]) return;
+      historyImportSelections[fileId].timezone_confirmed = checkbox.checked;
+      renderHistoryImportActions();
+    });
+    el("history-import-submit").addEventListener("click", submitHistoryImport);
+    el("history-import-log-list").addEventListener("click", (event) => {
+      const button = event.target && event.target.closest
+        ? event.target.closest("[data-history-import-retry]")
+        : null;
+      if (!button) return;
+      retryHistoryImportEnrichment(String(button.dataset.historyImportRetry || ""));
+    });
+    document.addEventListener("click", (event) => {
+      if (!event.target || !event.target.closest(".history-import-select")) {
+        closeHistoryImportSelects();
+      }
+    });
     el("assets-close").addEventListener("click", closeAssets);
     el("assets-back").addEventListener("click", () => {
       if (accountView === "pnl") {
@@ -4521,13 +4948,16 @@
     });
     document.querySelectorAll("[data-pnl-days]").forEach((button) => {
       button.addEventListener("click", () => {
-        const days = Number(button.dataset.pnlDays);
-        if (!Number.isInteger(days) || days === pnlPeriodDays) return;
+        const rawDays = String(button.dataset.pnlDays || "");
+        const days = rawDays === "all" ? "all" : Number(rawDays);
+        if ((days !== "all" && !Number.isInteger(days)) || days === pnlPeriodDays) return;
         pnlPeriodDays = days;
         // keep the current rows (preserveContent) so the list updates in place
         // via syncPnlList's keyed diff instead of clearing → no empty flash
         document.querySelectorAll("[data-pnl-days]").forEach((candidate) => {
-          const active = Number(candidate.dataset.pnlDays) === pnlPeriodDays;
+          const candidateRaw = String(candidate.dataset.pnlDays || "");
+          const candidateDays = candidateRaw === "all" ? "all" : Number(candidateRaw);
+          const active = candidateDays === pnlPeriodDays;
           candidate.classList.toggle("active", active);
           candidate.setAttribute("aria-pressed", String(active));
         });

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -1730,27 +1730,38 @@
       : number < 0 ? "account-pnl-negative" : "";
   }
 
-  function positionRealizedPnlCell(position) {
+  function updatePositionRealizedPnlCell(cell, position) {
     const value = position.realized_pnl === null || position.realized_pnl === undefined
       ? Number.NaN
       : Number(position.realized_pnl);
-    if (!Number.isFinite(value)) return positionTableCell("—", "", "Realized PnL");
-    const cell = positionTableCell("", positionPnlClass(value), "Realized PnL");
-    const button = document.createElement("button");
-    button.className = "position-pnl-value";
-    button.type = "button";
-    button.textContent = formatSignedPositionNumber(value);
-    button.title = "Show realized PnL calculation";
-    button.setAttribute("aria-haspopup", "dialog");
-    button.setAttribute("aria-expanded", "false");
+    if (!Number.isFinite(value)) {
+      if (activePositionPnlButton && cell.contains(activePositionPnlButton)) {
+        closePositionPnlPopover();
+      }
+      setClass(cell, "");
+      setText(cell, "—");
+      cell.title = "—";
+      return;
+    }
+    setClass(cell, positionPnlClass(value));
+    let button = cell.querySelector(".position-pnl-value");
+    if (!button) {
+      button = document.createElement("button");
+      button.className = "position-pnl-value";
+      button.type = "button";
+      button.title = "Show realized PnL calculation";
+      button.setAttribute("aria-haspopup", "dialog");
+      button.setAttribute("aria-expanded", "false");
+      cell.replaceChildren(button);
+    }
+    setText(button, formatSignedPositionNumber(value));
     const breakdown = position.realized_pnl_breakdown;
     button.dataset.positionPnl = JSON.stringify(
       breakdown && typeof breakdown === "object"
         ? breakdown
         : { gross_pnl: null, fees: null, net_pnl: value, complete: false },
     );
-    cell.appendChild(button);
-    return cell;
+    cell.title = button.textContent;
   }
 
   let activePositionPnlButton = null;
@@ -1814,6 +1825,125 @@
     popover.style.top = `${top}px`;
   }
 
+  function positionRowKey(position) {
+    return JSON.stringify([
+      position.account || "",
+      position.exchange || "",
+      position.market_scope || "",
+      position.dex || "",
+      position.symbol || "",
+      position.side || "",
+    ]);
+  }
+
+  function createPositionRow() {
+    const row = document.createElement("tr");
+    const fields = [
+      ["account", "Account", "account-table-account"],
+      ["symbol", "Symbol", "account-table-symbol"],
+      ["side", "Side", ""],
+      ["size", "Size", ""],
+      ["entry", "Entry", ""],
+      ["mark", "Mark", ""],
+      ["unrealized", "Unrealized PnL", ""],
+      ["realized", "Realized PnL", ""],
+      ["return", "Return", ""],
+      ["leverage", "Leverage", ""],
+      ["liquidation", "Liquidation", ""],
+    ];
+    const cells = {};
+    fields.forEach(([field, label, className]) => {
+      const cell = positionTableCell("", className, label);
+      cell.dataset.positionField = field;
+      cells[field] = cell;
+      row.appendChild(cell);
+    });
+    row.positionCells = cells;
+    return row;
+  }
+
+  function updatePositionCell(cell, text, className = "") {
+    setClass(cell, className);
+    setText(cell, text);
+    cell.title = text;
+  }
+
+  function updatePositionRow(row, position) {
+    const cells = row.positionCells;
+    const accountName = String(position.account || "—");
+    const exchangeName = String(position.exchange || "").toUpperCase();
+    const accountIdentity = JSON.stringify([
+      accountName,
+      exchangeName,
+      position.exchange_logo_url || "",
+    ]);
+    if (cells.account.dataset.identity !== accountIdentity) {
+      const exchangeLogo = logoImg(
+        position.exchange_logo_url,
+        exchangeName,
+        "exchange-logo",
+      );
+      setHTML(
+        cells.account,
+        `${exchangeLogo}<span class="account-table-account-name">${esc(accountName)}</span>`,
+      );
+      cells.account.dataset.identity = accountIdentity;
+    }
+    cells.account.title = accountName;
+
+    const symbolText = String(position.symbol || "—");
+    const scopeText = String(position.market_scope || position.dex || "");
+    const symbolIdentity = JSON.stringify([symbolText, scopeText]);
+    if (cells.symbol.dataset.identity !== symbolIdentity) {
+      cells.symbol.replaceChildren(document.createTextNode(symbolText));
+      if (scopeText) {
+        const scope = document.createElement("small");
+        scope.textContent = scopeText;
+        cells.symbol.appendChild(scope);
+      }
+      cells.symbol.dataset.identity = symbolIdentity;
+    }
+    cells.symbol.title = symbolText;
+
+    const sideText = String(position.side || "—");
+    const sideClass = sideText.toLowerCase() === "long"
+      ? "account-position-long"
+      : sideText.toLowerCase() === "short" ? "account-position-short" : "";
+    const pnl = position.unrealized_pnl === null || position.unrealized_pnl === undefined
+      ? Number.NaN
+      : Number(position.unrealized_pnl);
+    const pnlClass = positionPnlClass(pnl);
+    const percentage = position.percentage === null || position.percentage === undefined
+      ? Number.NaN
+      : Number(position.percentage);
+    const percentageText = Number.isFinite(percentage)
+      ? `${percentage > 0 ? "+" : ""}${formatPositionNumber(percentage, 2)}%`
+      : "—";
+
+    updatePositionCell(cells.side, sideText, sideClass);
+    updatePositionCell(cells.size, formatPositionNumber(position.quantity ?? position.contracts));
+    updatePositionCell(cells.entry, formatPositionNumber(position.entry_price));
+    updatePositionCell(cells.mark, formatPositionNumber(position.mark_price));
+    updatePositionCell(
+      cells.unrealized,
+      Number.isFinite(pnl)
+        ? `${pnl > 0 ? "+" : ""}${formatPositionNumber(pnl, 4)}`
+        : "—",
+      pnlClass,
+    );
+    updatePositionRealizedPnlCell(cells.realized, position);
+    updatePositionCell(cells.return, percentageText, pnlClass);
+    updatePositionCell(
+      cells.leverage,
+      position.leverage !== null
+        && position.leverage !== undefined
+        && Number.isFinite(Number(position.leverage))
+        ? `${formatPositionNumber(position.leverage, 2)}x`
+        : "—",
+    );
+    updatePositionCell(cells.liquidation, formatPositionNumber(position.liquidation_price));
+  }
+
   function renderPositions(payload) {
     const observedAt = Date.parse(payload.collected_at || "");
     if (Number.isFinite(observedAt) && observedAt < positionsObservedAt) return;
@@ -1861,87 +1991,24 @@
     el("positions-table-wrap").classList.toggle("hidden", positions.length === 0);
 
     const tableBody = el("positions-table-body");
-    tableBody.replaceChildren();
-    positions.forEach((position) => {
-      const row = document.createElement("tr");
-      const accountName = String(position.account || "—");
-      const exchangeName = String(position.exchange || "").toUpperCase();
-      const account = positionTableCell("", "account-table-account", "Account");
-      account.title = accountName;
-      const exchangeLogo = logoImg(
-        position.exchange_logo_url,
-        exchangeName,
-        "exchange-logo",
-      );
-      setHTML(
-        account,
-        `${exchangeLogo}<span class="account-table-account-name">${esc(accountName)}</span>`,
-      );
-      account.dataset.label = "Account";
-
-      const symbol = positionTableCell(
-        String(position.symbol || "—"),
-        "account-table-symbol",
-        "Symbol",
-      );
-      const scopeText = String(position.market_scope || position.dex || "");
-      if (scopeText) {
-        const scope = document.createElement("small");
-        scope.textContent = scopeText;
-        symbol.appendChild(scope);
+    const existingRows = new Map(
+      Array.from(tableBody.children).map((row) => [row.dataset.positionKey || "", row]),
+    );
+    positions.forEach((position, index) => {
+      const key = positionRowKey(position);
+      let row = existingRows.get(key);
+      if (!row) row = createPositionRow();
+      row.dataset.positionKey = key;
+      updatePositionRow(row, position);
+      const currentRow = tableBody.children[index];
+      if (currentRow !== row) tableBody.insertBefore(row, currentRow || null);
+      existingRows.delete(key);
+    });
+    existingRows.forEach((row) => {
+      if (activePositionPnlButton && row.contains(activePositionPnlButton)) {
+        closePositionPnlPopover();
       }
-
-      const sideText = String(position.side || "—");
-      const sideClass = sideText.toLowerCase() === "long"
-        ? "account-position-long"
-        : sideText.toLowerCase() === "short" ? "account-position-short" : "";
-      const pnl = position.unrealized_pnl === null || position.unrealized_pnl === undefined
-        ? Number.NaN
-        : Number(position.unrealized_pnl);
-      const pnlClass = positionPnlClass(pnl);
-      const percentage = position.percentage === null || position.percentage === undefined
-        ? Number.NaN
-        : Number(position.percentage);
-      const percentageText = Number.isFinite(percentage)
-        ? `${percentage > 0 ? "+" : ""}${formatPositionNumber(percentage, 2)}%`
-        : "—";
-
-      row.append(
-        account,
-        symbol,
-        positionTableCell(sideText, sideClass, "Side"),
-        positionTableCell(
-          formatPositionNumber(position.quantity ?? position.contracts),
-          "",
-          "Size",
-        ),
-        positionTableCell(formatPositionNumber(position.entry_price), "", "Entry"),
-        positionTableCell(formatPositionNumber(position.mark_price), "", "Mark"),
-        positionTableCell(
-          Number.isFinite(pnl)
-            ? `${pnl > 0 ? "+" : ""}${formatPositionNumber(pnl, 4)}`
-            : "—",
-          pnlClass,
-          "Unrealized PnL",
-        ),
-        positionRealizedPnlCell(position),
-        positionTableCell(percentageText, pnlClass, "Return"),
-        positionTableCell(
-          position.leverage !== null
-            && position.leverage !== undefined
-            && Number.isFinite(Number(position.leverage))
-            ? `${formatPositionNumber(position.leverage, 2)}x`
-            : "—",
-          "",
-          "Leverage",
-        ),
-        positionTableCell(
-          formatPositionNumber(position.liquidation_price),
-          "",
-          "Liquidation",
-        ),
-      );
-      tableBody.appendChild(row);
+      row.remove();
     });
 
     const errorContainer = el("positions-account-errors");
@@ -2704,7 +2771,8 @@
       const menu = el("hub-account-menu");
       const expanded = el("hub-account-toggle").getAttribute("aria-expanded") === "true";
       el("hub-account-toggle").setAttribute("aria-expanded", String(!expanded));
-      menu.classList.toggle("hidden", expanded);
+      menu.classList.toggle("open", !expanded);
+      menu.setAttribute("aria-hidden", String(expanded));
     });
     el("hub-account-menu").addEventListener("click", (event) => {
       const button = event.target && event.target.closest
@@ -2717,7 +2785,8 @@
       const menu = el("hub-history-menu");
       const expanded = el("hub-history-toggle").getAttribute("aria-expanded") === "true";
       el("hub-history-toggle").setAttribute("aria-expanded", String(!expanded));
-      menu.classList.toggle("hidden", expanded);
+      menu.classList.toggle("open", !expanded);
+      menu.setAttribute("aria-hidden", String(expanded));
     });
     el("hub-update-button").addEventListener("click", checkForUpdate);
     el("update-close").addEventListener("click", closeUpdateModal);

--- a/data_service/update_service.py
+++ b/data_service/update_service.py
@@ -7,7 +7,9 @@ import secrets
 import shutil
 import subprocess
 import sys
+import tempfile
 import time
+import tomllib
 from pathlib import Path
 from typing import Any, Callable
 
@@ -45,6 +47,7 @@ def write_update_state(path: Path, **values: Any) -> None:
 
 class UpdateService:
     _CONFIRM_TTL_SECONDS = 120
+    _DEPENDENCY_FILES = frozenset({"pyproject.toml", "requirements-runtime.txt"})
 
     def __init__(
         self,
@@ -272,6 +275,15 @@ class UpdateService:
             )
         else:
             try:
+                if self._dependency_sync_required(request.get("changed_files", [])):
+                    write_update_state(
+                        self.state_path,
+                        status="updating",
+                        message="Installing Python dependencies",
+                    )
+                    self._install_target_dependencies(str(request["target_sha"]))
+                    request["dependencies_synced"] = True
+                    _write_json_atomic(self.request_path, request)
                 write_update_state(
                     self.state_path,
                     status="updating",
@@ -312,6 +324,38 @@ class UpdateService:
                 status="failed",
                 message="Data service could not be restarted.",
                 error=f"{update_error}; {exc}" if update_error else str(exc),
+            )
+            raise
+
+    def sync_dependencies_after_legacy_update(self) -> None:
+        """Handle the first update performed by an older updater implementation."""
+        if not self.pending_restart():
+            return
+        request = read_update_state(self.request_path)
+        if request.get("dependencies_synced") or not self._dependency_sync_required(
+            request.get("changed_files", [])
+        ):
+            return
+        try:
+            write_update_state(
+                self.state_path,
+                status="restarting",
+                message="Installing Python dependencies",
+            )
+            self._install_current_dependencies()
+            request["dependencies_synced"] = True
+            _write_json_atomic(self.request_path, request)
+            write_update_state(
+                self.state_path,
+                status="restarting",
+                message="Restarting data service",
+            )
+        except Exception as exc:
+            write_update_state(
+                self.state_path,
+                status="failed",
+                message="Python dependency installation failed.",
+                error=str(exc),
             )
             raise
 
@@ -385,6 +429,76 @@ class UpdateService:
                 dirs.remove(name)
                 removed += 1
         return removed
+
+    @classmethod
+    def _dependency_sync_required(cls, changed_files: Any) -> bool:
+        return any(str(path) in cls._DEPENDENCY_FILES for path in changed_files)
+
+    @staticmethod
+    def _runtime_requirements(text: str) -> list[str]:
+        return [
+            line
+            for raw_line in text.splitlines()
+            if (line := raw_line.strip()) and not line.startswith("#")
+        ]
+
+    @staticmethod
+    def _project_requirements(text: str) -> list[str]:
+        project = tomllib.loads(text).get("project", {})
+        optional = project.get("optional-dependencies", {})
+        return [str(item) for item in optional.get("all", [])]
+
+    @staticmethod
+    def _deduplicate_requirements(requirements: list[str]) -> list[str]:
+        return list(dict.fromkeys(requirements))
+
+    def _install_requirements(self, requirements: list[str]) -> None:
+        requirements = self._deduplicate_requirements(requirements)
+        if not requirements:
+            return
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".txt") as handle:
+            handle.write("\n".join(requirements) + "\n")
+            handle.flush()
+            completed = subprocess.run(
+                [sys.executable, "-m", "pip", "install", "-r", handle.name],
+                cwd=self.repo_root,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                timeout=900,
+            )
+        if completed.stdout.strip():
+            print(f"[update] {completed.stdout.strip()}")
+        if completed.returncode != 0:
+            detail = completed.stdout.strip()
+            if len(detail) > 4000:
+                detail = detail[-4000:]
+            raise subprocess.SubprocessError(
+                detail
+                or f"Python dependency installation failed with exit code {completed.returncode}"
+            )
+
+    def _install_target_dependencies(self, target_sha: str) -> None:
+        requirements = self._project_requirements(
+            self._git("show", f"{target_sha}:pyproject.toml")
+        )
+        requirements.extend(
+            self._runtime_requirements(
+                self._git("show", f"{target_sha}:requirements-runtime.txt")
+            )
+        )
+        self._install_requirements(requirements)
+
+    def _install_current_dependencies(self) -> None:
+        requirements = self._project_requirements(
+            (self.repo_root / "pyproject.toml").read_text(encoding="utf-8")
+        )
+        requirements.extend(
+            self._runtime_requirements(
+                (self.repo_root / "requirements-runtime.txt").read_text(encoding="utf-8")
+            )
+        )
+        self._install_requirements(requirements)
 
     def _git(self, *args: str, timeout: float = 60) -> str:
         completed = subprocess.run(

--- a/data_service/ws_manager.py
+++ b/data_service/ws_manager.py
@@ -35,6 +35,8 @@ def _coalesce_key(payload: Any) -> Optional[tuple]:
         return ("bar", data.get("time"))
     if t == "sessions":
         return ("sessions",)
+    if t == "account.positions":
+        return ("account.positions",)
     return None
 
 

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,0 +1,9 @@
+python-dateutil
+dotenv
+flask
+pandas
+numpy
+uvicorn[standard]
+fastapi
+python-multipart
+tomlkit

--- a/setup.sh
+++ b/setup.sh
@@ -199,7 +199,7 @@ _setup_main() {
   python -m pip install --upgrade setuptools || return 1
 
   python -m pip install -e ".[all]" || return 1
-  python -m pip install python-dateutil dotenv flask pandas numpy 'uvicorn[standard]' fastapi tomlkit || return 1
+  python -m pip install -r requirements-runtime.txt || return 1
 
   _setup_ai_sandbox
   _setup_ai_chart_capture


### PR DESCRIPTION
## 변경사항

- 기존 Assets 기능을 Account Center로 확장하고 Assets, Positions, PnL, Position History, Order History, Import History 화면을 통합했습니다.
- 거래소별 실시간 포지션 스트림과 REST 보정, 로컬 SQLite 캐시, 90일 초기 백필 및 주기적 이력 수집을 추가했습니다.
- 포지션·주문 이력을 거래소와 심볼별로 탐색하고 수수료·펀딩을 반영한 순 PnL을 기간별로 확인할 수 있도록 구현했습니다.
- Binance, Bitget, OKX, Hyperliquid CSV 이력 가져오기와 중복 제거·정규화·재임포트를 지원합니다. Hyperliquid 주문 이력은 API로 보완합니다.
- 모바일 카드·스크롤·팝오버와 데스크톱 테이블의 실시간 갱신 및 레이아웃 안정성을 보완했습니다.
- Account Center 사용법, 캐시 구조, CSV별 권장 파일과 지원 범위를 README에 정리했습니다.

## 지원 범위

Bybit 계정의 API 기반 Account Center 조회는 유지하지만, Bybit CSV Import는 이번 PR에 포함하지 않았습니다.