### PR TITLE
기능: 실시간 선물 Watchlist 및 세션 추가 지원

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,12 +15,14 @@ workdir/config/providers.toml
 workdir/config/sessions.json
 workdir/config/ai_chat.json
 workdir/config/calendar_events.json
+workdir/config/watchlist_favorites.json
 workdir/config/update_request.json
 workdir/config/update_state.json
 workdir/output/realtime/
 
 # Ignore SQLite cache files but keep the directory
 workdir/data/cache/*.sqlite
+workdir/data/cache/watchlist_logos/
 
 # Ignore OHLCV and TOML files in workdir/data/
 workdir/data/ccxt*.ohlcv

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Run your crypto trading strategy in real time without TradingView.
 - 🔔 Webhook, Telegram, and draggable manual price alerts on the chart
 - 💼 **Account Center** — assets, live positions, trade history, net PnL,
   CSV history import, and reviewed internal transfers
+- 👁️ **Futures Watchlist** — live prices, 24-hour moves, turnover, favorites,
+  and direct session setup across supported exchanges
 - 📱 Full mobile dashboard
 
 ## 🤖 AI Copilot
@@ -364,6 +366,25 @@ values:
 ```json
 {"signal":"CLOSE TP3","ticker":"{{ticker}}","timeframe":"{{timeframe}}"}
 ```
+
+## Futures Watchlist
+
+Open the Hub menu and select **Watchlist** to browse futures markets from
+Binance, Bitget, Bybit, OKX, and Hyperliquid. The list updates while it is open
+and supports exchange, quote-currency, and Stocks / ETFs / Commodities filters,
+search, favorites, and price, 24-hour change, or turnover sorting.
+
+Select a market symbol to add it as a dashboard session. The exchange and symbol
+come from the selected Watchlist row; choose the timeframe and UTC history start
+date and time in the confirmation dialog. The default history range starts two
+months earlier at `00:00` UTC.
+
+Watchlist sessions are initially created without a strategy script. While their
+Runner is stopped, select the **Script** value in the dashboard row to assign or
+change a strategy. Script changes are blocked while the Runner is starting or
+running, and `Start` remains disabled until a script has been selected. Sessions
+on the same exchange, symbol, and timeframe share one market-data feed while
+still allowing separate strategies.
 
 ## Account Center
 

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -33,6 +33,7 @@ from calendar_store import CalendarEventStore, CalendarStoreError
 from data_integrity import DataIntegrityCancelled, inspect_data_integrity
 from registry import (
     HistoryNotReadyError,
+    RunnerActiveError,
     SessionExistsError,
     SessionLimitError,
     SessionNotFoundError,
@@ -351,6 +352,23 @@ def _resolve_script_path(spec: SessionSpec) -> Path:
     if script_path.suffix != ".py":
         raise ValueError("script must be a .py file")
     return script_path
+
+
+def _validate_script_name(raw: object) -> str:
+    value = str(raw or "").strip()
+    if not value:
+        raise ValueError("script_name is required")
+    scripts_dir = app_state.scripts_dir.resolve()
+    script_path = (scripts_dir / value).resolve()
+    try:
+        relative = script_path.relative_to(scripts_dir)
+    except ValueError as exc:
+        raise ValueError("script path must be inside scripts directory") from exc
+    if script_path.suffix != ".py" or not script_path.is_file():
+        raise ValueError(f"script not found: {value}")
+    if not _declares_strategy(script_path):
+        raise ValueError("script must declare script.strategy(...)")
+    return relative.as_posix()
 
 
 def _script_source_display_name(spec: SessionSpec, script_path: Path | None = None) -> str:
@@ -1618,6 +1636,30 @@ def build_control_router(
         except Exception as e:
             return JSONResponse({"error": f"failed to update history_since: {e}"}, status_code=500)
         return JSONResponse({"ok": True, "history_since": value})
+
+    @r.patch("/api/sessions/{session_id}/script")
+    async def update_session_script(
+        session_id: str,
+        payload: dict = Body(default_factory=dict),
+    ) -> JSONResponse:
+        try:
+            script_name = _validate_script_name(payload.get("script_name"))
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        try:
+            spec = await registry.update_script_name(session_id, script_name)
+        except SessionNotFoundError:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        except RunnerActiveError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
+        except SessionExistsError:
+            return JSONResponse(
+                {"error": "this script is already assigned to the same market session"},
+                status_code=409,
+            )
+        except Exception as exc:
+            return JSONResponse({"error": f"failed to update script: {exc}"}, status_code=500)
+        return JSONResponse({"ok": True, "id": spec.id, "script_name": spec.script_name})
 
     @r.get("/api/sessions/{session_id}/data-integrity")
     async def check_data_integrity(session_id: str) -> JSONResponse:

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, AsyncIterator, Dict, List, Optional
 
 from fastapi import APIRouter, Body, File, Request, UploadFile
-from fastapi.responses import JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, JSONResponse, Response, StreamingResponse
 from markdown_it import MarkdownIt
 
 from pynecore.cli.app import app_state
@@ -52,6 +52,7 @@ from manual_alerts import send_manual_alert_payload
 from ohlcv_io import make_ccxt_pro_client
 from ohlcv_paths import make_cache_path
 from update_service import UpdateService, UpdateServiceError
+from watchlist import WatchlistService
 
 # Cache of exchange -> ccxt markets so symbol validation hits the network at most
 # once per exchange for the hub's lifetime.
@@ -703,6 +704,7 @@ def build_control_router(
     account_data_service: AccountDataService,
     asset_portfolio_service: AssetPortfolioService,
     asset_transfer_service: AssetTransferService,
+    watchlist_service: WatchlistService,
     update_service: UpdateService,
 ) -> APIRouter:
     r = APIRouter()
@@ -736,6 +738,55 @@ def build_control_router(
         except UpdateServiceError as exc:
             return JSONResponse({"error": str(exc)}, status_code=exc.status_code)
         return JSONResponse(result, status_code=202)
+
+    @r.get("/api/watchlist/favorites")
+    async def get_watchlist_favorites() -> JSONResponse:
+        result = await asyncio.to_thread(watchlist_service.favorites_payload)
+        return JSONResponse(result)
+
+    @r.get("/api/watchlist/logos/{cmc_id}.png")
+    async def get_watchlist_logo(cmc_id: int) -> Response:
+        try:
+            path = await watchlist_service.logo_path(cmc_id)
+        except Exception:
+            return Response(status_code=404)
+        return FileResponse(
+            path,
+            media_type="image/png",
+            headers={
+                "Cache-Control": "public, max-age=2592000",
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+
+    @r.put("/api/watchlist/favorites")
+    async def set_watchlist_favorite(
+        payload: dict = Body(default_factory=dict),
+    ) -> JSONResponse:
+        exchange = payload.get("exchange")
+        symbol = payload.get("symbol")
+        favorite = payload.get("favorite")
+        if not isinstance(exchange, str) or not isinstance(symbol, str):
+            return JSONResponse(
+                {"error": "exchange and symbol must be strings"},
+                status_code=400,
+            )
+        if not isinstance(favorite, bool):
+            return JSONResponse(
+                {"error": "favorite must be a boolean"},
+                status_code=400,
+            )
+        try:
+            result = await asyncio.to_thread(
+                watchlist_service.set_favorite,
+                exchange,
+                symbol,
+                favorite,
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        await watchlist_service.broadcast_favorites(result)
+        return JSONResponse(result)
 
     @r.get("/api/assets")
     @r.get("/api/account/assets")

--- a/data_service/cmc_logos.py
+++ b/data_service/cmc_logos.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+
+CMC_DATA_API_URL = (
+    "https://api.coinmarketcap.com/data-api/v3/exchange/market-pairs/latest"
+)
+CMC_LOGO_URL_TEMPLATE = (
+    "https://s2.coinmarketcap.com/static/img/coins/64x64/{cmc_id}.png"
+)
+CMC_EXCHANGE_SLUGS = {
+    "binance": "binance",
+    "bitget": "bitget",
+    "bybit": "bybit",
+    "okx": "okx",
+    "hyperliquid": "hyperliquid",
+}
+CATALOG_TTL_SECONDS = 24 * 60 * 60
+CATALOG_CHECK_SECONDS = 30 * 60
+MAX_LOGO_BYTES = 2 * 1024 * 1024
+_PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+_COMMODITY_SYMBOLS = {
+    "BRENT", "BZ", "CL", "COPPER", "GOLD", "NATGAS", "OIL",
+    "PALLADIUM", "PLATINUM", "SILVER", "WTI", "XAG", "XAU", "XPD", "XPT",
+}
+_COMMODITY_TERMS = (
+    "brent oil",
+    "copper",
+    "crude oil",
+    "gold",
+    "natural gas",
+    "palladium",
+    "platinum",
+    "silver",
+)
+_ETF_SYMBOLS = {
+    "BITO", "CSOPSAMSUNG2L", "CSOPSKHYNIX2L", "DIA", "DRAM", "EWT", "EWJ",
+    "EWY", "EWZ", "GDX", "IBIT", "IWM", "KODEX200", "KORU", "MUU", "MVLL",
+    "QQQ", "SMH", "SNXX", "SOXL", "SOXS", "SPY", "SQQQ", "TBT", "TMF",
+    "TQQQ", "TZA", "URNM", "UVXY", "XBI", "XLE",
+}
+_ETF_TERMS = (
+    " etf",
+    "exchange traded fund",
+    "leveraged product",
+    "proshares ultrapro",
+    "proshares ultrashort",
+)
+_INDEX_SYMBOLS = {
+    "DJI", "HK50", "JP225", "KR200", "NAS100", "NIKKEI", "SP500", "US100",
+    "US30", "US500",
+}
+_INDEX_TERMS = (
+    "dow jones index",
+    "hang seng index",
+    "index futures",
+    "korea 200 index",
+    "nasdaq 100 index",
+    "nikkei 225 index",
+    "s&p 500 index",
+)
+_FOREX_SYMBOLS = {
+    "AUD", "CAD", "CHF", "EUR", "GBP", "JPY", "KRW", "MXN", "NZD",
+}
+
+
+def _classify_asset(base_symbol: str, name: str, slug: str) -> str:
+    symbol = base_symbol.strip().upper()
+    normalized_name = " ".join(name.strip().lower().split())
+    normalized_slug = slug.strip().lower()
+    if symbol in _COMMODITY_SYMBOLS or any(
+        term in normalized_name for term in _COMMODITY_TERMS
+    ):
+        return "commodities"
+    if symbol in _ETF_SYMBOLS or any(term in normalized_name for term in _ETF_TERMS):
+        return "etfs"
+    if symbol in _INDEX_SYMBOLS or any(term in normalized_name for term in _INDEX_TERMS):
+        return "other"
+    if symbol in _FOREX_SYMBOLS:
+        return "other"
+    if normalized_name.endswith("(derivatives)") or normalized_slug.endswith("-derivatives"):
+        return "stocks"
+    return "crypto"
+
+
+class CmcLogoCatalog:
+    def __init__(self, path: Path) -> None:
+        self.path = path.resolve()
+        self._lock = threading.Lock()
+        self._symbols: dict[str, dict[str, int]] = {}
+        self._asset_classes: dict[str, dict[str, str]] = {}
+        self._updated_at: dict[str, float] = {}
+        self._load()
+
+    def _load(self) -> None:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return
+        exchanges = payload.get("exchanges") if isinstance(payload, dict) else None
+        if not isinstance(exchanges, dict):
+            return
+        for exchange_id in CMC_EXCHANGE_SLUGS:
+            item = exchanges.get(exchange_id)
+            if not isinstance(item, dict):
+                continue
+            raw_symbols = item.get("symbols")
+            if not isinstance(raw_symbols, dict):
+                continue
+            symbols: dict[str, int] = {}
+            for symbol, value in raw_symbols.items():
+                try:
+                    cmc_id = int(value)
+                except (TypeError, ValueError):
+                    continue
+                normalized = str(symbol).strip().upper()
+                if normalized and cmc_id > 0:
+                    symbols[normalized] = cmc_id
+            if symbols:
+                self._symbols[exchange_id] = symbols
+                raw_asset_classes = item.get("asset_classes")
+                if isinstance(raw_asset_classes, dict):
+                    asset_classes = {
+                        str(symbol).strip().upper(): str(asset_class).strip().lower()
+                        for symbol, asset_class in raw_asset_classes.items()
+                        if str(asset_class).strip().lower()
+                        in {"stocks", "etfs", "commodities", "other"}
+                    }
+                    self._asset_classes[exchange_id] = asset_classes
+                try:
+                    self._updated_at[exchange_id] = float(item.get("updated_at") or 0)
+                except (TypeError, ValueError):
+                    self._updated_at[exchange_id] = 0.0
+
+    @staticmethod
+    def _fetch_exchange(slug: str) -> tuple[dict[str, int], dict[str, str]]:
+        start = 1
+        limit = 1000
+        rows: list[dict[str, Any]] = []
+        total = 0
+        with httpx.Client(
+            timeout=20.0,
+            follow_redirects=True,
+            headers={
+                "Accept": "application/json",
+                "User-Agent": "PyneReal/Watchlist",
+            },
+        ) as client:
+            while True:
+                response = client.get(CMC_DATA_API_URL, params={
+                    "slug": slug,
+                    "start": start,
+                    "limit": limit,
+                    "category": "perpetual",
+                    "centerType": "all",
+                    "sort": "cmc_rank_advanced",
+                })
+                response.raise_for_status()
+                payload = response.json()
+                data = payload.get("data") if isinstance(payload, dict) else None
+                page = data.get("marketPairs") if isinstance(data, dict) else None
+                if not isinstance(page, list):
+                    raise RuntimeError(f"invalid CoinMarketCap response for {slug}")
+                rows.extend(item for item in page if isinstance(item, dict))
+                try:
+                    total = int(data.get("numMarketPairs") or len(rows))
+                except (TypeError, ValueError):
+                    total = len(rows)
+                if not page or len(rows) >= total:
+                    break
+                start += len(page)
+
+        symbols: dict[str, int] = {}
+        asset_classes: dict[str, str] = {}
+        ambiguous: set[str] = set()
+        for row in rows:
+            symbol = str(row.get("baseSymbol") or "").strip().upper()
+            try:
+                cmc_id = int(row.get("baseCurrencyId"))
+            except (TypeError, ValueError):
+                continue
+            if not symbol or cmc_id <= 0 or symbol in ambiguous:
+                continue
+            previous = symbols.get(symbol)
+            if previous is not None and previous != cmc_id:
+                symbols.pop(symbol, None)
+                asset_classes.pop(symbol, None)
+                ambiguous.add(symbol)
+                continue
+            symbols[symbol] = cmc_id
+            asset_class = _classify_asset(
+                symbol,
+                str(row.get("baseCurrencyName") or ""),
+                str(row.get("baseCurrencySlug") or ""),
+            )
+            if asset_class != "crypto":
+                asset_classes[symbol] = asset_class
+        if not symbols:
+            raise RuntimeError(f"empty CoinMarketCap catalog for {slug}")
+        return symbols, asset_classes
+
+    def refresh_if_stale(self) -> list[str]:
+        with self._lock:
+            now = time.time()
+            stale = [
+                exchange_id
+                for exchange_id in CMC_EXCHANGE_SLUGS
+                if (
+                    now - self._updated_at.get(exchange_id, 0.0) >= CATALOG_TTL_SECONDS
+                    or exchange_id not in self._asset_classes
+                )
+            ]
+            if not stale:
+                return []
+            refreshed: dict[str, tuple[dict[str, int], dict[str, str]]] = {}
+            failures: list[str] = []
+            with ThreadPoolExecutor(
+                max_workers=min(3, len(stale)),
+                thread_name_prefix="cmc-logo",
+            ) as executor:
+                futures = {
+                    executor.submit(
+                        self._fetch_exchange,
+                        CMC_EXCHANGE_SLUGS[exchange_id],
+                    ): exchange_id
+                    for exchange_id in stale
+                }
+                for future in as_completed(futures):
+                    exchange_id = futures[future]
+                    try:
+                        refreshed[exchange_id] = future.result()
+                    except Exception as exc:
+                        failures.append(
+                            f"{exchange_id}: {type(exc).__name__}: {exc}"
+                        )
+            if refreshed:
+                refreshed_at = time.time()
+                for exchange_id, (symbols, asset_classes) in refreshed.items():
+                    self._symbols[exchange_id] = symbols
+                    self._asset_classes[exchange_id] = asset_classes
+                    self._updated_at[exchange_id] = refreshed_at
+                self._write()
+            return failures
+
+    def _write(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": "1.0",
+            "exchanges": {
+                exchange_id: {
+                    "updated_at": self._updated_at.get(exchange_id, 0.0),
+                    "symbols": self._symbols.get(exchange_id, {}),
+                    "asset_classes": self._asset_classes.get(exchange_id, {}),
+                }
+                for exchange_id in CMC_EXCHANGE_SLUGS
+                if self._symbols.get(exchange_id)
+            },
+        }
+        temporary = self.path.with_suffix(self.path.suffix + ".tmp")
+        temporary.write_text(
+            json.dumps(payload, ensure_ascii=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        temporary.replace(self.path)
+
+    @staticmethod
+    def _symbol_candidates(exchange_id: str, base: str) -> tuple[str, ...]:
+        normalized = base.strip().upper()
+        candidates = [normalized] if normalized else []
+        if exchange_id == "hyperliquid":
+            for separator in (":", "-"):
+                if separator in normalized:
+                    candidate = normalized.rsplit(separator, 1)[-1].strip()
+                    if candidate and candidate not in candidates:
+                        candidates.append(candidate)
+        return tuple(candidates)
+
+    def resolve_id(self, exchange_id: str, base: str) -> int | None:
+        exchange_id = exchange_id.strip().lower()
+        with self._lock:
+            sources = [self._symbols.get("binance", {})]
+            if exchange_id != "binance":
+                sources.append(self._symbols.get(exchange_id, {}))
+            for candidate in self._symbol_candidates(exchange_id, base):
+                for symbols in sources:
+                    cmc_id = symbols.get(candidate)
+                    if cmc_id is not None:
+                        return cmc_id
+        return None
+
+    def resolve_url(self, exchange_id: str, base: str) -> str:
+        cmc_id = self.resolve_id(exchange_id, base)
+        return f"/api/watchlist/logos/{cmc_id}.png" if cmc_id is not None else ""
+
+    def resolve_asset_class(self, exchange_id: str, base: str) -> str:
+        exchange_id = exchange_id.strip().lower()
+        with self._lock:
+            sources = [self._asset_classes.get(exchange_id, {})]
+            if exchange_id != "binance":
+                sources.append(self._asset_classes.get("binance", {}))
+            for candidate in self._symbol_candidates(exchange_id, base):
+                for asset_classes in sources:
+                    asset_class = asset_classes.get(candidate)
+                    if asset_class is not None:
+                        return asset_class
+        return "crypto"
+
+
+class CmcLogoImageCache:
+    def __init__(self, directory: Path, catalog_path: Path) -> None:
+        self.directory = directory.resolve()
+        self.catalog_path = catalog_path.resolve()
+        self._locks_guard = threading.Lock()
+        self._locks: dict[int, threading.Lock] = {}
+        self._catalog_mtime_ns = -1
+        self._allowed_ids: set[int] = set()
+
+    def _logo_lock(self, cmc_id: int) -> threading.Lock:
+        with self._locks_guard:
+            return self._locks.setdefault(cmc_id, threading.Lock())
+
+    def _is_allowed(self, cmc_id: int) -> bool:
+        try:
+            mtime_ns = self.catalog_path.stat().st_mtime_ns
+        except OSError:
+            return False
+        with self._locks_guard:
+            if mtime_ns != self._catalog_mtime_ns:
+                try:
+                    payload = json.loads(self.catalog_path.read_text(encoding="utf-8"))
+                except (OSError, json.JSONDecodeError):
+                    return False
+                exchanges = payload.get("exchanges") if isinstance(payload, dict) else None
+                allowed: set[int] = set()
+                for item in exchanges.values() if isinstance(exchanges, dict) else ():
+                    symbols = item.get("symbols") if isinstance(item, dict) else None
+                    for value in symbols.values() if isinstance(symbols, dict) else ():
+                        try:
+                            value = int(value)
+                        except (TypeError, ValueError):
+                            continue
+                        if value > 0:
+                            allowed.add(value)
+                self._allowed_ids = allowed
+                self._catalog_mtime_ns = mtime_ns
+            return cmc_id in self._allowed_ids
+
+    def get(self, cmc_id: int) -> Path:
+        if cmc_id <= 0 or cmc_id > 1_000_000_000:
+            raise ValueError("invalid CoinMarketCap logo id")
+        if not self._is_allowed(cmc_id):
+            raise ValueError("unknown CoinMarketCap logo id")
+        path = self.directory / f"{cmc_id}.png"
+        if path.is_file() and path.stat().st_size > 0:
+            return path
+        with self._logo_lock(cmc_id):
+            if path.is_file() and path.stat().st_size > 0:
+                return path
+            response = httpx.get(
+                CMC_LOGO_URL_TEMPLATE.format(cmc_id=cmc_id),
+                timeout=15.0,
+                follow_redirects=True,
+                headers={
+                    "Accept": "image/png,image/*;q=0.8",
+                    "User-Agent": "PyneReal/Watchlist",
+                },
+            )
+            response.raise_for_status()
+            content_type = str(response.headers.get("Content-Type") or "")
+            data = response.content
+            if (
+                not content_type.lower().startswith("image/")
+                or len(data) > MAX_LOGO_BYTES
+                or not data.startswith(_PNG_SIGNATURE)
+            ):
+                raise RuntimeError("invalid CoinMarketCap logo response")
+            self.directory.mkdir(parents=True, exist_ok=True)
+            temporary = path.with_name(f".{cmc_id}.{os.getpid()}.tmp")
+            temporary.write_bytes(data)
+            temporary.replace(path)
+            return path

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -26,6 +26,7 @@ from registry import SessionRegistry
 from api import build_session_api_router, build_control_router, build_validation_router
 from ui import build_ui_router
 from update_service import UpdateService
+from watchlist import WatchlistService
 
 _BANNER = r"""
     ____                   ____             __
@@ -44,6 +45,7 @@ def build_app(
     account_data_service: AccountDataService,
     asset_portfolio_service: AssetPortfolioService,
     asset_transfer_service: AssetTransferService,
+    watchlist_service: WatchlistService,
     update_service: UpdateService,
 ) -> FastAPI:
     app = FastAPI()
@@ -87,6 +89,7 @@ def build_app(
             account_data_service,
             asset_portfolio_service,
             asset_transfer_service,
+            watchlist_service,
             update_service,
         )
     )
@@ -121,6 +124,17 @@ def build_app(
             await account_data_service.disconnect_live(ws)
         except Exception:
             await account_data_service.disconnect_live(ws)
+
+    @app.websocket("/ws/watchlist")
+    async def watchlist_ws(ws: WebSocket):
+        await watchlist_service.connect_live(ws)
+        try:
+            while True:
+                await ws.receive_text()
+        except WebSocketDisconnect:
+            await watchlist_service.disconnect_live(ws)
+        except Exception:
+            await watchlist_service.disconnect_live(ws)
 
     @app.websocket("/ws/{session_id}")
     async def session_ws(ws: WebSocket, session_id: str):
@@ -203,6 +217,10 @@ async def main() -> None:
     asset_transfer_service = AssetTransferService(
         _PROJECT_ROOT / "workdir" / "config" / "providers.toml"
     )
+    watchlist_service = WatchlistService(
+        _PROJECT_ROOT / "workdir" / "config" / "watchlist_favorites.json",
+        _PROJECT_ROOT / "workdir" / "data" / "cache" / "watchlist_logos",
+    )
     codex_service = CodexService(
         project_root=_PROJECT_ROOT,
         session_registry=registry,
@@ -239,6 +257,7 @@ async def main() -> None:
         account_data_service,
         asset_portfolio_service,
         asset_transfer_service,
+        watchlist_service,
         update_service,
     )
 
@@ -294,7 +313,10 @@ async def main() -> None:
                 try:
                     await asset_portfolio_service.close()
                 finally:
-                    await codex_service.close()
+                    try:
+                        await watchlist_service.close()
+                    finally:
+                        await codex_service.close()
     if update_shutdown.is_set():
         update_service.apply_and_restart()
 

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -36,6 +36,10 @@ class SessionOrderError(Exception):
     pass
 
 
+class RunnerActiveError(Exception):
+    pass
+
+
 class SessionRegistry:
     """Owns Feeds (one per market, shared) and Sessions (one per strategy), their
     background tasks, the runner supervisor, and the dashboard (/ws/hub) push.
@@ -320,6 +324,40 @@ class SessionRegistry:
             raise
         await self.notify_hub()
         return self.snapshots()
+
+    async def update_script_name(self, session_id: str, script_name: str) -> SessionSpec:
+        session = self.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFoundError(session_id)
+        if self.supervisor.is_active(session_id) or session.runner_count > 0:
+            raise RunnerActiveError("stop the runner before changing its script")
+        if session.spec.script_name == script_name:
+            return session.spec
+
+        for other in self.sessions.values():
+            if other is session:
+                continue
+            if other.spec.feed_id == session.spec.feed_id and other.spec.script_name == script_name:
+                raise SessionExistsError(other.spec.id)
+
+        previous_spec = session.spec
+        next_spec = replace(previous_spec, script_name=script_name)
+        session.spec = next_spec
+        try:
+            self._persist()
+        except Exception:
+            session.spec = previous_spec
+            raise
+
+        session.reconfigure_script(next_spec)
+        for path in (session.paths.plot_path, session.paths.hash_path):
+            try:
+                path.unlink(missing_ok=True)
+            except OSError as exc:
+                print(f"[registry] failed to clear stale strategy output {path}: {exc}")
+        await session.send_to_charts({"type": "script_modified"})
+        await self.notify_hub()
+        return next_spec
 
     async def update_webhook(self, session_id: str, *, enabled: bool | None = None,
                              telegram_notification: bool | None = None,

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -303,6 +303,27 @@ class Session:
         self._manual_alert_trigger_gates: dict[str, dict[str, Any]] = {}
         self.reset_manual_alert_trigger_gate()
 
+    def reconfigure_script(self, spec: SessionSpec) -> None:
+        """Apply a stopped-session script change without replacing its identity."""
+        self.spec = spec
+        self.trades_history.clear()
+        self.plot_options.clear()
+        self.plotchar_history.clear()
+        self.runner_ready = False
+        self.history_resync_pending = False
+        self.calculation_generation_id = uuid.uuid4().hex
+        self.calculation_status = "stopped"
+        self.calculation_latest_confirmed_bar = None
+        self.calculated_through = None
+        self.calculation_updated_at = datetime.now(UTC).isoformat()
+        self.strategy_snapshot = None
+        self.strategy_snapshot_generation_id = None
+        self.chart_info["script_title"] = None
+        self.chart_info["script_source_name"] = None
+        self.chart_info["script_source"] = ""
+        self._processed_ai_instruction_ids.clear()
+        self._processed_ai_instruction_order.clear()
+
     @property
     def ohlcv_path(self) -> Path:
         return self.feed.paths.ohlcv_path

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -596,6 +596,17 @@ body {
   font-size: 12px;
   line-height: 1;
 }
+.script-select-toggle-chevron {
+  flex: 0 0 auto;
+  width: 0;
+  height: 0;
+  border-top: 4px solid transparent;
+  border-bottom: 4px solid transparent;
+  border-left: 5px solid var(--muted);
+  transform-origin: 40% 50%;
+  transition: transform 220ms cubic-bezier(0.22, 0.75, 0.25, 1);
+}
+.script-select-animated.open .script-select-toggle-chevron { transform: rotate(90deg); }
 .script-select-options {
   position: absolute;
   top: calc(100% + 4px);
@@ -614,6 +625,43 @@ body {
 }
 .script-select-options.hidden {
   display: none;
+}
+.script-select.script-select-animated .script-select-options,
+.script-select.script-select-animated .script-select-options.hidden {
+  display: block;
+  max-height: 0;
+  overflow: hidden;
+  padding-top: 0;
+  padding-bottom: 0;
+  border-color: transparent;
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+  transform: translateY(-5px);
+  transition:
+    max-height 240ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    padding 240ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    opacity 170ms ease,
+    transform 240ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    visibility 0s linear 240ms,
+    border-color 0s linear 240ms;
+}
+.script-select.script-select-animated.open .script-select-options {
+  overflow-y: auto;
+  padding-top: 4px;
+  padding-bottom: 4px;
+  border-color: var(--border);
+  opacity: 1;
+  visibility: visible;
+  pointer-events: auto;
+  transform: translateY(0);
+  transition:
+    max-height 240ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    padding 240ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    opacity 170ms ease 30ms,
+    transform 240ms cubic-bezier(0.22, 0.75, 0.25, 1),
+    visibility 0s,
+    border-color 0s;
 }
 .script-select-options::-webkit-scrollbar {
   width: 10px;
@@ -1182,12 +1230,31 @@ tr:last-child td { border-bottom: none; }
   gap: 5px;
   min-width: 0;
 }
-.watchlist-market-name strong {
+.watchlist-symbol-button {
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px dashed #8b949e;
+  background: transparent;
   overflow: hidden;
   color: #f2f5f8;
+  font: inherit;
   font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-align: left;
   text-overflow: ellipsis;
   white-space: nowrap;
+  cursor: pointer;
+}
+.watchlist-symbol-button:hover {
+  color: #79c0ff;
+  border-bottom-color: currentColor;
+}
+.watchlist-symbol-button:focus-visible {
+  border-radius: 3px;
+  outline: 2px solid #4b87c5;
+  outline-offset: 2px;
 }
 .watchlist-market-name span {
   flex: none;
@@ -1302,10 +1369,260 @@ tr:last-child td { border-bottom: none; }
   .watchlist-row { padding: 0 8px; }
   .watchlist-exchange-logo { width: 22px; height: 22px; }
   .watchlist-market { gap: 7px; }
-  .watchlist-market-name strong { font-size: 11px; }
+  .watchlist-symbol-button { font-size: 11px; }
   .watchlist-number { font-size: 11px; }
   .watchlist-exchange-errors { margin: 7px 2px 0; }
 }
+.watchlist-add-modal { z-index: 90; }
+.watchlist-add-modal button { touch-action: manipulation; }
+.watchlist-add-modal-box { overflow: visible; }
+.watchlist-add-form {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px;
+}
+.watchlist-add-market {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+}
+.watchlist-add-logo {
+  flex: none;
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  background: #fff;
+  object-fit: contain;
+}
+.watchlist-add-market > div {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.watchlist-add-market strong {
+  overflow: hidden;
+  color: #f2f5f8;
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.watchlist-add-market span {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+}
+.watchlist-add-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 11px;
+}
+.watchlist-add-field small {
+  color: #697482;
+  font-size: 9px;
+  font-weight: 500;
+}
+.watchlist-add-field input,
+.watchlist-add-date-button {
+  width: 100%;
+  height: 38px;
+  padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 13px;
+  letter-spacing: 0;
+  color-scheme: dark;
+}
+.watchlist-add-field input:focus,
+.watchlist-add-date-button:focus-visible {
+  border-color: #4b87c5;
+  outline: none;
+}
+.watchlist-add-history-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 82px;
+  gap: 10px;
+  align-items: end;
+}
+.watchlist-add-date-picker { position: relative; }
+.watchlist-add-date-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  text-align: left;
+  cursor: pointer;
+}
+.watchlist-add-date-button .icon {
+  flex: none;
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: #8b949e;
+  stroke-width: 1.7;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.watchlist-add-calendar {
+  position: absolute;
+  z-index: 30;
+  top: calc(100% + 6px);
+  left: 0;
+  width: 100%;
+  padding: 10px;
+  border: 1px solid #303843;
+  border-radius: 6px;
+  background: #151b23;
+  box-shadow: 0 14px 34px rgb(0 0 0 / 45%);
+}
+.watchlist-add-calendar.above {
+  top: auto;
+  bottom: calc(100% + 6px);
+}
+.watchlist-add-calendar-toolbar {
+  display: grid;
+  grid-template-columns: 30px 1fr 30px;
+  align-items: center;
+  margin-bottom: 8px;
+}
+.watchlist-add-calendar-toolbar strong {
+  font-size: 12px;
+  font-weight: 600;
+  text-align: center;
+}
+.watchlist-add-calendar-toolbar .btn-icon {
+  width: 28px;
+  height: 28px;
+  font-size: 20px;
+  line-height: 1;
+}
+.watchlist-add-calendar-weekdays,
+.watchlist-add-calendar-days {
+  display: grid;
+  grid-template-columns: repeat(7, 1fr);
+}
+.watchlist-add-calendar-days {
+  overflow: hidden;
+  touch-action: pan-y;
+}
+.watchlist-add-calendar-days.month-prev {
+  animation: watchlist-calendar-prev 340ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+.watchlist-add-calendar-days.month-next {
+  animation: watchlist-calendar-next 340ms cubic-bezier(0.16, 1, 0.3, 1);
+}
+@keyframes watchlist-calendar-prev {
+  from { opacity: 0.65; transform: translateX(-14px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+@keyframes watchlist-calendar-next {
+  from { opacity: 0.65; transform: translateX(14px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+.watchlist-add-calendar-weekdays span {
+  padding: 4px 0 6px;
+  color: #727e8c;
+  font-size: 9px;
+  text-align: center;
+}
+.watchlist-add-calendar-day {
+  aspect-ratio: 1;
+  min-width: 0;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: #c9d1d9;
+  font: inherit;
+  font-size: 11px;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+.watchlist-add-calendar-day:hover:not(:disabled) { background: #222a35; }
+.watchlist-add-calendar-day.outside { color: #5d6875; }
+.watchlist-add-calendar-day.today { box-shadow: inset 0 0 0 1px #4b87c5; }
+.watchlist-add-calendar-day.selected {
+  background: #2463a7;
+  color: #fff;
+  font-weight: 600;
+}
+.watchlist-add-calendar-day:disabled {
+  color: #3f4853;
+  cursor: default;
+}
+.watchlist-add-select { width: 100%; min-width: 0; flex: none; }
+.watchlist-add-select .script-select-button { height: 38px; }
+.watchlist-add-form .error:empty { display: none; }
+.script-change-modal { z-index: 90; }
+.script-change-modal-box { overflow: visible; }
+.script-change-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 14px;
+}
+.script-change-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--muted);
+  font-size: 11px;
+}
+.script-change-select { width: 100%; min-width: 0; flex: none; }
+.script-change-select .script-select-button { height: 38px; }
+.script-change-body .error:empty { display: none; }
+.session-script-button {
+  min-width: 0;
+  max-width: 100%;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 2px 3px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  letter-spacing: 0;
+  text-align: left;
+}
+.session-script-button:not(:disabled) { cursor: pointer; }
+.session-script-button:not(:disabled):hover,
+.session-script-button:not(:disabled):focus-visible {
+  background: #1b222b;
+  color: #f2f5f8;
+  outline: none;
+}
+.session-script-button.empty:not(:disabled) { color: #79c0ff; }
+.session-script-button:disabled { cursor: default; opacity: 1; }
+.session-script-label {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.session-script-edit-icon {
+  flex: none;
+  width: 12px;
+  height: 12px;
+  transform: translateY(2px);
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+.session-script-button:disabled .session-script-edit-icon { display: none; }
 .calendar-toolbar {
   position: relative;
   min-height: 34px;
@@ -4557,9 +4874,44 @@ tr:last-child td { border-bottom: none; }
   .watchlist-row { padding: 0 8px; }
   .watchlist-exchange-logo { width: 22px; height: 22px; }
   .watchlist-market { gap: 7px; }
-  .watchlist-market-name strong { font-size: 11px; }
+  .watchlist-symbol-button { font-size: 11px; }
   .watchlist-number { font-size: 11px; }
   .watchlist-exchange-errors { margin: 7px 2px 0; }
+  .watchlist-add-modal { padding: 12px; }
+  .watchlist-add-modal-box {
+    width: 100%;
+    max-height: calc(100dvh - 24px);
+  }
+  .watchlist-add-history-row {
+    grid-template-columns: minmax(0, 1fr) 72px;
+    gap: 8px;
+  }
+  .watchlist-add-calendar { padding: 7px; }
+  .watchlist-add-calendar-toolbar {
+    grid-template-columns: 25px 1fr 25px;
+    margin-bottom: 3px;
+  }
+  .watchlist-add-calendar-toolbar .btn-icon {
+    width: 24px;
+    height: 24px;
+    font-size: 18px;
+    -webkit-user-select: none;
+    user-select: none;
+  }
+  .watchlist-add-calendar-toolbar strong { font-size: 11px; }
+  .watchlist-add-calendar-weekdays span {
+    padding: 2px 0 3px;
+    font-size: 8px;
+  }
+  .watchlist-add-calendar-day { font-size: 10px; }
+  #watchlist-add-timeframe-button,
+  .watchlist-add-date-button,
+  .watchlist-add-time-field input {
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 400;
+  }
+  .watchlist-add-select .script-select-option { min-height: 38px; font-size: 14px; }
   .assets-modal { padding: 0; }
   .assets-modal-box {
     position: relative;

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -944,6 +944,368 @@ tr:last-child td { border-bottom: none; }
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 }
+
+/* ---- futures watchlist ---- */
+.watchlist-modal { z-index: 80; }
+.watchlist-modal-box {
+  width: min(940px, 100%);
+  height: min(720px, calc(100vh - 32px));
+  max-height: calc(100vh - 32px);
+}
+.watchlist-modal-header { min-height: 50px; }
+.watchlist-title-group {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.watchlist-title-group > span:first-child {
+  color: #f2f5f8;
+  font-size: 14px;
+  font-weight: 600;
+}
+.watchlist-live-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  color: var(--muted);
+  font-size: 10px;
+  font-weight: 500;
+}
+.watchlist-live-status::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #6e7681;
+}
+.watchlist-live-status.live { color: #7ee787; }
+.watchlist-live-status.live::before { background: #3fb950; }
+.watchlist-live-status.error { color: #ff9a92; }
+.watchlist-live-status.error::before { background: #f85149; }
+.watchlist-modal button { touch-action: manipulation; }
+.watchlist-body {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 14px;
+  overflow: hidden;
+}
+.watchlist-toolbar {
+  flex: none;
+  display: grid;
+  grid-template-columns: minmax(190px, 1fr) auto;
+  gap: 9px 12px;
+  align-items: center;
+  margin-bottom: 10px;
+}
+.watchlist-search {
+  grid-row: 1 / span 2;
+  position: relative;
+  display: flex;
+  align-items: center;
+}
+.watchlist-search svg {
+  position: absolute;
+  left: 10px;
+  width: 16px;
+  height: 16px;
+  fill: none;
+  stroke: var(--muted);
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  pointer-events: none;
+}
+.watchlist-search input {
+  width: 100%;
+  height: 38px;
+  padding: 0 12px 0 34px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--text);
+  font: inherit;
+  font-size: 12px;
+  letter-spacing: 0;
+}
+.watchlist-search input:focus {
+  border-color: #4b87c5;
+  outline: none;
+}
+.watchlist-filter-row {
+  min-width: 0;
+  display: flex;
+  justify-content: flex-end;
+  gap: 3px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.watchlist-filter-row::-webkit-scrollbar { display: none; }
+.watchlist-filter {
+  flex: none;
+  min-height: 28px;
+  padding: 4px 9px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 11px;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+.watchlist-filter:hover { color: #f2f5f8; background: #1b222b; }
+.watchlist-filter.active { color: #f2f5f8; background: #29313c; }
+.watchlist-meta {
+  flex: none;
+  min-height: 25px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 0 3px 7px;
+  color: var(--muted);
+  font-size: 10px;
+}
+.watchlist-list-shell {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #0f141a;
+}
+.watchlist-list-header,
+.watchlist-row {
+  display: grid;
+  grid-template-columns: 36px minmax(210px, 1fr) minmax(105px, 150px) minmax(84px, 112px);
+  align-items: center;
+}
+.watchlist-list-header {
+  flex: none;
+  min-height: 34px;
+  padding: 0 12px;
+  border-bottom: 1px solid var(--border);
+  background: #161b22;
+}
+.watchlist-list-header button {
+  min-width: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 10px;
+  letter-spacing: 0;
+  text-align: right;
+  cursor: pointer;
+}
+.watchlist-list-header button[data-watchlist-sort="turnover_24h"] { text-align: left; }
+.watchlist-list-header button.active { color: #dce3eb; }
+.watchlist-list-header button.active::after {
+  content: "\2191";
+  display: inline-block;
+  margin-left: 4px;
+  font-size: 9px;
+}
+.watchlist-list-header button.active.desc::after { content: "\2193"; }
+.watchlist-list {
+  --watchlist-row-height: 57px;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: #3a4350 #0b0e13;
+  scrollbar-width: thin;
+}
+.watchlist-spacer {
+  width: 100%;
+  min-height: 0;
+  pointer-events: none;
+}
+@media (hover: hover) and (pointer: fine) {
+  .watchlist-list::-webkit-scrollbar { width: 9px; }
+  .watchlist-list::-webkit-scrollbar-track { background: #0b0e13; }
+  .watchlist-list::-webkit-scrollbar-thumb {
+    border: 2px solid #0b0e13;
+    border-radius: 999px;
+    background: #3a4350;
+  }
+}
+.watchlist-row {
+  height: var(--watchlist-row-height);
+  min-height: var(--watchlist-row-height);
+  padding: 0 12px;
+  border-bottom: 1px solid #1d242d;
+  content-visibility: auto;
+  contain-intrinsic-size: 57px;
+  font-variant-numeric: tabular-nums;
+}
+.watchlist-row:last-child { border-bottom: 0; }
+@media (hover: hover) and (pointer: fine) {
+  .watchlist-row:hover { background: #151c24; }
+}
+.watchlist-favorite {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: #596372;
+  font-size: 18px;
+  line-height: 1;
+  cursor: pointer;
+}
+.watchlist-favorite:hover { color: #d7a928; }
+.watchlist-favorite.active { color: #f2cc60; }
+.watchlist-market {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.watchlist-exchange-logo {
+  flex: none;
+  width: 25px;
+  height: 25px;
+  object-fit: contain;
+  border-radius: 50%;
+  background: #ffffff;
+}
+.watchlist-market-text { min-width: 0; }
+.watchlist-market-name {
+  display: flex;
+  align-items: baseline;
+  gap: 5px;
+  min-width: 0;
+}
+.watchlist-market-name strong {
+  overflow: hidden;
+  color: #f2f5f8;
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.watchlist-market-name span {
+  flex: none;
+  color: var(--muted);
+  font-size: 9px;
+  text-transform: uppercase;
+}
+.watchlist-market-meta {
+  display: block;
+  margin-top: 3px;
+  overflow: hidden;
+  color: #7d8896;
+  font-size: 9px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.watchlist-number {
+  min-width: 0;
+  color: #dce3eb;
+  font-size: 12px;
+  text-align: right;
+  white-space: nowrap;
+}
+.watchlist-change.positive { color: #3fb950; }
+.watchlist-change.negative { color: #ff7b72; }
+.watchlist-state {
+  flex: 1;
+  min-height: 120px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 9px;
+  padding: 20px;
+  color: var(--muted);
+  font-size: 12px;
+  text-align: center;
+}
+.watchlist-state-error { color: #ff9a92; }
+.watchlist-exchange-errors {
+  flex: none;
+  margin-top: 8px;
+  overflow: hidden;
+  color: #d29922;
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+@media (min-width: 721px) {
+  .watchlist-modal {
+    align-items: stretch;
+    justify-content: flex-end;
+    padding: 0;
+  }
+  .watchlist-modal-box {
+    width: min(440px, 100vw);
+    height: 100vh;
+    max-height: none;
+    border-width: 0 0 0 1px;
+    border-radius: 0;
+  }
+  .watchlist-modal.watchlist-opening {
+    animation: calendar-backdrop-in 220ms ease-out;
+  }
+  .watchlist-modal.watchlist-opening .watchlist-modal-box {
+    animation: watchlist-drawer-in 220ms cubic-bezier(0.22, 0.75, 0.25, 1);
+  }
+  .watchlist-modal.watchlist-closing {
+    animation: calendar-backdrop-out 220ms ease-in forwards;
+  }
+  .watchlist-modal.watchlist-closing .watchlist-modal-box {
+    animation: watchlist-drawer-out 220ms cubic-bezier(0.55, 0, 1, 0.45) forwards;
+  }
+  .watchlist-body { padding: 10px; }
+  .watchlist-toolbar {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 7px;
+    margin-bottom: 8px;
+  }
+  .watchlist-search {
+    flex: none;
+    grid-row: auto;
+  }
+  .watchlist-search input { height: 36px; }
+  .watchlist-filter-row {
+    justify-content: flex-start;
+    margin: 0 -2px;
+    padding: 0 2px;
+  }
+  .watchlist-market-filters {
+    border-top: 1px solid #1d242d;
+    padding-top: 5px;
+  }
+  .watchlist-filter {
+    min-height: 30px;
+    padding: 5px 9px;
+  }
+  .watchlist-meta {
+    min-height: 23px;
+    padding-bottom: 6px;
+  }
+  .watchlist-list-header,
+  .watchlist-row {
+    grid-template-columns: 31px minmax(118px, 1fr) minmax(82px, 0.72fr) 69px;
+  }
+  .watchlist-list-header {
+    min-height: 32px;
+    padding: 0 8px;
+  }
+  .watchlist-list { --watchlist-row-height: 59px; }
+  .watchlist-row { padding: 0 8px; }
+  .watchlist-exchange-logo { width: 22px; height: 22px; }
+  .watchlist-market { gap: 7px; }
+  .watchlist-market-name strong { font-size: 11px; }
+  .watchlist-number { font-size: 11px; }
+  .watchlist-exchange-errors { margin: 7px 2px 0; }
+}
 .calendar-toolbar {
   position: relative;
   min-height: 34px;
@@ -4121,6 +4483,83 @@ tr:last-child td { border-bottom: none; }
     right: 44px;
     width: calc(100% - 62px);
   }
+  .watchlist-modal { padding: 0; }
+  .watchlist-modal-box {
+    position: relative;
+    width: 100%;
+    height: 100dvh;
+    max-height: none;
+    border: 0;
+    border-radius: 0;
+  }
+  .watchlist-modal.watchlist-opening {
+    animation: calendar-backdrop-in 220ms ease-out;
+  }
+  .watchlist-modal.watchlist-opening .watchlist-modal-box {
+    animation: calendar-sheet-in 220ms cubic-bezier(0.22, 0.75, 0.25, 1);
+  }
+  .watchlist-modal.watchlist-dragging .watchlist-modal-box {
+    animation: none;
+    transition: none;
+  }
+  .watchlist-modal.watchlist-closing {
+    animation: calendar-backdrop-out 220ms ease-in forwards;
+  }
+  .watchlist-modal.watchlist-closing .watchlist-modal-box {
+    animation: calendar-sheet-out 220ms cubic-bezier(0.55, 0, 1, 0.45) forwards;
+  }
+  .watchlist-modal.watchlist-closing.watchlist-swipe-closing .watchlist-modal-box {
+    animation: none;
+  }
+  .watchlist-modal-header {
+    position: relative;
+    padding-top: calc(18px + env(safe-area-inset-top));
+    touch-action: none;
+  }
+  .watchlist-modal-header::before {
+    content: "";
+    position: absolute;
+    top: calc(7px + env(safe-area-inset-top));
+    left: 50%;
+    width: 40px;
+    height: 4px;
+    margin-left: -20px;
+    border-radius: 999px;
+    background: var(--border);
+  }
+  .watchlist-body {
+    padding: 10px;
+    padding-bottom: calc(10px + env(safe-area-inset-bottom, 0px));
+  }
+  .watchlist-toolbar {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 7px;
+    margin-bottom: 8px;
+  }
+  .watchlist-search { flex: none; }
+  .watchlist-search input { height: 36px; font-size: 16px; }
+  .watchlist-filter-row {
+    justify-content: flex-start;
+    margin: 0 -2px;
+    padding: 0 2px;
+  }
+  .watchlist-market-filters { border-top: 1px solid #1d242d; padding-top: 5px; }
+  .watchlist-filter { min-height: 30px; padding: 5px 9px; }
+  .watchlist-meta { min-height: 23px; padding-bottom: 6px; }
+  .watchlist-list-header,
+  .watchlist-row {
+    grid-template-columns: 31px minmax(118px, 1fr) minmax(82px, 0.72fr) 69px;
+  }
+  .watchlist-list-header { min-height: 32px; padding: 0 8px; }
+  .watchlist-list { --watchlist-row-height: 59px; }
+  .watchlist-row { padding: 0 8px; }
+  .watchlist-exchange-logo { width: 22px; height: 22px; }
+  .watchlist-market { gap: 7px; }
+  .watchlist-market-name strong { font-size: 11px; }
+  .watchlist-number { font-size: 11px; }
+  .watchlist-exchange-errors { margin: 7px 2px 0; }
   .assets-modal { padding: 0; }
   .assets-modal-box {
     position: relative;
@@ -4695,4 +5134,12 @@ tr:last-child td { border-bottom: none; }
 @keyframes calendar-backdrop-out {
   from { background: rgba(0, 0, 0, 0.6); }
   to { background: rgba(0, 0, 0, 0); }
+}
+@keyframes watchlist-drawer-in {
+  from { transform: translateX(100%); }
+  to { transform: translateX(0); }
+}
+@keyframes watchlist-drawer-out {
+  from { transform: translateX(0); }
+  to { transform: translateX(100%); }
 }

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=121" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=124" />
 </head>
 <body>
   <header class="topbar">
@@ -107,6 +107,17 @@
         </span>
         <span>Calendar</span>
       </button>
+      <button id="hub-watchlist-open" class="hub-menu-item" type="button">
+        <span class="hub-menu-emoji" aria-hidden="true">
+          <svg class="hub-menu-glyph" viewBox="0 0 24 24" aria-hidden="true">
+            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+            <polyline points="14 2 14 8 20 8" />
+            <line x1="8" y1="13" x2="16" y2="13" />
+            <line x1="8" y1="17" x2="16" y2="17" />
+          </svg>
+        </span>
+        <span>Watchlist</span>
+      </button>
     </nav>
     <div class="hub-menu-footer">
       <div id="hub-update-message" class="hub-update-message" aria-live="polite"></div>
@@ -187,6 +198,67 @@
     </table>
     <div id="empty" class="muted">No sessions yet. Add one above.</div>
   </section>
+
+  <div id="watchlist-modal" class="modal watchlist-modal hidden" aria-hidden="true">
+    <div class="modal-box watchlist-modal-box" role="dialog" aria-modal="true" aria-labelledby="watchlist-title">
+      <div class="modal-header watchlist-modal-header">
+        <div class="watchlist-title-group">
+          <span id="watchlist-title">Futures Watchlist</span>
+          <span id="watchlist-live-status" class="watchlist-live-status">Offline</span>
+        </div>
+        <button id="watchlist-close" class="btn btn-icon" type="button" title="Close" aria-label="Close">&times;</button>
+      </div>
+      <div class="watchlist-body">
+        <div class="watchlist-toolbar">
+          <label class="watchlist-search">
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <circle cx="11" cy="11" r="7" />
+              <path d="m20 20-4-4" />
+            </svg>
+            <input id="watchlist-search" type="search" autocomplete="off"
+                   placeholder="Search futures" aria-label="Search futures" />
+          </label>
+          <div id="watchlist-exchange-filters" class="watchlist-filter-row" aria-label="Exchange filter">
+            <button class="watchlist-filter active" type="button" data-watchlist-exchange="all">All</button>
+            <button class="watchlist-filter" type="button" data-watchlist-exchange="binance">Binance</button>
+            <button class="watchlist-filter" type="button" data-watchlist-exchange="bitget">Bitget</button>
+            <button class="watchlist-filter" type="button" data-watchlist-exchange="bybit">Bybit</button>
+            <button class="watchlist-filter" type="button" data-watchlist-exchange="okx">OKX</button>
+            <button class="watchlist-filter" type="button" data-watchlist-exchange="hyperliquid">Hyperliquid</button>
+          </div>
+          <div id="watchlist-market-filters" class="watchlist-filter-row watchlist-market-filters" aria-label="Market filter">
+            <button class="watchlist-filter active" type="button" data-watchlist-market="all">All</button>
+            <button class="watchlist-filter" type="button" data-watchlist-market="favorites">Favorites</button>
+            <button class="watchlist-filter" type="button" data-watchlist-market="stocks">Stocks</button>
+            <button class="watchlist-filter" type="button" data-watchlist-market="etfs">ETFs</button>
+            <button class="watchlist-filter" type="button" data-watchlist-market="commodities">Commodities</button>
+            <button class="watchlist-filter" type="button" data-watchlist-market="USDT">USDT</button>
+            <button class="watchlist-filter" type="button" data-watchlist-market="USDC">USDC</button>
+          </div>
+        </div>
+        <div class="watchlist-meta">
+          <span id="watchlist-count">0 markets</span>
+          <span id="watchlist-updated">Waiting for market data</span>
+        </div>
+        <div class="watchlist-list-shell">
+          <div class="watchlist-list-header" role="row">
+            <span aria-hidden="true"></span>
+            <button type="button" class="active desc" data-watchlist-sort="turnover_24h">Market / Turnover</button>
+            <button type="button" data-watchlist-sort="last">Last</button>
+            <button type="button" data-watchlist-sort="change_24h">24h</button>
+          </div>
+          <div id="watchlist-loading" class="watchlist-state">
+            <span class="assets-spinner" aria-hidden="true"></span>
+            <span>Loading futures markets...</span>
+          </div>
+          <div id="watchlist-error" class="watchlist-state watchlist-state-error hidden" role="alert"></div>
+          <div id="watchlist-empty" class="watchlist-state hidden">No matching futures markets.</div>
+          <div id="watchlist-list" class="watchlist-list" role="table" aria-label="Futures markets"></div>
+        </div>
+        <div id="watchlist-exchange-errors" class="watchlist-exchange-errors hidden"></div>
+      </div>
+    </div>
+  </div>
 
   <div id="calendar-modal" class="modal calendar-modal hidden" aria-hidden="true">
     <div class="modal-box calendar-modal-box" role="dialog" aria-modal="true" aria-labelledby="calendar-title">
@@ -802,6 +874,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=130"></script>
+  <script src="/static/dashboard.js?v=137"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=124" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=136" />
 </head>
 <body>
   <header class="topbar">
@@ -148,14 +148,14 @@
       <div class="field"><input name="history_since" placeholder="history_since (YYYY-MM-DD, optional)" /></div>
       <div class="field">
         <div class="script-row">
-          <div class="script-select" id="script-select-control">
+          <div class="script-select script-select-animated" id="script-select-control">
             <select name="script_name" id="script-select" class="script-native-select" tabindex="-1" aria-hidden="true">
               <option value="">script_name…</option>
             </select>
             <button type="button" id="script-select-button" class="script-select-button"
                     aria-haspopup="listbox" aria-expanded="false" aria-controls="script-select-options">
               <span id="script-select-label" class="script-select-label">script_name…</span>
-              <span class="script-select-chevron" aria-hidden="true">&#9662;</span>
+              <span class="script-select-toggle-chevron" aria-hidden="true"></span>
             </button>
             <div id="script-select-options" class="script-select-options hidden" role="listbox"></div>
           </div>
@@ -256,6 +256,125 @@
           <div id="watchlist-list" class="watchlist-list" role="table" aria-label="Futures markets"></div>
         </div>
         <div id="watchlist-exchange-errors" class="watchlist-exchange-errors hidden"></div>
+      </div>
+    </div>
+  </div>
+
+  <div id="watchlist-add-modal" class="modal watchlist-add-modal hidden" aria-hidden="true">
+    <div class="modal-box modal-box-sm watchlist-add-modal-box" role="dialog" aria-modal="true"
+         aria-labelledby="watchlist-add-title">
+      <div class="modal-header">
+        <span id="watchlist-add-title">Add session</span>
+        <button id="watchlist-add-close" class="btn btn-icon" type="button" title="Close"
+                aria-label="Close">&times;</button>
+      </div>
+      <form id="watchlist-add-form" class="watchlist-add-form">
+        <div class="watchlist-add-market">
+          <img id="watchlist-add-logo" class="watchlist-add-logo" alt="" />
+          <div>
+            <strong id="watchlist-add-symbol" class="mono"></strong>
+            <span id="watchlist-add-exchange"></span>
+          </div>
+        </div>
+        <div class="watchlist-add-field">
+          <span>Timeframe</span>
+          <div id="watchlist-add-timeframe-control"
+               class="script-select script-select-animated watchlist-add-select">
+            <button id="watchlist-add-timeframe-button" class="script-select-button" type="button"
+                    aria-haspopup="listbox" aria-expanded="false"
+                    aria-controls="watchlist-add-timeframe-options">
+              <span id="watchlist-add-timeframe-label" class="script-select-label">5m</span>
+              <span class="script-select-toggle-chevron" aria-hidden="true"></span>
+            </button>
+            <div id="watchlist-add-timeframe-options" class="script-select-options hidden" role="listbox">
+              <button class="script-select-option" type="button" data-watchlist-timeframe="1m" role="option">1m</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="3m" role="option">3m</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="5m" role="option">5m</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="15m" role="option">15m</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="30m" role="option">30m</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="1h" role="option">1h</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="2h" role="option">2h</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="4h" role="option">4h</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="6h" role="option">6h</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="12h" role="option">12h</button>
+              <button class="script-select-option" type="button" data-watchlist-timeframe="1d" role="option">1d</button>
+            </div>
+          </div>
+        </div>
+        <div class="watchlist-add-history-row">
+          <div class="watchlist-add-field">
+            <span>History since <small>UTC</small></span>
+            <div id="watchlist-add-date-picker" class="watchlist-add-date-picker">
+              <button id="watchlist-add-date-button" class="watchlist-add-date-button" type="button"
+                      aria-haspopup="dialog" aria-expanded="false"
+                      aria-controls="watchlist-add-calendar">
+                <span id="watchlist-add-date-label"></span>
+                <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="M8 2v4M16 2v4M3 9h18"></path>
+                  <rect x="3" y="4" width="18" height="17" rx="2"></rect>
+                </svg>
+              </button>
+              <div id="watchlist-add-calendar" class="watchlist-add-calendar hidden" role="dialog"
+                   aria-label="Choose history start date">
+                <div class="watchlist-add-calendar-toolbar">
+                  <button id="watchlist-add-calendar-prev" class="btn btn-icon" type="button"
+                          title="Previous month" aria-label="Previous month">&#8249;</button>
+                  <strong id="watchlist-add-calendar-title"></strong>
+                  <button id="watchlist-add-calendar-next" class="btn btn-icon" type="button"
+                          title="Next month" aria-label="Next month">&#8250;</button>
+                </div>
+                <div class="watchlist-add-calendar-weekdays" aria-hidden="true">
+                  <span>Su</span><span>Mo</span><span>Tu</span><span>We</span>
+                  <span>Th</span><span>Fr</span><span>Sa</span>
+                </div>
+                <div id="watchlist-add-calendar-days" class="watchlist-add-calendar-days"></div>
+              </div>
+            </div>
+          </div>
+          <label class="watchlist-add-field watchlist-add-time-field">
+            <span>Time <small>UTC</small></span>
+            <input id="watchlist-add-history-time" type="text" value="00:00"
+                   inputmode="numeric" maxlength="5" autocomplete="off"
+                   aria-label="History start time in UTC" />
+          </label>
+        </div>
+        <div id="watchlist-add-error" class="error" role="alert"></div>
+      </form>
+      <div class="confirm-footer">
+        <button id="watchlist-add-cancel" class="btn" type="button">Cancel</button>
+        <button id="watchlist-add-submit" class="btn btn-primary" type="submit"
+                form="watchlist-add-form">Add</button>
+      </div>
+    </div>
+  </div>
+
+  <div id="script-change-modal" class="modal script-change-modal hidden" aria-hidden="true">
+    <div class="modal-box modal-box-sm script-change-modal-box" role="dialog" aria-modal="true"
+         aria-labelledby="script-change-title">
+      <div class="modal-header">
+        <span id="script-change-title">Change script</span>
+        <button id="script-change-close" class="btn btn-icon" type="button" title="Close"
+                aria-label="Close">&times;</button>
+      </div>
+      <div class="script-change-body">
+        <div id="script-change-session" class="confirm-session mono"></div>
+        <div class="script-change-field">
+          <span>Strategy script</span>
+          <div id="script-change-select" class="script-select script-select-animated script-change-select">
+            <button id="script-change-select-button" class="script-select-button" type="button"
+                    aria-haspopup="listbox" aria-expanded="false"
+                    aria-controls="script-change-options">
+              <span id="script-change-select-label" class="script-select-label">Select script</span>
+              <span class="script-select-toggle-chevron" aria-hidden="true"></span>
+            </button>
+            <div id="script-change-options" class="script-select-options hidden" role="listbox"></div>
+          </div>
+        </div>
+        <div id="script-change-error" class="error" role="alert"></div>
+      </div>
+      <div class="confirm-footer">
+        <button id="script-change-cancel" class="btn" type="button">Cancel</button>
+        <button id="script-change-save" class="btn btn-primary" type="button">Save</button>
       </div>
     </div>
   </div>
@@ -874,6 +993,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=137"></script>
+  <script src="/static/dashboard.js?v=144"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -57,6 +57,16 @@
   let watchlistUiError = "";
   let watchlistFilteredRowsCache = [];
   let watchlistWindowRenderFrame = null;
+  let watchlistAddRow = null;
+  let watchlistAddTimeframe = "5m";
+  let watchlistAddHistoryDate = "";
+  let watchlistAddCalendarMonth = new Date(Date.UTC(1970, 0, 1));
+  let watchlistAddCalendarSuppressTapUntil = 0;
+  let lastWatchlistAddCalendarTouchAt = 0;
+  let watchlistAddPending = false;
+  let scriptChangeSessionId = null;
+  let scriptChangeSelected = "";
+  let scriptChangePending = false;
   const watchlistFavorites = new Set();
   const watchlistOverscanRows = 8;
   let registerAnimatedPepeFace = () => {};
@@ -632,7 +642,10 @@
     text.className = "watchlist-market-text";
     const name = document.createElement("div");
     name.className = "watchlist-market-name";
-    const symbol = document.createElement("strong");
+    const symbol = document.createElement("button");
+    symbol.type = "button";
+    symbol.className = "watchlist-symbol-button";
+    symbol.dataset.watchlistAddSymbol = "";
     const exchange = document.createElement("span");
     name.append(symbol, exchange);
     const meta = document.createElement("span");
@@ -658,6 +671,7 @@
     const key = watchlistFavoriteKey(row.exchange, row.symbol);
     const isFavorite = watchlistFavorites.has(key);
     item.dataset.watchlistKey = key;
+    item._watchlistRow = row;
     nodes.favorite.classList.toggle("active", isFavorite);
     nodes.favorite.dataset.watchlistFavoriteExchange = String(row.exchange || "");
     nodes.favorite.dataset.watchlistFavoriteSymbol = String(row.symbol || "");
@@ -680,6 +694,9 @@
       nodes.logo.removeAttribute("src");
     }
     nodes.symbol.textContent = `${String(row.base || "")} / ${String(row.quote || "")}`;
+    nodes.symbol.dataset.watchlistAddSymbol = String(row.symbol || "");
+    nodes.symbol.title = `Add ${String(row.symbol || "")} session`;
+    nodes.symbol.setAttribute("aria-label", `Add ${String(row.symbol || "")} session`);
     const showExchange = watchlistExchange === "all";
     nodes.exchange.textContent = showExchange
       ? watchlistExchangeNames[row.exchange] || String(row.exchange || "")
@@ -933,6 +950,317 @@
         watchlistUiError = "";
         if (isWatchlistOpen()) renderWatchlist();
       }, 5000);
+    }
+  }
+
+  function defaultWatchlistHistorySince() {
+    const now = new Date();
+    const targetYear = now.getUTCFullYear();
+    const targetMonth = now.getUTCMonth() - 2;
+    const day = now.getUTCDate();
+    const lastDay = new Date(Date.UTC(targetYear, targetMonth + 1, 0)).getUTCDate();
+    return new Date(Date.UTC(targetYear, targetMonth, Math.min(day, lastDay)))
+      .toISOString()
+      .slice(0, 10);
+  }
+
+  function watchlistDateFromKey(value) {
+    const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(String(value || ""));
+    if (!match) return null;
+    const year = Number(match[1]);
+    const month = Number(match[2]) - 1;
+    const day = Number(match[3]);
+    const date = new Date(Date.UTC(year, month, day));
+    if (
+      date.getUTCFullYear() !== year
+      || date.getUTCMonth() !== month
+      || date.getUTCDate() !== day
+    ) return null;
+    return date;
+  }
+
+  function watchlistDateKey(date) {
+    return new Date(Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+    )).toISOString().slice(0, 10);
+  }
+
+  function watchlistDateLabel(value) {
+    const date = watchlistDateFromKey(value);
+    if (!date) return "Select date";
+    return date.toLocaleDateString("en-US", {
+      timeZone: "UTC",
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+  }
+
+  function setWatchlistAddHistoryDate(value) {
+    const date = watchlistDateFromKey(value);
+    if (!date) return;
+    watchlistAddHistoryDate = watchlistDateKey(date);
+    el("watchlist-add-date-label").textContent = watchlistDateLabel(watchlistAddHistoryDate);
+  }
+
+  function renderWatchlistAddCalendar() {
+    const month = watchlistAddCalendarMonth;
+    el("watchlist-add-calendar-title").textContent = month.toLocaleDateString("en-US", {
+      timeZone: "UTC",
+      year: "numeric",
+      month: "long",
+    });
+    const todayKey = new Date().toISOString().slice(0, 10);
+    const today = watchlistDateFromKey(todayKey);
+    const currentMonthIndex = month.getUTCFullYear() * 12 + month.getUTCMonth();
+    const todayMonthIndex = today.getUTCFullYear() * 12 + today.getUTCMonth();
+    el("watchlist-add-calendar-next").disabled = currentMonthIndex >= todayMonthIndex;
+
+    const year = month.getUTCFullYear();
+    const monthIndex = month.getUTCMonth();
+    const firstWeekday = new Date(Date.UTC(year, monthIndex, 1)).getUTCDay();
+    const days = [];
+    for (let index = 0; index < 42; index += 1) {
+      const date = new Date(Date.UTC(year, monthIndex, 1 - firstWeekday + index));
+      const key = watchlistDateKey(date);
+      const outside = date.getUTCMonth() !== monthIndex;
+      const future = key > todayKey;
+      const classes = [
+        "watchlist-add-calendar-day",
+        outside ? "outside" : "",
+        key === todayKey ? "today" : "",
+        key === watchlistAddHistoryDate ? "selected" : "",
+      ].filter(Boolean).join(" ");
+      days.push(
+        `<button type="button" class="${classes}" data-watchlist-history-date="${key}" `
+        + `aria-label="${esc(watchlistDateLabel(key))}" `
+        + `aria-selected="${key === watchlistAddHistoryDate ? "true" : "false"}"`
+        + `${future ? " disabled" : ""}>${date.getUTCDate()}</button>`,
+      );
+    }
+    el("watchlist-add-calendar-days").innerHTML = days.join("");
+  }
+
+  function closeWatchlistAddCalendar() {
+    const calendar = el("watchlist-add-calendar");
+    calendar.classList.add("hidden");
+    calendar.classList.remove("above");
+    el("watchlist-add-date-picker").classList.remove("open");
+    el("watchlist-add-date-button").setAttribute("aria-expanded", "false");
+  }
+
+  function toggleWatchlistAddCalendar() {
+    const calendar = el("watchlist-add-calendar");
+    if (!calendar.classList.contains("hidden")) {
+      closeWatchlistAddCalendar();
+      return;
+    }
+    const selected = watchlistDateFromKey(watchlistAddHistoryDate) || new Date();
+    watchlistAddCalendarMonth = new Date(Date.UTC(
+      selected.getUTCFullYear(),
+      selected.getUTCMonth(),
+      1,
+    ));
+    closeWatchlistAddTimeframeOptions();
+    renderWatchlistAddCalendar();
+    el("watchlist-add-date-picker").classList.add("open");
+    calendar.classList.remove("above");
+    calendar.classList.remove("hidden");
+    el("watchlist-add-date-button").setAttribute("aria-expanded", "true");
+    window.requestAnimationFrame(() => {
+      if (calendar.classList.contains("hidden")) return;
+      const calendarRect = calendar.getBoundingClientRect();
+      const buttonRect = el("watchlist-add-date-button").getBoundingClientRect();
+      if (
+        calendarRect.bottom > window.innerHeight - 8
+        && buttonRect.top >= calendarRect.height + 8
+      ) calendar.classList.add("above");
+    });
+  }
+
+  function moveWatchlistAddCalendarMonth(delta) {
+    const next = new Date(Date.UTC(
+      watchlistAddCalendarMonth.getUTCFullYear(),
+      watchlistAddCalendarMonth.getUTCMonth() + delta,
+      1,
+    ));
+    const today = new Date();
+    const nextIndex = next.getUTCFullYear() * 12 + next.getUTCMonth();
+    const todayIndex = today.getUTCFullYear() * 12 + today.getUTCMonth();
+    if (nextIndex > todayIndex) return;
+    watchlistAddCalendarMonth = next;
+    renderWatchlistAddCalendar();
+    const days = el("watchlist-add-calendar-days");
+    days.classList.remove("month-prev", "month-next");
+    void days.offsetWidth;
+    days.classList.add(delta < 0 ? "month-prev" : "month-next");
+  }
+
+  function normalizeWatchlistHistoryTime(raw) {
+    const value = String(raw || "").trim();
+    if (!value) return "00:00";
+    let hours;
+    let minutes;
+    const colonMatch = /^(\d{1,2}):(\d{1,2})$/.exec(value);
+    if (colonMatch) {
+      hours = Number(colonMatch[1]);
+      minutes = Number(colonMatch[2]);
+    } else if (/^\d{1,4}$/.test(value)) {
+      if (value.length <= 2) {
+        hours = Number(value);
+        minutes = 0;
+      } else {
+        hours = Number(value.slice(0, -2));
+        minutes = Number(value.slice(-2));
+      }
+    } else {
+      return null;
+    }
+    if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+    return `${String(hours).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+  }
+
+  function isWatchlistAddOpen() {
+    return !el("watchlist-add-modal").classList.contains("hidden");
+  }
+
+  function closeWatchlistAddTimeframeOptions() {
+    setAnimatedScriptOptions(
+      el("watchlist-add-timeframe-control"),
+      el("watchlist-add-timeframe-button"),
+      el("watchlist-add-timeframe-options"),
+      false,
+    );
+  }
+
+  function setWatchlistAddTimeframe(value) {
+    watchlistAddTimeframe = String(value || "5m");
+    el("watchlist-add-timeframe-label").textContent = watchlistAddTimeframe;
+    el("watchlist-add-timeframe-options").querySelectorAll("[data-watchlist-timeframe]").forEach((option) => {
+      const selected = option.dataset.watchlistTimeframe === watchlistAddTimeframe;
+      option.classList.toggle("selected", selected);
+      option.setAttribute("aria-selected", String(selected));
+    });
+  }
+
+  function toggleWatchlistAddTimeframeOptions() {
+    const options = el("watchlist-add-timeframe-options");
+    const opening = options.classList.contains("hidden");
+    if (!opening) {
+      closeWatchlistAddTimeframeOptions();
+      return;
+    }
+    closeWatchlistAddCalendar();
+    setAnimatedScriptOptions(
+      el("watchlist-add-timeframe-control"),
+      el("watchlist-add-timeframe-button"),
+      options,
+      true,
+    );
+  }
+
+  function setWatchlistAddPending(pending) {
+    watchlistAddPending = Boolean(pending);
+    el("watchlist-add-submit").disabled = watchlistAddPending;
+    el("watchlist-add-cancel").disabled = watchlistAddPending;
+    el("watchlist-add-close").disabled = watchlistAddPending;
+    el("watchlist-add-date-button").disabled = watchlistAddPending;
+    el("watchlist-add-history-time").disabled = watchlistAddPending;
+    el("watchlist-add-submit").textContent = watchlistAddPending ? "Adding" : "Add";
+  }
+
+  function openWatchlistAddModal(row) {
+    if (!row || !row.exchange || !row.symbol) return;
+    watchlistAddRow = row;
+    watchlistAddCalendarSuppressTapUntil = 0;
+    lastWatchlistAddCalendarTouchAt = 0;
+    setWatchlistAddPending(false);
+    setWatchlistAddTimeframe("5m");
+    closeWatchlistAddTimeframeOptions();
+    closeWatchlistAddCalendar();
+    el("watchlist-add-error").textContent = "";
+    el("watchlist-add-symbol").textContent = String(row.symbol);
+    el("watchlist-add-exchange").textContent = watchlistExchangeNames[row.exchange]
+      || String(row.exchange);
+    setWatchlistAddHistoryDate(defaultWatchlistHistorySince());
+    el("watchlist-add-history-time").value = "00:00";
+
+    const logo = el("watchlist-add-logo");
+    const primary = String(row.symbol_logo_url || "");
+    const fallback = String(row.exchange_logo_url || "");
+    logo.dataset.fallbackSrc = fallback;
+    logo.onerror = () => {
+      if (fallback && logo.getAttribute("src") !== fallback) {
+        logo.src = fallback;
+        logo.hidden = false;
+      } else {
+        logo.hidden = true;
+      }
+    };
+    if (primary || fallback) {
+      logo.src = primary || fallback;
+      logo.hidden = false;
+    } else {
+      logo.removeAttribute("src");
+      logo.hidden = true;
+    }
+
+    const modal = el("watchlist-add-modal");
+    modal.classList.remove("hidden");
+    modal.setAttribute("aria-hidden", "false");
+    window.requestAnimationFrame(() => el("watchlist-add-timeframe-button").focus());
+  }
+
+  function closeWatchlistAddModal() {
+    if (!isWatchlistAddOpen() || watchlistAddPending) return;
+    closeWatchlistAddTimeframeOptions();
+    closeWatchlistAddCalendar();
+    el("watchlist-add-modal").classList.add("hidden");
+    el("watchlist-add-modal").setAttribute("aria-hidden", "true");
+    watchlistAddRow = null;
+    el("watchlist-add-error").textContent = "";
+  }
+
+  async function submitWatchlistSession() {
+    if (!watchlistAddRow || watchlistAddPending) return;
+    if (!watchlistAddHistoryDate) {
+      el("watchlist-add-error").textContent = "Select a history start date.";
+      el("watchlist-add-date-button").focus();
+      return;
+    }
+    const historyTime = normalizeWatchlistHistoryTime(el("watchlist-add-history-time").value);
+    if (!historyTime) {
+      el("watchlist-add-error").textContent = "Use a valid 24-hour time (HH:MM).";
+      el("watchlist-add-history-time").focus();
+      return;
+    }
+    el("watchlist-add-history-time").value = historyTime;
+    const historySince = `${watchlistAddHistoryDate} ${historyTime}`;
+    closeWatchlistAddCalendar();
+    setWatchlistAddPending(true);
+    el("watchlist-add-error").textContent = "";
+    try {
+      await api("/api/sessions", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          provider: "ccxt",
+          exchange: String(watchlistAddRow.exchange),
+          symbol: String(watchlistAddRow.symbol),
+          timeframe: watchlistAddTimeframe,
+          history_since: historySince,
+          market_type: "linear",
+        }),
+      });
+      setWatchlistAddPending(false);
+      closeWatchlistAddModal();
+    } catch (error) {
+      setWatchlistAddPending(false);
+      el("watchlist-add-error").textContent = error && error.message
+        ? error.message
+        : "Session could not be added.";
     }
   }
 
@@ -5483,6 +5811,171 @@
     watchlistModal.addEventListener("click", (event) => {
       if (event.target === watchlistModal) closeWatchlist();
     });
+    const watchlistAddModal = el("watchlist-add-modal");
+    watchlistAddModal.addEventListener("touchend", (event) => {
+      const button = event.target && event.target.closest
+        ? event.target.closest("#watchlist-add-calendar-prev, #watchlist-add-calendar-next")
+        : null;
+      if (!button) return;
+      const now = Date.now();
+      const isDoubleTap = now - lastWatchlistAddCalendarTouchAt < 360;
+      lastWatchlistAddCalendarTouchAt = now;
+      if (!isDoubleTap) return;
+      event.preventDefault();
+      button.click();
+    }, { passive: false });
+    el("watchlist-add-close").addEventListener("click", closeWatchlistAddModal);
+    el("watchlist-add-cancel").addEventListener("click", closeWatchlistAddModal);
+    watchlistAddModal.addEventListener("click", (event) => {
+      if (event.target === watchlistAddModal) closeWatchlistAddModal();
+    });
+    el("watchlist-add-form").addEventListener("submit", (event) => {
+      event.preventDefault();
+      submitWatchlistSession();
+    });
+    el("watchlist-add-timeframe-button").addEventListener("click", (event) => {
+      event.preventDefault();
+      toggleWatchlistAddTimeframeOptions();
+    });
+    el("watchlist-add-timeframe-options").addEventListener("click", (event) => {
+      const option = event.target && event.target.closest
+        ? event.target.closest("[data-watchlist-timeframe]")
+        : null;
+      if (!option) return;
+      setWatchlistAddTimeframe(option.dataset.watchlistTimeframe);
+      closeWatchlistAddTimeframeOptions();
+      el("watchlist-add-timeframe-button").focus();
+    });
+    el("watchlist-add-date-button").addEventListener("click", (event) => {
+      event.preventDefault();
+      toggleWatchlistAddCalendar();
+    });
+    el("watchlist-add-calendar-prev").addEventListener("click", () => {
+      moveWatchlistAddCalendarMonth(-1);
+    });
+    el("watchlist-add-calendar-next").addEventListener("click", () => {
+      moveWatchlistAddCalendarMonth(1);
+    });
+    const watchlistAddCalendarDays = el("watchlist-add-calendar-days");
+    let watchlistAddMonthDrag = null;
+    watchlistAddCalendarDays.addEventListener("pointerdown", (event) => {
+      if (!mobileHubQuery.matches || !event.isPrimary) return;
+      watchlistAddMonthDrag = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        dx: 0,
+        axis: null,
+      };
+    });
+    window.addEventListener("pointermove", (event) => {
+      if (!watchlistAddMonthDrag || event.pointerId !== watchlistAddMonthDrag.id) return;
+      const dx = event.clientX - watchlistAddMonthDrag.startX;
+      const dy = event.clientY - watchlistAddMonthDrag.startY;
+      if (!watchlistAddMonthDrag.axis) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) < 8) return;
+        watchlistAddMonthDrag.axis = Math.abs(dx) > Math.abs(dy) ? "x" : "y";
+        if (watchlistAddMonthDrag.axis === "x") {
+          try { watchlistAddCalendarDays.setPointerCapture(event.pointerId); } catch {}
+        }
+      }
+      if (watchlistAddMonthDrag.axis !== "x") return;
+      event.preventDefault();
+      watchlistAddMonthDrag.dx = dx;
+      watchlistAddCalendarSuppressTapUntil = Date.now() + 500;
+    }, { passive: false });
+    function endWatchlistAddMonthDrag(event) {
+      if (
+        !watchlistAddMonthDrag
+        || (event && event.pointerId !== watchlistAddMonthDrag.id)
+      ) return;
+      const current = watchlistAddMonthDrag;
+      watchlistAddMonthDrag = null;
+      try { watchlistAddCalendarDays.releasePointerCapture(current.id); } catch {}
+      if (current.axis !== "x" || Math.abs(current.dx) < 42) return;
+      moveWatchlistAddCalendarMonth(current.dx < 0 ? 1 : -1);
+    }
+    window.addEventListener("pointerup", endWatchlistAddMonthDrag);
+    window.addEventListener("pointercancel", endWatchlistAddMonthDrag);
+    watchlistAddCalendarDays.addEventListener("click", (event) => {
+      const day = event.target && event.target.closest
+        ? event.target.closest("[data-watchlist-history-date]")
+        : null;
+      if (!day || day.disabled) return;
+      setWatchlistAddHistoryDate(day.dataset.watchlistHistoryDate);
+      closeWatchlistAddCalendar();
+      el("watchlist-add-date-button").focus();
+    });
+    watchlistAddCalendarDays.addEventListener("click", (event) => {
+      if (Date.now() >= watchlistAddCalendarSuppressTapUntil) return;
+      event.preventDefault();
+      event.stopImmediatePropagation();
+    }, true);
+    el("watchlist-add-history-time").addEventListener("input", (event) => {
+      event.target.value = String(event.target.value || "").replace(/[^0-9:]/g, "").slice(0, 5);
+    });
+    el("watchlist-add-history-time").addEventListener("blur", (event) => {
+      const normalized = normalizeWatchlistHistoryTime(event.target.value);
+      if (normalized) event.target.value = normalized;
+    });
+    watchlistAddModal.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape") return;
+      if (!el("watchlist-add-timeframe-options").classList.contains("hidden")) {
+        closeWatchlistAddTimeframeOptions();
+        el("watchlist-add-timeframe-button").focus();
+      } else if (!el("watchlist-add-calendar").classList.contains("hidden")) {
+        closeWatchlistAddCalendar();
+        el("watchlist-add-date-button").focus();
+      } else {
+        closeWatchlistAddModal();
+      }
+    });
+    document.addEventListener("pointerdown", (event) => {
+      if (!isWatchlistAddOpen()) return;
+      const target = event.target && event.target.closest ? event.target : null;
+      if (!target || !target.closest("#watchlist-add-timeframe-control")) {
+        closeWatchlistAddTimeframeOptions();
+      }
+      if (!target || !target.closest("#watchlist-add-date-picker")) {
+        closeWatchlistAddCalendar();
+      }
+    }, { passive: true });
+    const scriptChangeModal = el("script-change-modal");
+    el("script-change-close").addEventListener("click", closeScriptChange);
+    el("script-change-cancel").addEventListener("click", closeScriptChange);
+    el("script-change-save").addEventListener("click", saveScriptChange);
+    scriptChangeModal.addEventListener("click", (event) => {
+      if (event.target === scriptChangeModal) closeScriptChange();
+    });
+    el("script-change-select-button").addEventListener("click", (event) => {
+      event.preventDefault();
+      toggleScriptChangeOptions();
+    });
+    el("script-change-options").addEventListener("click", (event) => {
+      const option = event.target && event.target.closest
+        ? event.target.closest("[data-script-change-value]")
+        : null;
+      if (!option) return;
+      scriptChangeSelected = String(option.dataset.scriptChangeValue || "");
+      syncScriptChangeSelection();
+      closeScriptChangeOptions();
+      el("script-change-select-button").focus();
+    });
+    scriptChangeModal.addEventListener("keydown", (event) => {
+      if (event.key !== "Escape") return;
+      if (!el("script-change-options").classList.contains("hidden")) {
+        closeScriptChangeOptions();
+        el("script-change-select-button").focus();
+      } else {
+        closeScriptChange();
+      }
+    });
+    document.addEventListener("pointerdown", (event) => {
+      if (!isScriptChangeOpen()) return;
+      const target = event.target && event.target.closest ? event.target : null;
+      if (target && target.closest("#script-change-select")) return;
+      closeScriptChangeOptions();
+    }, { passive: true });
     el("watchlist-search").addEventListener("input", (event) => {
       watchlistSearch = String(event.target.value || "");
       renderWatchlist(true);
@@ -5519,6 +6012,14 @@
     const watchlistList = el("watchlist-list");
     watchlistList.addEventListener("scroll", scheduleWatchlistWindowRender, { passive: true });
     watchlistList.addEventListener("click", (event) => {
+      const addButton = event.target && event.target.closest
+        ? event.target.closest("[data-watchlist-add-symbol]")
+        : null;
+      if (addButton) {
+        const row = addButton.closest(".watchlist-row");
+        openWatchlistAddModal(row && row._watchlistRow);
+        return;
+      }
       const button = event.target && event.target.closest
         ? event.target.closest("[data-watchlist-favorite-symbol]")
         : null;
@@ -6190,7 +6691,9 @@
       return `<button class="btn" data-runner="stop">Stop</button>` +
              `<button class="btn" data-runner="restart"${dataReady ? "" : " disabled"}>Restart</button>`;
     }
-    return `<button class="btn btn-primary" data-runner="start"${dataReady ? "" : " disabled"}>Start</button>`;
+    const canStart = dataReady && Boolean(s.script_name);
+    const title = s.script_name ? "" : ' title="Select a script first"';
+    return `<button class="btn btn-primary" data-runner="start"${canStart ? "" : " disabled"}${title}>Start</button>`;
   }
 
   function esc(s) {
@@ -6297,24 +6800,39 @@
     if (active) active.scrollIntoView({ block: "nearest" });
   }
 
+  function setAnimatedScriptOptions(control, button, options, expanded) {
+    if (!control || !button || !options) return;
+    button.setAttribute("aria-expanded", String(expanded));
+    if (expanded) {
+      options.classList.remove("hidden");
+      options.style.maxHeight = "0px";
+      void options.offsetHeight;
+      control.classList.add("open");
+      const limit = Math.min(320, window.innerHeight * 0.48);
+      options.style.maxHeight = `${Math.min(options.scrollHeight, limit)}px`;
+      return;
+    }
+    options.style.maxHeight = `${options.getBoundingClientRect().height}px`;
+    void options.offsetHeight;
+    control.classList.remove("open");
+    options.classList.add("hidden");
+    options.style.maxHeight = "0px";
+  }
+
   function openScriptDropdown() {
     const nodes = scriptSelectNodes();
     if (!nodes.control || !nodes.button || !nodes.options) return;
     const currentIndex = scriptOptions.indexOf(selectedScriptValue());
     scriptActiveIndex = currentIndex >= 0 ? currentIndex : 0;
     renderScriptOptions();
-    nodes.control.classList.add("open");
-    nodes.button.setAttribute("aria-expanded", "true");
-    nodes.options.classList.remove("hidden");
+    setAnimatedScriptOptions(nodes.control, nodes.button, nodes.options, true);
     nodes.options.setAttribute("tabindex", "-1");
   }
 
   function closeScriptDropdown() {
     const nodes = scriptSelectNodes();
     if (!nodes.control || !nodes.button || !nodes.options) return;
-    nodes.control.classList.remove("open");
-    nodes.button.setAttribute("aria-expanded", "false");
-    nodes.options.classList.add("hidden");
+    setAnimatedScriptOptions(nodes.control, nodes.button, nodes.options, false);
   }
 
   function toggleScriptDropdown() {
@@ -6347,6 +6865,134 @@
     return true;
   }
 
+  function isScriptChangeOpen() {
+    return !el("script-change-modal").classList.contains("hidden");
+  }
+
+  function scriptChangeSession() {
+    return sessions.find((session) => sessionId(session) === scriptChangeSessionId) || null;
+  }
+
+  function syncScriptChangeSelection() {
+    const session = scriptChangeSession();
+    const current = String(session && session.script_name || "");
+    el("script-change-select-label").textContent = scriptChangeSelected || "Select script";
+    el("script-change-select-button").title = scriptChangeSelected || "Select script";
+    el("script-change-options").querySelectorAll("[data-script-change-value]").forEach((option) => {
+      const selected = option.dataset.scriptChangeValue === scriptChangeSelected;
+      option.classList.toggle("selected", selected);
+      option.setAttribute("aria-selected", String(selected));
+    });
+    el("script-change-save").disabled = (
+      scriptChangePending || !scriptChangeSelected || scriptChangeSelected === current
+    );
+  }
+
+  function renderScriptChangeOptions(loading = false) {
+    const options = el("script-change-options");
+    if (loading) {
+      options.innerHTML = '<div class="script-select-empty">Loading scripts...</div>';
+    } else if (!scriptOptions.length) {
+      options.innerHTML = '<div class="script-select-empty">No scripts found</div>';
+    } else {
+      options.innerHTML = scriptOptions.map((script) => (
+        `<button type="button" role="option" class="script-select-option" `
+        + `data-script-change-value="${esc(script)}" title="${esc(script)}">${esc(script)}</button>`
+      )).join("");
+    }
+    syncScriptChangeSelection();
+  }
+
+  function closeScriptChangeOptions() {
+    setAnimatedScriptOptions(
+      el("script-change-select"),
+      el("script-change-select-button"),
+      el("script-change-options"),
+      false,
+    );
+  }
+
+  function toggleScriptChangeOptions() {
+    const options = el("script-change-options");
+    if (!options.classList.contains("hidden")) {
+      closeScriptChangeOptions();
+      return;
+    }
+    renderScriptChangeOptions();
+    setAnimatedScriptOptions(
+      el("script-change-select"),
+      el("script-change-select-button"),
+      options,
+      true,
+    );
+  }
+
+  function setScriptChangePending(pending) {
+    scriptChangePending = Boolean(pending);
+    el("script-change-close").disabled = scriptChangePending;
+    el("script-change-cancel").disabled = scriptChangePending;
+    el("script-change-select-button").disabled = scriptChangePending;
+    el("script-change-save").textContent = scriptChangePending ? "Saving" : "Save";
+    syncScriptChangeSelection();
+  }
+
+  async function openScriptChange(id) {
+    const session = sessions.find((item) => sessionId(item) === id);
+    if (!session) return;
+    const runner = String(session.runner || "stopped");
+    if (runner === "running" || runner === "starting") return;
+    scriptChangeSessionId = id;
+    scriptChangeSelected = String(session.script_name || "");
+    setScriptChangePending(false);
+    closeScriptChangeOptions();
+    el("script-change-error").textContent = "";
+    el("script-change-session").textContent = `${session.symbol} · ${session.timeframe} · ${String(session.exchange || "").toUpperCase()}`;
+    el("script-change-title").textContent = session.script_name ? "Change script" : "Select script";
+    renderScriptChangeOptions(true);
+    const modal = el("script-change-modal");
+    modal.classList.remove("hidden");
+    modal.setAttribute("aria-hidden", "false");
+    lockBodyScroll();
+    await loadScripts();
+    if (!isScriptChangeOpen() || scriptChangeSessionId !== id) return;
+    renderScriptChangeOptions();
+    el("script-change-select-button").focus();
+  }
+
+  function closeScriptChange() {
+    if (!isScriptChangeOpen() || scriptChangePending) return;
+    closeScriptChangeOptions();
+    el("script-change-modal").classList.add("hidden");
+    el("script-change-modal").setAttribute("aria-hidden", "true");
+    el("script-change-error").textContent = "";
+    scriptChangeSessionId = null;
+    scriptChangeSelected = "";
+    unlockBodyScroll();
+  }
+
+  async function saveScriptChange() {
+    if (!scriptChangeSessionId || !scriptChangeSelected || scriptChangePending) return;
+    const id = scriptChangeSessionId;
+    setScriptChangePending(true);
+    closeScriptChangeOptions();
+    el("script-change-error").textContent = "";
+    try {
+      await api(`/api/sessions/${encodeURIComponent(id)}/script`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ script_name: scriptChangeSelected }),
+      });
+      setScriptChangePending(false);
+      closeScriptChange();
+      await refresh();
+    } catch (error) {
+      setScriptChangePending(false);
+      el("script-change-error").textContent = error && error.message
+        ? error.message
+        : "Script could not be changed.";
+    }
+  }
+
   function toggleDataSinceTooltip(tr) {
     const wrap = tr.querySelector(".data-badge-wrap");
     if (!wrap) return;
@@ -6377,7 +7023,15 @@
       `<td data-label="Symbol" class="mono"><span data-field="symbol-cell" class="symbol-cell"></span></td>` +
       `<td data-label="TF" data-field="timeframe"></td>` +
       `<td data-label="Exchange"><span data-field="exchange-cell" class="exchange-cell"></span></td>` +
-      `<td data-label="Script" class="mono" data-field="script-name"></td>` +
+      `<td data-label="Script" class="mono script-cell">` +
+        `<button type="button" class="session-script-button" data-act="script-edit">` +
+          `<span data-field="script-name" class="session-script-label"></span>` +
+          `<svg class="session-script-edit-icon" viewBox="0 0 24 24" aria-hidden="true">` +
+            `<path d="M12 20h9"></path>` +
+            `<path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"></path>` +
+          `</svg>` +
+        `</button>` +
+      `</td>` +
       `<td data-label="Data" class="data-cell"><span class="data-controls">` +
         `<span class="data-badge-wrap">` +
           `<span data-field="collector-badge" class="badge data-badge" ` +
@@ -6441,6 +7095,7 @@
         }
       } else if (act === "data-edit") openSettings(id, "data-since");
       else if (act === "data-integrity") openSettings(id, "data-integrity");
+      else if (act === "script-edit") openScriptChange(id);
       else if (act === "delete") openRemoveConfirm(id);
       else if (act === "logs") openLogs(id);
       else if (act === "webhook-settings") openSettings(id, "webhook");
@@ -6452,7 +7107,7 @@
   function patchSessionRow(tr, s) {
     const id = sessionId(s);
     const runner = s.runner || "stopped";
-    const runnerControlsKey = `${runner}:${s.history_ready ? "ready" : "preparing"}`;
+    const runnerControlsKey = `${runner}:${s.history_ready ? "ready" : "preparing"}:${s.script_name ? "script" : "no-script"}`;
     const collector = s.collector || "stopped";
     const wh = s.webhook || {};
     const exchange = (s.exchange || "").toUpperCase();
@@ -6482,7 +7137,21 @@
     }
 
     setText(tr.querySelector('[data-field="timeframe"]'), s.timeframe);
-    setText(tr.querySelector('[data-field="script-name"]'), s.script_name);
+    const scriptButton = tr.querySelector('[data-act="script-edit"]');
+    const scriptEditable = runner !== "running" && runner !== "starting";
+    const scriptName = String(s.script_name || "");
+    setText(tr.querySelector('[data-field="script-name"]'), scriptName || "Select script");
+    if (scriptButton) {
+      setClass(
+        scriptButton,
+        `session-script-button${scriptName ? "" : " empty"}`,
+      );
+      scriptButton.disabled = !scriptEditable;
+      scriptButton.title = scriptEditable
+        ? (scriptName ? "Change script" : "Select script")
+        : "Stop runner to change script";
+      scriptButton.setAttribute("aria-label", scriptButton.title);
+    }
 
     const badge = tr.querySelector('[data-field="collector-badge"]');
     setClass(badge, `badge data-badge badge-${collector}`);

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -39,6 +39,26 @@
   let calendarAddSessionMenuOpen = false;
   let calendarAddComposing = false;
   const calendarAddSessionIds = new Set();
+  let watchlistRows = [];
+  let watchlistErrors = [];
+  let watchlistCollectedAt = "";
+  let watchlistHasSnapshot = false;
+  let watchlistExchange = "all";
+  let watchlistMarketFilter = "all";
+  let watchlistSearch = "";
+  let watchlistSort = "turnover_24h";
+  let watchlistSortDescending = true;
+  let watchlistWs = null;
+  let watchlistGeneration = 0;
+  let watchlistReconnectTimer = null;
+  let watchlistKeepaliveTimer = null;
+  let watchlistOpenTimer = null;
+  let watchlistCloseTimer = null;
+  let watchlistUiError = "";
+  let watchlistFilteredRowsCache = [];
+  let watchlistWindowRenderFrame = null;
+  const watchlistFavorites = new Set();
+  const watchlistOverscanRows = 8;
   let registerAnimatedPepeFace = () => {};
   const assetColors = [
     "#3b82f6", "#f59e0b", "#10b981", "#ef4444",
@@ -59,6 +79,7 @@
   let assetsHaveData = false;
   let assetsPayload = null;
   let selectedAssetExchange = null;
+  const assetAccountTypeDonuts = new Set();
   let accountView = "assets";
   let accountPagerScrollToView = null;
   let positionsRequestSeq = 0;
@@ -407,6 +428,512 @@
     menu.setAttribute("aria-hidden", "true");
     backdrop.setAttribute("aria-hidden", "true");
     el("hub-menu-button").setAttribute("aria-expanded", "false");
+  }
+
+  const watchlistExchangeNames = {
+    binance: "Binance",
+    bitget: "Bitget",
+    bybit: "Bybit",
+    okx: "OKX",
+    hyperliquid: "Hyperliquid",
+  };
+
+  function isWatchlistOpen() {
+    return !el("watchlist-modal").classList.contains("hidden");
+  }
+
+  function watchlistFavoriteKey(exchange, symbol) {
+    return `${String(exchange || "").toLowerCase()}|${String(symbol || "").toUpperCase()}`;
+  }
+
+  function applyWatchlistFavorites(payload) {
+    watchlistFavorites.clear();
+    const favorites = payload && Array.isArray(payload.favorites) ? payload.favorites : [];
+    for (const item of favorites) {
+      if (!item || typeof item !== "object") continue;
+      watchlistFavorites.add(watchlistFavoriteKey(item.exchange, item.symbol));
+    }
+    if (isWatchlistOpen()) renderWatchlist();
+  }
+
+  function watchlistNumber(value) {
+    if (value === null || value === undefined || value === "") return null;
+    const number = Number(value);
+    return Number.isFinite(number) ? number : null;
+  }
+
+  function formatWatchlistPrice(value) {
+    const number = watchlistNumber(value);
+    if (number === null) return "—";
+    const absolute = Math.abs(number);
+    let digits = 8;
+    if (absolute >= 1000) digits = 2;
+    else if (absolute >= 1) digits = 4;
+    else if (absolute >= 0.01) digits = 6;
+    return new Intl.NumberFormat("en-US", {
+      maximumFractionDigits: digits,
+      minimumFractionDigits: 0,
+    }).format(number);
+  }
+
+  function formatWatchlistTurnover(value) {
+    const number = watchlistNumber(value);
+    if (number === null) return "Turnover unavailable";
+    return `${new Intl.NumberFormat("en-US", {
+      notation: "compact",
+      maximumFractionDigits: 2,
+    }).format(number)} 24h turnover`;
+  }
+
+  function formatWatchlistChange(value) {
+    const number = watchlistNumber(value);
+    if (number === null) return "—";
+    return `${number > 0 ? "+" : ""}${number.toFixed(2)}%`;
+  }
+
+  function formatWatchlistUpdated(value) {
+    const date = new Date(value || "");
+    if (!Number.isFinite(date.getTime())) return "Waiting for market data";
+    return `Updated ${date.toLocaleTimeString([], {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hour12: false,
+    })}`;
+  }
+
+  function setWatchlistStatus(text, state = "") {
+    const node = el("watchlist-live-status");
+    node.textContent = text;
+    node.className = `watchlist-live-status${state ? ` ${state}` : ""}`;
+  }
+
+  function filteredWatchlistRows() {
+    const search = watchlistSearch.trim().toUpperCase();
+    const rows = watchlistRows.filter((row) => {
+      if (!row || typeof row !== "object") return false;
+      const exchange = String(row.exchange || "").toLowerCase();
+      if (watchlistExchange !== "all" && exchange !== watchlistExchange) return false;
+      const key = watchlistFavoriteKey(exchange, row.symbol);
+      if (watchlistMarketFilter === "favorites" && !watchlistFavorites.has(key)) return false;
+      if (
+        ["stocks", "etfs", "commodities"].includes(watchlistMarketFilter)
+        && String(row.category || "crypto").toLowerCase() !== watchlistMarketFilter
+      ) return false;
+      if (
+        (watchlistMarketFilter === "USDT" || watchlistMarketFilter === "USDC")
+        && String(row.quote || "").toUpperCase() !== watchlistMarketFilter
+      ) return false;
+      if (!search) return true;
+      return [row.symbol, row.market_id, row.base, row.quote, row.exchange]
+        .some((value) => String(value || "").toUpperCase().includes(search));
+    });
+    const direction = watchlistSortDescending ? -1 : 1;
+    rows.sort((left, right) => {
+      const leftValue = watchlistNumber(left[watchlistSort]);
+      const rightValue = watchlistNumber(right[watchlistSort]);
+      const leftValid = leftValue !== null;
+      const rightValid = rightValue !== null;
+      if (leftValid && rightValid && leftValue !== rightValue) {
+        return (leftValue - rightValue) * direction;
+      }
+      if (leftValid !== rightValid) return leftValid ? -1 : 1;
+      return String(left.symbol || "").localeCompare(String(right.symbol || ""));
+    });
+    return rows;
+  }
+
+  function watchlistRowHeight() {
+    const value = Number.parseFloat(
+      getComputedStyle(el("watchlist-list")).getPropertyValue("--watchlist-row-height"),
+    );
+    return Number.isFinite(value) && value > 0 ? value : 57;
+  }
+
+  function renderWatchlistWindow() {
+    watchlistWindowRenderFrame = null;
+    const list = el("watchlist-list");
+    const rows = watchlistFilteredRowsCache;
+    if (list.classList.contains("hidden") || rows.length === 0) {
+      list.replaceChildren();
+      return;
+    }
+
+    const rowHeight = watchlistRowHeight();
+    const viewportRows = Math.max(1, Math.ceil(list.clientHeight / rowHeight));
+    const requestedStart = Math.max(
+      0,
+      Math.floor(list.scrollTop / rowHeight) - watchlistOverscanRows,
+    );
+    const start = Math.min(requestedStart, Math.max(0, rows.length - viewportRows));
+    const end = Math.min(rows.length, start + viewportRows + watchlistOverscanRows * 2);
+    const existing = new Map(
+      Array.from(list.querySelectorAll(".watchlist-row"))
+        .map((item) => [item.dataset.watchlistKey, item]),
+    );
+    const fragment = document.createDocumentFragment();
+    const topSpacer = document.createElement("div");
+    topSpacer.className = "watchlist-spacer";
+    topSpacer.style.height = `${start * rowHeight}px`;
+    fragment.appendChild(topSpacer);
+
+    for (let index = start; index < end; index += 1) {
+      const row = rows[index];
+      const key = watchlistFavoriteKey(row.exchange, row.symbol);
+      const item = existing.get(key) || createWatchlistRow();
+      patchWatchlistRow(item, row);
+      fragment.appendChild(item);
+    }
+
+    const bottomSpacer = document.createElement("div");
+    bottomSpacer.className = "watchlist-spacer";
+    bottomSpacer.style.height = `${(rows.length - end) * rowHeight}px`;
+    fragment.appendChild(bottomSpacer);
+    list.replaceChildren(fragment);
+  }
+
+  function scheduleWatchlistWindowRender() {
+    if (watchlistWindowRenderFrame !== null) return;
+    watchlistWindowRenderFrame = window.requestAnimationFrame(renderWatchlistWindow);
+  }
+
+  function createWatchlistRow() {
+    const item = document.createElement("div");
+    item.className = "watchlist-row";
+    item.setAttribute("role", "row");
+
+    const favorite = document.createElement("button");
+    favorite.type = "button";
+    favorite.className = "watchlist-favorite";
+    favorite.textContent = "★";
+    item.appendChild(favorite);
+
+    const market = document.createElement("div");
+    market.className = "watchlist-market";
+    const logo = document.createElement("img");
+    logo.className = "watchlist-exchange-logo";
+    logo.alt = "";
+    logo.decoding = "async";
+    logo.loading = "lazy";
+    logo.fetchPriority = "low";
+    logo.addEventListener("error", () => {
+      const current = logo.getAttribute("src") || "";
+      const fallback = logo.dataset.fallbackSrc || "";
+      if (fallback && current !== fallback) {
+        logo.dataset.failedSrc = current;
+        logo.src = fallback;
+        logo.hidden = false;
+        return;
+      }
+      logo.hidden = true;
+    });
+    market.appendChild(logo);
+    const text = document.createElement("div");
+    text.className = "watchlist-market-text";
+    const name = document.createElement("div");
+    name.className = "watchlist-market-name";
+    const symbol = document.createElement("strong");
+    const exchange = document.createElement("span");
+    name.append(symbol, exchange);
+    const meta = document.createElement("span");
+    meta.className = "watchlist-market-meta";
+    text.append(name, meta);
+    market.appendChild(text);
+    item.appendChild(market);
+
+    const last = document.createElement("span");
+    last.className = "watchlist-number";
+    item.appendChild(last);
+
+    const change = document.createElement("span");
+    change.className = "watchlist-number watchlist-change";
+    item.appendChild(change);
+    item._watchlistNodes = { favorite, logo, symbol, exchange, meta, last, change };
+    return item;
+  }
+
+  function patchWatchlistRow(item, row) {
+    const nodes = item._watchlistNodes;
+    if (!nodes) return;
+    const key = watchlistFavoriteKey(row.exchange, row.symbol);
+    const isFavorite = watchlistFavorites.has(key);
+    item.dataset.watchlistKey = key;
+    nodes.favorite.classList.toggle("active", isFavorite);
+    nodes.favorite.dataset.watchlistFavoriteExchange = String(row.exchange || "");
+    nodes.favorite.dataset.watchlistFavoriteSymbol = String(row.symbol || "");
+    nodes.favorite.setAttribute("aria-pressed", String(isFavorite));
+    nodes.favorite.setAttribute("aria-label", `${isFavorite ? "Remove" : "Add"} ${row.symbol} favorite`);
+    nodes.favorite.title = isFavorite ? "Remove favorite" : "Add favorite";
+    const symbolLogoUrl = String(row.symbol_logo_url || "");
+    const fallbackLogoUrl = String(row.exchange_logo_url || "");
+    nodes.logo.dataset.fallbackSrc = fallbackLogoUrl;
+    const logoUrl = (
+      symbolLogoUrl && nodes.logo.dataset.failedSrc !== symbolLogoUrl
+        ? symbolLogoUrl
+        : fallbackLogoUrl
+    );
+    if (logoUrl) {
+      if (nodes.logo.getAttribute("src") !== logoUrl) nodes.logo.src = logoUrl;
+      nodes.logo.hidden = false;
+    } else {
+      nodes.logo.hidden = true;
+      nodes.logo.removeAttribute("src");
+    }
+    nodes.symbol.textContent = `${String(row.base || "")} / ${String(row.quote || "")}`;
+    const showExchange = watchlistExchange === "all";
+    nodes.exchange.textContent = showExchange
+      ? watchlistExchangeNames[row.exchange] || String(row.exchange || "")
+      : "";
+    nodes.exchange.hidden = !showExchange;
+    nodes.meta.textContent = formatWatchlistTurnover(row.turnover_24h);
+    nodes.last.textContent = formatWatchlistPrice(row.last);
+    const changeValue = watchlistNumber(row.change_24h);
+    nodes.change.classList.toggle("positive", changeValue !== null && changeValue > 0);
+    nodes.change.classList.toggle("negative", changeValue !== null && changeValue < 0);
+    nodes.change.textContent = formatWatchlistChange(row.change_24h);
+  }
+
+  function renderWatchlist(resetScroll = false) {
+    const rows = filteredWatchlistRows();
+    const list = el("watchlist-list");
+    const loading = el("watchlist-loading");
+    const error = el("watchlist-error");
+    const empty = el("watchlist-empty");
+    const noDataError = Boolean(watchlistUiError && !watchlistHasSnapshot);
+    loading.classList.toggle("hidden", watchlistHasSnapshot || noDataError);
+    error.classList.toggle("hidden", !noDataError);
+    error.textContent = noDataError ? watchlistUiError : "";
+    empty.classList.toggle("hidden", !watchlistHasSnapshot || rows.length > 0);
+    list.classList.toggle("hidden", !watchlistHasSnapshot || rows.length === 0);
+    watchlistFilteredRowsCache = rows;
+    if (resetScroll) list.scrollTop = 0;
+    scheduleWatchlistWindowRender();
+    el("watchlist-count").textContent = `${rows.length.toLocaleString()} of ${watchlistRows.length.toLocaleString()} markets`;
+    el("watchlist-updated").textContent = formatWatchlistUpdated(watchlistCollectedAt);
+
+    document.querySelectorAll("[data-watchlist-exchange]").forEach((button) => {
+      button.classList.toggle("active", button.dataset.watchlistExchange === watchlistExchange);
+    });
+    document.querySelectorAll("[data-watchlist-market]").forEach((button) => {
+      button.classList.toggle("active", button.dataset.watchlistMarket === watchlistMarketFilter);
+    });
+    document.querySelectorAll("[data-watchlist-sort]").forEach((button) => {
+      const active = button.dataset.watchlistSort === watchlistSort;
+      button.classList.toggle("active", active);
+      button.classList.toggle("desc", active && watchlistSortDescending);
+    });
+
+    const exchangeErrors = watchlistErrors.map((item) => {
+      const exchangeName = watchlistExchangeNames[item && item.exchange] || String(item && item.exchange || "Exchange");
+      return `${exchangeName} unavailable`;
+    });
+    if (watchlistUiError && watchlistHasSnapshot) exchangeErrors.unshift(watchlistUiError);
+    const errorSummary = el("watchlist-exchange-errors");
+    errorSummary.textContent = exchangeErrors.join(" · ");
+    errorSummary.title = errorSummary.textContent;
+    errorSummary.classList.toggle("hidden", exchangeErrors.length === 0);
+  }
+
+  function clearWatchlistTimers() {
+    if (watchlistReconnectTimer !== null) {
+      clearTimeout(watchlistReconnectTimer);
+      watchlistReconnectTimer = null;
+    }
+    if (watchlistKeepaliveTimer !== null) {
+      clearInterval(watchlistKeepaliveTimer);
+      watchlistKeepaliveTimer = null;
+    }
+  }
+
+  function closeWatchlistSocket() {
+    clearWatchlistTimers();
+    const ws = watchlistWs;
+    watchlistWs = null;
+    if (!ws) return;
+    ws.onopen = null;
+    ws.onmessage = null;
+    ws.onclose = null;
+    ws.onerror = null;
+    if (ws.readyState !== WebSocket.CLOSED && ws.readyState !== WebSocket.CLOSING) {
+      try { ws.close(); } catch {}
+    }
+  }
+
+  function scheduleWatchlistReconnect(generation) {
+    if (watchlistReconnectTimer !== null || !isWatchlistOpen()) return;
+    watchlistReconnectTimer = window.setTimeout(() => {
+      watchlistReconnectTimer = null;
+      connectWatchlist(generation);
+    }, 2000);
+  }
+
+  function connectWatchlist(generation = watchlistGeneration) {
+    if (
+      generation !== watchlistGeneration
+      || !isWatchlistOpen()
+      || document.visibilityState !== "visible"
+    ) return;
+    if (
+      watchlistWs
+      && (watchlistWs.readyState === WebSocket.OPEN || watchlistWs.readyState === WebSocket.CONNECTING)
+    ) return;
+    setWatchlistStatus("Connecting");
+    const proto = location.protocol === "https:" ? "wss:" : "ws:";
+    const ws = new WebSocket(`${proto}//${location.host}/ws/watchlist`);
+    watchlistWs = ws;
+    ws.onopen = () => {
+      if (watchlistWs !== ws || generation !== watchlistGeneration) return;
+      setWatchlistStatus(watchlistHasSnapshot ? "Live" : "Syncing", watchlistHasSnapshot ? "live" : "");
+      watchlistKeepaliveTimer = window.setInterval(() => {
+        if (watchlistWs === ws && ws.readyState === WebSocket.OPEN) ws.send("ping");
+      }, 15000);
+    };
+    ws.onmessage = (event) => {
+      if (watchlistWs !== ws || generation !== watchlistGeneration) return;
+      try {
+        const message = JSON.parse(event.data);
+        if (message.type === "watchlist.snapshot") {
+          const payload = message.payload && typeof message.payload === "object" ? message.payload : {};
+          watchlistRows = Array.isArray(payload.results) ? payload.results : [];
+          watchlistErrors = Array.isArray(payload.errors) ? payload.errors : [];
+          watchlistCollectedAt = String(payload.collected_at || "");
+          watchlistHasSnapshot = true;
+          watchlistUiError = "";
+          setWatchlistStatus("Live", "live");
+          renderWatchlist();
+        } else if (message.type === "watchlist.favorites") {
+          applyWatchlistFavorites(message.payload);
+        }
+      } catch {
+        watchlistUiError = "Invalid watchlist response";
+        renderWatchlist();
+      }
+    };
+    ws.onclose = () => {
+      if (watchlistWs !== ws || generation !== watchlistGeneration) return;
+      watchlistWs = null;
+      clearWatchlistTimers();
+      setWatchlistStatus("Reconnecting", "error");
+      scheduleWatchlistReconnect(generation);
+    };
+    ws.onerror = () => {
+      if (watchlistWs !== ws || generation !== watchlistGeneration) return;
+      setWatchlistStatus("Reconnecting", "error");
+    };
+  }
+
+  function finishWatchlistOpening() {
+    if (watchlistOpenTimer !== null) clearTimeout(watchlistOpenTimer);
+    watchlistOpenTimer = null;
+    el("watchlist-modal").classList.remove("watchlist-opening");
+  }
+
+  function finishWatchlistClose() {
+    const modal = el("watchlist-modal");
+    const box = modal.querySelector(".watchlist-modal-box");
+    modal.classList.remove(
+      "watchlist-closing",
+      "watchlist-dragging",
+      "watchlist-swipe-closing",
+      "watchlist-opening",
+    );
+    modal.classList.add("hidden");
+    modal.style.background = "";
+    box.style.transform = "";
+    box.style.transition = "";
+    modal.setAttribute("aria-hidden", "true");
+    watchlistCloseTimer = null;
+    watchlistOpenTimer = null;
+    unlockBodyScroll();
+  }
+
+  function openWatchlist() {
+    closeHubMenu();
+    closeAiChat();
+    if (watchlistCloseTimer !== null) {
+      clearTimeout(watchlistCloseTimer);
+      watchlistCloseTimer = null;
+    }
+    if (watchlistOpenTimer !== null) {
+      clearTimeout(watchlistOpenTimer);
+      watchlistOpenTimer = null;
+    }
+    const modal = el("watchlist-modal");
+    const box = modal.querySelector(".watchlist-modal-box");
+    modal.classList.remove(
+      "watchlist-closing",
+      "watchlist-dragging",
+      "watchlist-swipe-closing",
+      "watchlist-opening",
+      "hidden",
+    );
+    modal.classList.add("watchlist-opening");
+    modal.style.background = "";
+    box.style.transform = "";
+    box.style.transition = "";
+    modal.setAttribute("aria-hidden", "false");
+    watchlistOpenTimer = window.setTimeout(finishWatchlistOpening, 230);
+    lockBodyScroll();
+    renderWatchlist();
+    watchlistGeneration += 1;
+    connectWatchlist(watchlistGeneration);
+  }
+
+  function closeWatchlist(options = {}) {
+    if (!isWatchlistOpen()) return;
+    const modal = el("watchlist-modal");
+    if (modal.classList.contains("watchlist-closing")) return;
+    finishWatchlistOpening();
+    watchlistGeneration += 1;
+    closeWatchlistSocket();
+    setWatchlistStatus("Offline");
+    if (!mobileHubQuery.matches) {
+      modal.classList.add("watchlist-closing");
+      watchlistCloseTimer = window.setTimeout(finishWatchlistClose, 220);
+      return;
+    }
+    const box = modal.querySelector(".watchlist-modal-box");
+    modal.classList.remove("watchlist-dragging");
+    if (options.fromDrag === true) {
+      modal.classList.add("watchlist-swipe-closing");
+      box.style.transition = "transform 220ms cubic-bezier(0.55, 0, 1, 0.45)";
+      window.requestAnimationFrame(() => {
+        box.style.transform = "translateY(100dvh)";
+      });
+    } else {
+      box.style.transform = "";
+      box.style.transition = "";
+    }
+    modal.classList.add("watchlist-closing");
+    watchlistCloseTimer = window.setTimeout(finishWatchlistClose, 220);
+  }
+
+  async function toggleWatchlistFavorite(button) {
+    const exchange = String(button.dataset.watchlistFavoriteExchange || "");
+    const symbol = String(button.dataset.watchlistFavoriteSymbol || "");
+    const key = watchlistFavoriteKey(exchange, symbol);
+    const favorite = !watchlistFavorites.has(key);
+    if (favorite) watchlistFavorites.add(key);
+    else watchlistFavorites.delete(key);
+    renderWatchlist();
+    try {
+      const payload = await api("/api/watchlist/favorites", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ exchange, symbol, favorite }),
+      });
+      applyWatchlistFavorites(payload);
+    } catch (error) {
+      if (favorite) watchlistFavorites.delete(key);
+      else watchlistFavorites.add(key);
+      watchlistUiError = error && error.message ? error.message : "Favorite could not be saved";
+      renderWatchlist();
+      window.setTimeout(() => {
+        if (!watchlistUiError) return;
+        watchlistUiError = "";
+        if (isWatchlistOpen()) renderWatchlist();
+      }, 5000);
+    }
   }
 
   async function openCalendar() {
@@ -1449,6 +1976,12 @@
     return `${String(exchange || "")}:${String(quoteCurrency || "")}`;
   }
 
+  function assetPortfolioDonutKey(portfolio) {
+    return [portfolio.exchange, portfolio.account, portfolio.quote_currency]
+      .map((value) => String(value || ""))
+      .join("\u0000");
+  }
+
   function groupAssetPortfolios(portfolios) {
     const groups = new Map();
     portfolios.forEach((portfolio) => {
@@ -1530,7 +2063,8 @@
 
     const legend = document.createElement("div");
     legend.className = "assets-legend";
-    let showAccountTypes = false;
+    const donutKey = assetPortfolioDonutKey(portfolio);
+    let showAccountTypes = assetAccountTypeDonuts.has(donutKey);
 
     function renderDonutMode() {
       const slices = showAccountTypes
@@ -1632,6 +2166,8 @@
     }
     donut.addEventListener("click", () => {
       showAccountTypes = !showAccountTypes;
+      if (showAccountTypes) assetAccountTypeDonuts.add(donutKey);
+      else assetAccountTypeDonuts.delete(donutKey);
       renderDonutMode();
     });
     renderDonutMode();
@@ -4808,8 +5344,68 @@
     header.addEventListener("pointercancel", (event) => endAssetsCloseDrag(event, true));
   }
 
+  function initMobileWatchlistGestures() {
+    const modal = el("watchlist-modal");
+    const box = modal.querySelector(".watchlist-modal-box");
+    const header = modal.querySelector(".watchlist-modal-header");
+    let closeDrag = null;
+
+    header.addEventListener("pointerdown", (event) => {
+      if (!mobileHubQuery.matches || !event.isPrimary) return;
+      if (event.target && event.target.closest && event.target.closest("button")) return;
+      closeDrag = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        dy: 0,
+        active: false,
+      };
+      try { header.setPointerCapture(event.pointerId); } catch {}
+    });
+    header.addEventListener("pointermove", (event) => {
+      if (!closeDrag || event.pointerId !== closeDrag.id) return;
+      const dx = event.clientX - closeDrag.startX;
+      const dy = event.clientY - closeDrag.startY;
+      if (!closeDrag.active) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) < 8) return;
+        if (dy <= 0 || Math.abs(dy) <= Math.abs(dx)) {
+          closeDrag = null;
+          return;
+        }
+        closeDrag.active = true;
+        finishWatchlistOpening();
+        modal.classList.add("watchlist-dragging");
+      }
+      event.preventDefault();
+      closeDrag.dy = Math.max(0, dy);
+      box.style.transform = `translateY(${closeDrag.dy}px)`;
+    }, { passive: false });
+    function endWatchlistCloseDrag(event, cancelled = false) {
+      if (!closeDrag || (event && event.pointerId !== closeDrag.id)) return;
+      const current = closeDrag;
+      closeDrag = null;
+      try { header.releasePointerCapture(current.id); } catch {}
+      modal.classList.remove("watchlist-dragging");
+      if (!cancelled && current.active && current.dy > 100) {
+        closeWatchlist({ fromDrag: true });
+        return;
+      }
+      if (!current.active) return;
+      box.style.transition = "transform 180ms ease";
+      box.style.transform = "translateY(0)";
+      window.setTimeout(() => {
+        if (!isWatchlistOpen() || modal.classList.contains("watchlist-closing")) return;
+        box.style.transition = "";
+        box.style.transform = "";
+      }, 190);
+    }
+    header.addEventListener("pointerup", (event) => endWatchlistCloseDrag(event));
+    header.addEventListener("pointercancel", (event) => endWatchlistCloseDrag(event, true));
+  }
+
   function initHubMenuCalendar() {
     const calendarModal = el("calendar-modal");
+    const watchlistModal = el("watchlist-modal");
     calendarModal.addEventListener("touchend", (event) => {
       if (Date.now() < calendarSuppressTapUntil) {
         lastCalendarTouchAt = 0;
@@ -4832,6 +5428,7 @@
     el("hub-menu-button").addEventListener("click", openHubMenu);
     el("hub-menu-close").addEventListener("click", closeHubMenu);
     el("hub-menu-backdrop").addEventListener("click", closeHubMenu);
+    el("hub-watchlist-open").addEventListener("click", openWatchlist);
     el("hub-calendar-open").addEventListener("click", openCalendar);
     // Expand/collapse an accordion section to its exact content height so the
     // easing settles on-screen instead of being cut off mid-curve (which reads
@@ -4882,6 +5479,54 @@
       if (event.target === el("update-modal")) closeUpdateModal();
     });
     el("calendar-close").addEventListener("click", closeCalendar);
+    el("watchlist-close").addEventListener("click", closeWatchlist);
+    watchlistModal.addEventListener("click", (event) => {
+      if (event.target === watchlistModal) closeWatchlist();
+    });
+    el("watchlist-search").addEventListener("input", (event) => {
+      watchlistSearch = String(event.target.value || "");
+      renderWatchlist(true);
+    });
+    el("watchlist-exchange-filters").addEventListener("click", (event) => {
+      const button = event.target && event.target.closest
+        ? event.target.closest("[data-watchlist-exchange]")
+        : null;
+      if (!button) return;
+      watchlistExchange = String(button.dataset.watchlistExchange || "all");
+      renderWatchlist(true);
+    });
+    el("watchlist-market-filters").addEventListener("click", (event) => {
+      const button = event.target && event.target.closest
+        ? event.target.closest("[data-watchlist-market]")
+        : null;
+      if (!button) return;
+      watchlistMarketFilter = String(button.dataset.watchlistMarket || "all");
+      renderWatchlist(true);
+    });
+    watchlistModal.querySelector(".watchlist-list-header").addEventListener("click", (event) => {
+      const button = event.target && event.target.closest
+        ? event.target.closest("[data-watchlist-sort]")
+        : null;
+      if (!button) return;
+      const field = String(button.dataset.watchlistSort || "turnover_24h");
+      if (watchlistSort === field) watchlistSortDescending = !watchlistSortDescending;
+      else {
+        watchlistSort = field;
+        watchlistSortDescending = field !== "symbol";
+      }
+      renderWatchlist(true);
+    });
+    const watchlistList = el("watchlist-list");
+    watchlistList.addEventListener("scroll", scheduleWatchlistWindowRender, { passive: true });
+    watchlistList.addEventListener("click", (event) => {
+      const button = event.target && event.target.closest
+        ? event.target.closest("[data-watchlist-favorite-symbol]")
+        : null;
+      if (button) toggleWatchlistFavorite(button);
+    });
+    window.addEventListener("resize", () => {
+      if (isWatchlistOpen()) scheduleWatchlistWindowRender();
+    });
     calendarModal.addEventListener("click", (event) => {
       if (event.target === calendarModal) closeCalendar();
     });
@@ -5008,6 +5653,7 @@
     initMobileHubMenuSwipe();
     initMobileHubMenuEdgeSwipe();
     initMobileCalendarGestures();
+    initMobileWatchlistGestures();
     const accountTabs = document.querySelector(".account-tabs");
     let accountTabGesture = null;
     let suppressAccountTabClickUntil = 0;
@@ -8574,16 +9220,27 @@
       connectAccountPositions();
       scheduleAssetsRefresh();
       schedulePnlRefresh();
+      if (isWatchlistOpen()) {
+        watchlistGeneration += 1;
+        connectWatchlist(watchlistGeneration);
+      }
     } else {
       clearAssetsRefreshTimer();
       clearPnlRefreshTimer();
       closeForBackground();
       closeAccountPositionsSocket();
+      watchlistGeneration += 1;
+      closeWatchlistSocket();
+      if (isWatchlistOpen()) setWatchlistStatus("Paused");
     }
   });
   window.addEventListener("online", () => {
     rebuildHub();
     connectAccountPositions();
+    if (isWatchlistOpen()) {
+      watchlistGeneration += 1;
+      connectWatchlist(watchlistGeneration);
+    }
   });
 
   initHubMenuCalendar();

--- a/data_service/watchlist.py
+++ b/data_service/watchlist.py
@@ -1,0 +1,739 @@
+from __future__ import annotations
+
+import asyncio
+import copy
+import json
+import math
+import multiprocessing
+import os
+import queue
+import sys
+import threading
+import time
+from concurrent.futures import FIRST_COMPLETED, Future, ThreadPoolExecutor, wait
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import ccxt
+
+from cmc_logos import (
+    CATALOG_CHECK_SECONDS,
+    CmcLogoCatalog,
+    CmcLogoImageCache,
+)
+from tv_logos import exchange_logo_url
+from ws_manager import WSManager
+
+
+WATCHLIST_EXCHANGES = ("binance", "bitget", "bybit", "okx", "hyperliquid")
+WATCHLIST_REFRESH_SECONDS = 5.0
+WATCHLIST_IDLE_GRACE_SECONDS = 30.0
+HYPERLIQUID_HIP3_REFRESH_SECONDS = 30.0
+MARKET_RELOAD_SECONDS = 30 * 60.0
+
+
+@dataclass(frozen=True)
+class ExchangeSpec:
+    exchange_id: str
+    class_name: str
+    options: dict[str, Any]
+    ticker_params: dict[str, Any]
+    quotes: frozenset[str]
+
+
+EXCHANGE_SPECS = (
+    ExchangeSpec(
+        "binance",
+        "binanceusdm",
+        {
+            "defaultType": "swap",
+            "defaultSubType": "linear",
+            "fetchMarkets": {"types": ["linear"]},
+        },
+        {},
+        frozenset({"USDT", "USDC"}),
+    ),
+    ExchangeSpec(
+        "bitget",
+        "bitget",
+        {
+            "defaultType": "swap",
+            "defaultSubType": "linear",
+            "fetchMarkets": {"types": ["swap"]},
+        },
+        {"type": "swap", "productType": "USDT-FUTURES"},
+        frozenset({"USDT"}),
+    ),
+    ExchangeSpec(
+        "bybit",
+        "bybit",
+        {
+            "defaultType": "swap",
+            "defaultSubType": "linear",
+            "fetchMarkets": {"types": ["linear"]},
+        },
+        {"type": "swap", "subType": "linear"},
+        frozenset({"USDT", "USDC"}),
+    ),
+    ExchangeSpec(
+        "okx",
+        "okx",
+        {
+            "defaultType": "swap",
+            "fetchMarkets": {"types": ["swap"]},
+        },
+        {"type": "swap"},
+        frozenset({"USDT", "USDC"}),
+    ),
+    ExchangeSpec(
+        "hyperliquid",
+        "hyperliquid",
+        {
+            "defaultType": "swap",
+            "fetchMarkets": {
+                "types": ["swap", "hip3"],
+                "hip3": {"limit": 10, "dexes": []},
+            },
+        },
+        {"type": "swap"},
+        frozenset({"USDC"}),
+    ),
+)
+
+
+def _utc_now() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _log_error(message: str) -> None:
+    timestamp = datetime.now().astimezone().isoformat(sep=" ", timespec="seconds")
+    print(f"[{timestamp}]{message}", file=sys.stderr, flush=True)
+
+
+def _number(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _first_number(source: dict[str, Any], *keys: str) -> float | None:
+    for key in keys:
+        value = _number(source.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _ticker_percentage(ticker: dict[str, Any], info: dict[str, Any]) -> float | None:
+    percentage = _number(ticker.get("percentage"))
+    if percentage is not None:
+        return percentage
+    for key in ("change24h", "price24hPcnt"):
+        value = _number(info.get(key))
+        if value is not None:
+            return value * 100.0
+    percentage = _number(info.get("P"))
+    if percentage is not None:
+        return percentage
+    last = _number(ticker.get("last"))
+    reference = _first_number(ticker, "open", "previousClose")
+    if reference is None:
+        reference = _number(info.get("prevDayPx"))
+    if last is not None and reference not in (None, 0.0):
+        return (last / reference - 1.0) * 100.0
+    return None
+
+
+def _ticker_turnover(
+    exchange_id: str,
+    ticker: dict[str, Any],
+    info: dict[str, Any],
+    market: dict[str, Any],
+    last: float | None,
+) -> float | None:
+    if exchange_id == "okx" and market.get("swap"):
+        base_volume = _number(info.get("volCcy24h"))
+        if base_volume is not None and last is not None:
+            return base_volume * last
+    value = _number(ticker.get("quoteVolume"))
+    if value is not None:
+        return value
+    return _first_number(
+        info,
+        "turnover24h",
+        "quoteVolume",
+        "usdtVolume",
+        "dayNtlVlm",
+        "volCcy24h",
+        "q",
+    )
+
+
+def _ticker_mark(ticker: dict[str, Any], info: dict[str, Any]) -> float | None:
+    value = _first_number(ticker, "mark", "markPrice")
+    if value is not None:
+        return value
+    return _first_number(info, "markPx", "markPrice", "markPr")
+
+
+def _market_for_ticker(exchange: ccxt.Exchange, ticker: dict[str, Any]) -> dict[str, Any]:
+    symbol = str(ticker.get("symbol") or "")
+    market = exchange.markets.get(symbol)
+    if isinstance(market, dict):
+        return market
+    return {}
+
+
+def normalize_tickers(
+    exchange_id: str,
+    exchange: ccxt.Exchange,
+    tickers: dict[str, Any],
+    quotes: frozenset[str],
+    logo_catalog: CmcLogoCatalog | None = None,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    now_ms = int(time.time() * 1000)
+    for ticker in tickers.values():
+        if not isinstance(ticker, dict):
+            continue
+        market = _market_for_ticker(exchange, ticker)
+        if market:
+            if not market.get("swap") or market.get("active") is False:
+                continue
+            if market.get("linear") is False:
+                continue
+        symbol = str(ticker.get("symbol") or market.get("symbol") or "").strip()
+        if not symbol:
+            continue
+        base = str(market.get("base") or symbol.split("/", 1)[0]).upper()
+        quote = str(market.get("quote") or "").upper()
+        if not quote and "/" in symbol:
+            quote = symbol.split("/", 1)[1].split(":", 1)[0].upper()
+        if quote not in quotes:
+            continue
+        info = ticker.get("info")
+        info = info if isinstance(info, dict) else {}
+        last = _number(ticker.get("last"))
+        mark = _ticker_mark(ticker, info)
+        if last is None:
+            last = mark or _first_number(info, "lastPr", "last", "midPx")
+        if last is None:
+            continue
+        timestamp = _number(ticker.get("timestamp")) or _first_number(
+            info, "ts", "time", "E"
+        )
+        created = _number(market.get("created"))
+        rows.append({
+            "exchange": exchange_id,
+            "exchange_logo_url": exchange_logo_url(exchange_id),
+            "symbol_logo_url": (
+                logo_catalog.resolve_url(exchange_id, base)
+                if logo_catalog is not None
+                else ""
+            ),
+            "symbol": symbol,
+            "market_id": str(market.get("id") or info.get("symbol") or symbol),
+            "base": base,
+            "quote": quote,
+            "category": (
+                logo_catalog.resolve_asset_class(exchange_id, base)
+                if logo_catalog is not None
+                else "crypto"
+            ),
+            "last": last,
+            "mark": mark,
+            "change_24h": _ticker_percentage(ticker, info),
+            "turnover_24h": _ticker_turnover(
+                exchange_id,
+                ticker,
+                info,
+                market,
+                last,
+            ),
+            "updated_at": int(timestamp or now_ms),
+            "is_new": bool(created and now_ms - created <= 30 * 86_400_000),
+        })
+    rows.sort(key=lambda row: (-(row.get("turnover_24h") or 0.0), row["symbol"]))
+    return rows
+
+
+class _ExchangeCollector:
+    def __init__(self, spec: ExchangeSpec, logo_catalog: CmcLogoCatalog) -> None:
+        self.spec = spec
+        self.logo_catalog = logo_catalog
+        exchange_class = getattr(ccxt, spec.class_name)
+        self.exchange: ccxt.Exchange = exchange_class({
+            "enableRateLimit": True,
+            "timeout": 12_000,
+            "options": copy.deepcopy(spec.options),
+        })
+        self.markets_loaded_at = 0.0
+        self.hip3_rows: list[dict[str, Any]] = []
+        self.hip3_loaded_at = 0.0
+
+    def _load_markets(self) -> None:
+        now = time.monotonic()
+        if not self.exchange.markets or now - self.markets_loaded_at >= MARKET_RELOAD_SECONDS:
+            self.exchange.load_markets(reload=bool(self.exchange.markets))
+            self.markets_loaded_at = now
+
+    def collect(self) -> list[dict[str, Any]]:
+        self._load_markets()
+        tickers = self.exchange.fetch_tickers(None, dict(self.spec.ticker_params))
+        rows = normalize_tickers(
+            self.spec.exchange_id,
+            self.exchange,
+            tickers if isinstance(tickers, dict) else {},
+            self.spec.quotes,
+            self.logo_catalog,
+        )
+        if self.spec.exchange_id != "hyperliquid":
+            return rows
+
+        now = time.monotonic()
+        if now - self.hip3_loaded_at >= HYPERLIQUID_HIP3_REFRESH_SECONDS:
+            hip3 = self.exchange.fetch_tickers(None, {"hip3": True})
+            self.hip3_rows = normalize_tickers(
+                self.spec.exchange_id,
+                self.exchange,
+                hip3 if isinstance(hip3, dict) else {},
+                self.spec.quotes,
+                self.logo_catalog,
+            )
+            self.hip3_loaded_at = now
+        merged = {(row["exchange"], row["symbol"]): row for row in rows}
+        merged.update({(row["exchange"], row["symbol"]): row for row in self.hip3_rows})
+        return sorted(
+            merged.values(),
+            key=lambda row: (-(row.get("turnover_24h") or 0.0), row["symbol"]),
+        )
+
+    def close(self) -> None:
+        try:
+            self.exchange.close()
+        except Exception:
+            pass
+
+
+def _replace_queue_item(output_queue: Any, payload: dict[str, Any]) -> None:
+    try:
+        output_queue.put_nowait(payload)
+        return
+    except queue.Full:
+        pass
+    try:
+        output_queue.get_nowait()
+    except queue.Empty:
+        pass
+    try:
+        output_queue.put_nowait(payload)
+    except queue.Full:
+        pass
+
+
+def _publish_snapshot(
+    output_queue: Any,
+    rows_by_exchange: dict[str, list[dict[str, Any]]],
+    errors: dict[str, dict[str, str]],
+    updated_exchanges: set[str],
+) -> None:
+    results = [
+        row
+        for exchange_id in WATCHLIST_EXCHANGES
+        for row in rows_by_exchange.get(exchange_id, [])
+    ]
+    _replace_queue_item(output_queue, {
+        "schema_version": "1.0",
+        "collected_at": _utc_now(),
+        "results": results,
+        "errors": [errors[key] for key in WATCHLIST_EXCHANGES if key in errors],
+        "updated_exchanges": sorted(updated_exchanges),
+        "summary": {
+            "exchanges": len(rows_by_exchange),
+            "markets": len(results),
+        },
+    })
+
+
+def run_watchlist_worker(
+    output_queue: Any,
+    stop_event: Any,
+    logo_catalog_path: str,
+    refresh_seconds: float = WATCHLIST_REFRESH_SECONDS,
+) -> None:
+    try:
+        if hasattr(os, "nice"):
+            try:
+                os.nice(5)
+            except OSError:
+                pass
+        logo_catalog = CmcLogoCatalog(Path(logo_catalog_path))
+        for failure in logo_catalog.refresh_if_stale():
+            _log_error(f"[watchlist] CMC logo refresh failed: {failure}")
+        next_logo_check = time.monotonic() + CATALOG_CHECK_SECONDS
+        collectors = {
+            spec.exchange_id: _ExchangeCollector(spec, logo_catalog)
+            for spec in EXCHANGE_SPECS
+        }
+        rows_by_exchange: dict[str, list[dict[str, Any]]] = {}
+        errors: dict[str, dict[str, str]] = {}
+        next_attempt = {exchange_id: 0.0 for exchange_id in collectors}
+        failures = {exchange_id: 0 for exchange_id in collectors}
+        last_logged: dict[str, tuple[str, float]] = {}
+        pending_updates: set[str] = set()
+        next_publish = 0.0
+        with ThreadPoolExecutor(
+            max_workers=len(collectors),
+            thread_name_prefix="watchlist",
+        ) as executor:
+            in_flight: dict[Future[list[dict[str, Any]]], str] = {}
+            while not stop_event.is_set():
+                now = time.monotonic()
+                if now >= next_logo_check:
+                    for failure in logo_catalog.refresh_if_stale():
+                        _log_error(f"[watchlist] CMC logo refresh failed: {failure}")
+                    next_logo_check = time.monotonic() + CATALOG_CHECK_SECONDS
+                active_exchanges = set(in_flight.values())
+                for exchange_id, collector in collectors.items():
+                    if exchange_id in active_exchanges or now < next_attempt[exchange_id]:
+                        continue
+                    in_flight[executor.submit(collector.collect)] = exchange_id
+                if not in_flight:
+                    stop_event.wait(0.1)
+                    completed: set[Future[list[dict[str, Any]]]] = set()
+                else:
+                    completed, _ = wait(
+                        tuple(in_flight),
+                        timeout=0.25,
+                        return_when=FIRST_COMPLETED,
+                    )
+                for future in completed:
+                    exchange_id = in_flight.pop(future)
+                    pending_updates.add(exchange_id)
+                    try:
+                        rows_by_exchange[exchange_id] = future.result()
+                        errors.pop(exchange_id, None)
+                        failures[exchange_id] = 0
+                        next_attempt[exchange_id] = time.monotonic() + refresh_seconds
+                    except Exception as exc:
+                        failures[exchange_id] += 1
+                        delay = min(refresh_seconds * (2 ** (failures[exchange_id] - 1)), 60.0)
+                        next_attempt[exchange_id] = time.monotonic() + delay
+                        message = str(exc).replace("\n", " ").strip()[:400]
+                        errors[exchange_id] = {
+                            "exchange": exchange_id,
+                            "type": type(exc).__name__,
+                            "message": message or type(exc).__name__,
+                        }
+                        previous, logged_at = last_logged.get(exchange_id, ("", 0.0))
+                        if previous != message or time.monotonic() - logged_at >= 300.0:
+                            _log_error(
+                                f"[watchlist] {exchange_id} ticker refresh failed: "
+                                f"{type(exc).__name__}: {message}"
+                            )
+                            last_logged[exchange_id] = (message, time.monotonic())
+                now = time.monotonic()
+                if pending_updates and now >= next_publish:
+                    _publish_snapshot(
+                        output_queue,
+                        rows_by_exchange,
+                        errors,
+                        pending_updates,
+                    )
+                    pending_updates = set()
+                    next_publish = now + refresh_seconds
+        for collector in collectors.values():
+            collector.close()
+    except KeyboardInterrupt:
+        pass
+    except Exception as exc:
+        _log_error(f"[watchlist] worker stopped: {type(exc).__name__}: {exc}")
+    finally:
+        try:
+            output_queue.put_nowait(None)
+        except Exception:
+            pass
+
+
+class WatchlistFavoritesStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path.resolve()
+        self._lock = threading.Lock()
+
+    @staticmethod
+    def _normalize(exchange: str, symbol: str) -> tuple[str, str]:
+        normalized_exchange = exchange.strip().lower()
+        normalized_symbol = symbol.strip().upper()
+        if normalized_exchange not in WATCHLIST_EXCHANGES:
+            raise ValueError("unsupported watchlist exchange")
+        if not normalized_symbol or len(normalized_symbol) > 100:
+            raise ValueError("invalid watchlist symbol")
+        return normalized_exchange, normalized_symbol
+
+    def _read_unlocked(self) -> set[tuple[str, str]]:
+        try:
+            payload = json.loads(self.path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return set()
+        except (OSError, json.JSONDecodeError):
+            return set()
+        rows = payload.get("favorites") if isinstance(payload, dict) else []
+        favorites: set[tuple[str, str]] = set()
+        for row in rows if isinstance(rows, list) else []:
+            if not isinstance(row, dict):
+                continue
+            try:
+                favorites.add(self._normalize(
+                    str(row.get("exchange") or ""),
+                    str(row.get("symbol") or ""),
+                ))
+            except ValueError:
+                continue
+        return favorites
+
+    def get(self) -> list[dict[str, str]]:
+        with self._lock:
+            values = self._read_unlocked()
+        return [
+            {"exchange": exchange, "symbol": symbol}
+            for exchange, symbol in sorted(values)
+        ]
+
+    def set(self, exchange: str, symbol: str, favorite: bool) -> list[dict[str, str]]:
+        key = self._normalize(exchange, symbol)
+        with self._lock:
+            values = self._read_unlocked()
+            if favorite:
+                values.add(key)
+            else:
+                values.discard(key)
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            payload = {
+                "schema_version": "1.0",
+                "favorites": [
+                    {"exchange": item[0], "symbol": item[1]}
+                    for item in sorted(values)
+                ],
+            }
+            temporary = self.path.with_suffix(self.path.suffix + ".tmp")
+            temporary.write_text(
+                json.dumps(payload, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+            temporary.replace(self.path)
+        return [
+            {"exchange": item[0], "symbol": item[1]}
+            for item in sorted(values)
+        ]
+
+
+class WatchlistService:
+    def __init__(self, favorites_path: Path, logo_cache_dir: Path) -> None:
+        self.favorites = WatchlistFavoritesStore(favorites_path)
+        self.logo_cache_dir = logo_cache_dir.resolve()
+        self.logo_catalog_path = self.logo_cache_dir / "catalog.json"
+        self.logo_images = CmcLogoImageCache(
+            self.logo_cache_dir / "images",
+            self.logo_catalog_path,
+        )
+        self._logo_download_limit = asyncio.Semaphore(4)
+        self.live_ws = WSManager(on_disconnect=self._on_disconnect)
+        self._clients: set[Any] = set()
+        self._process_lock = asyncio.Lock()
+        self._process: multiprocessing.Process | None = None
+        self._output: Any = None
+        self._stop: Any = None
+        self._reader: asyncio.Task[None] | None = None
+        self._idle_task: asyncio.Task[None] | None = None
+        self._snapshot: dict[str, Any] | None = None
+
+    def favorites_payload(self) -> dict[str, Any]:
+        return {"schema_version": "1.0", "favorites": self.favorites.get()}
+
+    def set_favorite(
+        self,
+        exchange: str,
+        symbol: str,
+        favorite: bool,
+    ) -> dict[str, Any]:
+        return {
+            "schema_version": "1.0",
+            "favorites": self.favorites.set(exchange, symbol, favorite),
+        }
+
+    async def broadcast_favorites(self, payload: dict[str, Any]) -> None:
+        await self.live_ws.broadcast_json({
+            "type": "watchlist.favorites",
+            "payload": payload,
+        })
+
+    async def logo_path(self, cmc_id: int) -> Path:
+        async with self._logo_download_limit:
+            return await asyncio.to_thread(self.logo_images.get, cmc_id)
+
+    async def connect_live(self, ws: Any) -> None:
+        idle_task = self._idle_task
+        self._idle_task = None
+        if idle_task is not None:
+            idle_task.cancel()
+            await asyncio.gather(idle_task, return_exceptions=True)
+        await self.live_ws.connect(ws)
+        self._clients.add(ws)
+        await self._ensure_worker()
+        if self._snapshot is not None:
+            await self.live_ws.send(ws, {
+                "type": "watchlist.snapshot",
+                "payload": copy.deepcopy(self._snapshot),
+            })
+        await self.live_ws.send(ws, {
+            "type": "watchlist.favorites",
+            "payload": self.favorites_payload(),
+        })
+
+    async def disconnect_live(self, ws: Any) -> None:
+        await self.live_ws.disconnect(ws)
+
+    async def _on_disconnect(self, ws: Any) -> None:
+        self._clients.discard(ws)
+        if self._clients or self._idle_task is not None:
+            return
+        self._idle_task = asyncio.create_task(self._stop_after_idle())
+
+    async def _stop_after_idle(self) -> None:
+        try:
+            await asyncio.sleep(WATCHLIST_IDLE_GRACE_SECONDS)
+            if not self._clients:
+                await self._close_worker()
+        except asyncio.CancelledError:
+            pass
+        finally:
+            if self._idle_task is asyncio.current_task():
+                self._idle_task = None
+
+    async def _ensure_worker(self) -> None:
+        async with self._process_lock:
+            if self._process is not None and self._process.is_alive():
+                return
+            context = multiprocessing.get_context("spawn")
+            self._output = context.Queue(maxsize=1)
+            self._stop = context.Event()
+            self._process = context.Process(
+                target=run_watchlist_worker,
+                args=(self._output, self._stop, str(self.logo_catalog_path)),
+                name="pynereal-futures-watchlist",
+                daemon=True,
+            )
+            self._process.start()
+            self._reader = asyncio.create_task(self._read_output())
+
+    def _merge_snapshot(self, payload: dict[str, Any]) -> dict[str, Any]:
+        current = self._snapshot
+        updated = {
+            str(exchange)
+            for exchange in payload.get("updated_exchanges", [])
+            if str(exchange) in WATCHLIST_EXCHANGES
+        }
+        if current is None or not updated:
+            return payload
+
+        incoming_errors = {
+            str(item.get("exchange")): item
+            for item in payload.get("errors", [])
+            if isinstance(item, dict) and item.get("exchange")
+        }
+        successful = updated.difference(incoming_errors)
+        current_rows = current.get("results", [])
+        incoming_rows = payload.get("results", [])
+        rows = [
+            row for row in current_rows
+            if isinstance(row, dict) and str(row.get("exchange")) not in successful
+        ]
+        rows.extend(
+            row for row in incoming_rows
+            if isinstance(row, dict) and str(row.get("exchange")) in successful
+        )
+
+        errors = {
+            str(item.get("exchange")): item
+            for item in current.get("errors", [])
+            if isinstance(item, dict) and item.get("exchange")
+        }
+        for exchange_id in updated:
+            if exchange_id in incoming_errors:
+                errors[exchange_id] = incoming_errors[exchange_id]
+            else:
+                errors.pop(exchange_id, None)
+        merged = dict(payload)
+        merged["results"] = rows
+        merged["errors"] = [
+            errors[key] for key in WATCHLIST_EXCHANGES if key in errors
+        ]
+        merged["summary"] = {
+            "exchanges": len({
+                str(row.get("exchange")) for row in rows if isinstance(row, dict)
+            }),
+            "markets": len(rows),
+        }
+        return merged
+
+    async def _read_output(self) -> None:
+        output = self._output
+        if output is None:
+            return
+        while True:
+            try:
+                payload = await asyncio.to_thread(output.get, True, 1.0)
+            except queue.Empty:
+                if output is not self._output or self._process is None:
+                    return
+                continue
+            if payload is None:
+                return
+            if not isinstance(payload, dict):
+                continue
+            self._snapshot = self._merge_snapshot(payload)
+            await self.live_ws.broadcast_json({
+                "type": "watchlist.snapshot",
+                "payload": self._snapshot,
+            })
+
+    async def _close_worker(self) -> None:
+        async with self._process_lock:
+            process = self._process
+            stop = self._stop
+            reader = self._reader
+            output = self._output
+            self._process = None
+            self._stop = None
+            self._reader = None
+            self._output = None
+            if stop is not None:
+                stop.set()
+            if process is not None:
+                await asyncio.to_thread(process.join, 10)
+                if process.is_alive():
+                    process.terminate()
+                    await asyncio.to_thread(process.join, 5)
+            if reader is not None and not reader.done():
+                try:
+                    await asyncio.wait_for(reader, timeout=2)
+                except TimeoutError:
+                    reader.cancel()
+                    await asyncio.gather(reader, return_exceptions=True)
+            if output is not None:
+                output.close()
+                await asyncio.to_thread(output.join_thread)
+
+    async def close(self) -> None:
+        idle_task = self._idle_task
+        self._idle_task = None
+        if idle_task is not None:
+            idle_task.cancel()
+            await asyncio.gather(idle_task, return_exceptions=True)
+        await self._close_worker()

--- a/data_service/ws_manager.py
+++ b/data_service/ws_manager.py
@@ -37,6 +37,10 @@ def _coalesce_key(payload: Any) -> Optional[tuple]:
         return ("sessions",)
     if t == "account.positions":
         return ("account.positions",)
+    if t == "watchlist.snapshot":
+        return ("watchlist.snapshot",)
+    if t == "watchlist.favorites":
+        return ("watchlist.favorites",)
     return None
 
 


### PR DESCRIPTION
## Summary
- Binance, Bitget, OKX, Bybit, Hyperliquid 선물 종목을 거래소·카테고리별로 조회하고 실시간 갱신하는 Watchlist를 추가했습니다.
- 거래대금, 가격 변동률, 종목 로고 캐시와 데스크톱 사이드 패널 및 모바일 시트 UI를 구현했습니다.
- Watchlist 심볼에서 타임프레임과 UTC 시작 시각을 선택해 세션을 추가할 수 있으며, 스크립트 없이 생성한 뒤 정지 상태에서 전략을 선택하거나 변경할 수 있습니다.
- 실행 중인 세션의 스크립트 변경과 동일 피드의 중복 전략 할당을 백엔드에서 차단하고 관련 사용법을 README에 추가했습니다.

## Verification
- `node --check data_service/templates/dashboard.js`
- `venv/bin/python -m py_compile data_service/api.py data_service/registry.py data_service/runtime.py`
- `git diff --check`
- 데스크톱 및 모바일 UI 동작 확인