### PR TITLE
AI 세션 평가의 증거 기반 불일치 진단 개선

### DIFF
--- a/account_service/cache.py
+++ b/account_service/cache.py
@@ -2445,6 +2445,274 @@ class AccountCache:
             connection.close()
         return [str(row["account"]) for row in rows if row["account"]]
 
+    def session_evaluation_evidence(
+        self,
+        *,
+        accounts: list[str],
+        exchange: str,
+        symbol: str,
+        position_max_age_seconds: float,
+        history_max_age_seconds: float,
+        limit_per_account: int = 100,
+    ) -> dict[str, Any]:
+        """Read account evidence for one strategy session without network access."""
+
+        selected_accounts = list(dict.fromkeys(
+            account.strip() for account in accounts if account.strip()
+        ))
+        normalized_exchange = exchange.strip().lower()
+        normalized_symbol = symbol.strip().lower()
+        now = datetime.now(UTC).timestamp()
+
+        def is_fresh(value: Any, max_age: float) -> bool:
+            timestamp = _iso_timestamp(value)
+            return (
+                timestamp is not None
+                and now - timestamp <= max_age
+                and timestamp - now <= 60.0
+            )
+
+        empty = {
+            "positions": {"results": [], "summary": {"requested": 0, "failed": 0}},
+            "orders": {"results": [], "summary": {"requested": 0, "failed": 0}},
+            "position_history": {
+                "results": [],
+                "summary": {"requested": 0, "failed": 0},
+            },
+            "freshness": {
+                "positions": {"fresh": False, "stale_accounts": selected_accounts},
+                "orders": {"fresh": False, "stale_accounts": selected_accounts},
+                "position_history": {
+                    "fresh": False,
+                    "stale_accounts": selected_accounts,
+                },
+            },
+            "cache_available": False,
+        }
+        if not selected_accounts:
+            return empty
+
+        connection = self._read_connection()
+        if connection is None:
+            return empty
+
+        placeholders = ",".join("?" for _ in selected_accounts)
+        account_params: list[Any] = [*selected_accounts, normalized_exchange]
+        try:
+            status_rows = {
+                str(row["account"]): row
+                for row in connection.execute(
+                    f"""
+                    SELECT account, stream_status, last_success_at
+                    FROM account_sync_status
+                    WHERE account IN ({placeholders}) AND LOWER(exchange) = ?
+                    """,
+                    account_params,
+                )
+            }
+            cursor_rows = connection.execute(
+                f"""
+                SELECT account, stream, MAX(updated_at) AS updated_at
+                FROM sync_cursors
+                WHERE account IN ({placeholders}) AND LOWER(exchange) = ?
+                GROUP BY account, stream
+                """,
+                account_params,
+            ).fetchall()
+            cursor_times: dict[str, dict[str, str]] = {}
+            for row in cursor_rows:
+                cursor_times.setdefault(str(row["account"]), {})[
+                    str(row["stream"])
+                ] = str(row["updated_at"] or "")
+
+            position_rows = []
+            order_rows = []
+            history_rows = []
+            position_stale: list[str] = []
+            order_stale: list[str] = []
+            history_stale: list[str] = []
+
+            for account in selected_accounts:
+                status = status_rows.get(account)
+                position_fresh = bool(
+                    status is not None
+                    and str(status["stream_status"] or "").lower()
+                    in {"ok", "live"}
+                    and is_fresh(
+                        status["last_success_at"],
+                        position_max_age_seconds,
+                    )
+                )
+                streams = cursor_times.get(account, {})
+                order_synced_at = max(
+                    (
+                        updated_at
+                        for stream, updated_at in streams.items()
+                        if stream.startswith("orders")
+                    ),
+                    default="",
+                )
+                position_history_synced_at = max(
+                    (
+                        updated_at
+                        for stream, updated_at in streams.items()
+                        if stream in {"fills", "positions"}
+                    ),
+                    default="",
+                )
+                order_fresh = is_fresh(order_synced_at, history_max_age_seconds)
+                position_history_fresh = is_fresh(
+                    position_history_synced_at,
+                    history_max_age_seconds,
+                )
+                if not position_fresh:
+                    position_stale.append(account)
+                if not order_fresh:
+                    order_stale.append(account)
+                if not position_history_fresh:
+                    history_stale.append(account)
+
+                positions = []
+                for row in connection.execute(
+                    """
+                    SELECT payload_json
+                    FROM current_positions
+                    WHERE account = ? AND LOWER(exchange) = ? AND LOWER(symbol) = ?
+                    ORDER BY last_seen_at DESC
+                    """,
+                    (account, normalized_exchange, normalized_symbol),
+                ):
+                    payload = _payload_object(row["payload_json"])
+                    if payload:
+                        positions.append(payload)
+                position_rows.append({
+                    "account": account,
+                    "exchange": normalized_exchange,
+                    "status": "ok" if position_fresh else "stale",
+                    "positions": positions,
+                    "position_count": len(positions),
+                })
+
+                orders = []
+                for row in connection.execute(
+                    """
+                    SELECT order_id, client_order_id, market_scope, symbol, status,
+                           side, order_type, created_at, updated_at, payload_json
+                    FROM orders
+                    WHERE account = ? AND LOWER(exchange) = ? AND LOWER(symbol) = ?
+                    ORDER BY COALESCE(updated_at, created_at, '') DESC
+                    LIMIT ?
+                    """,
+                    (
+                        account,
+                        normalized_exchange,
+                        normalized_symbol,
+                        limit_per_account,
+                    ),
+                ):
+                    payload = _payload_object(row["payload_json"])
+                    payload.setdefault("id", row["order_id"])
+                    payload.setdefault("client_order_id", row["client_order_id"])
+                    payload.setdefault("market_scope", row["market_scope"])
+                    payload.setdefault("symbol", row["symbol"])
+                    payload.setdefault("status", row["status"])
+                    payload.setdefault("side", row["side"])
+                    payload.setdefault("type", row["order_type"])
+                    payload.setdefault("datetime", row["created_at"] or row["updated_at"])
+                    orders.append(payload)
+                order_rows.append({
+                    "account": account,
+                    "exchange": normalized_exchange,
+                    "status": "ok" if order_fresh else "stale",
+                    "orders": orders,
+                    "order_count": len(orders),
+                })
+
+                positions_history = []
+                for row in connection.execute(
+                    """
+                    SELECT market_scope, dex, symbol, side, opened_at, closed_at,
+                           source, payload_json
+                    FROM position_history
+                    WHERE account = ? AND LOWER(exchange) = ? AND LOWER(symbol) = ?
+                    ORDER BY closed_at DESC
+                    LIMIT ?
+                    """,
+                    (
+                        account,
+                        normalized_exchange,
+                        normalized_symbol,
+                        limit_per_account,
+                    ),
+                ):
+                    payload = _payload_object(row["payload_json"])
+                    payload.setdefault("market_scope", row["market_scope"])
+                    payload.setdefault("dex", row["dex"])
+                    payload.setdefault("symbol", row["symbol"])
+                    payload.setdefault("side", row["side"])
+                    payload.setdefault("opened_at", row["opened_at"])
+                    payload.setdefault("closed_at", row["closed_at"])
+                    payload.setdefault("source", row["source"])
+                    positions_history.append(payload)
+                history_rows.append({
+                    "account": account,
+                    "exchange": normalized_exchange,
+                    "status": "ok" if position_history_fresh else "stale",
+                    "positions": positions_history,
+                    "position_count": len(positions_history),
+                })
+        except sqlite3.OperationalError:
+            return empty
+        finally:
+            connection.close()
+
+        def payload(source: str, rows: list[dict[str, Any]], failed: int) -> dict[str, Any]:
+            return {
+                "schema_version": "1.0",
+                "collected_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+                "source": source,
+                "read_only": True,
+                "results": rows,
+                "summary": {
+                    "requested": len(rows),
+                    "succeeded": len(rows) - failed,
+                    "failed": failed,
+                },
+            }
+
+        return {
+            "positions": payload(
+                "account_cache.current_positions",
+                position_rows,
+                len(position_stale),
+            ),
+            "orders": payload(
+                "account_cache.orders",
+                order_rows,
+                len(order_stale),
+            ),
+            "position_history": payload(
+                "account_cache.position_history",
+                history_rows,
+                len(history_stale),
+            ),
+            "freshness": {
+                "positions": {
+                    "fresh": not position_stale,
+                    "stale_accounts": position_stale,
+                },
+                "orders": {
+                    "fresh": not order_stale,
+                    "stale_accounts": order_stale,
+                },
+                "position_history": {
+                    "fresh": not history_stale,
+                    "stale_accounts": history_stale,
+                },
+            },
+            "cache_available": True,
+        }
+
     def position_history_page(
         self,
         *,

--- a/account_service/positions.py
+++ b/account_service/positions.py
@@ -19,11 +19,22 @@ from position import collect_one  # noqa: E402
 SCHEMA_VERSION = "1.0"
 
 
-def collect_positions_snapshot(config_path: str) -> dict[str, Any]:
-    """Collect every configured account without exposing credentials to the parent."""
-
+def _collect_positions_snapshot(
+    config_path: str,
+    *,
+    account_names: tuple[str, ...] = (),
+    exchange_id: str = "",
+    symbols: tuple[str, ...] = (),
+    account_type: str = "swap",
+    all_derivative_scopes: bool = True,
+) -> dict[str, Any]:
     data = read_provider_config(Path(config_path))
     accounts = configured_accounts(data)
+    selected_names = set(account_names)
+    if selected_names:
+        accounts = [account for account in accounts if account.name in selected_names]
+    if exchange_id:
+        accounts = [account for account in accounts if account.exchange_id == exchange_id]
     if not accounts:
         return {
             "schema_version": SCHEMA_VERSION,
@@ -42,10 +53,10 @@ def collect_positions_snapshot(config_path: str) -> dict[str, Any]:
     args = argparse.Namespace(
         timeout_ms=30_000,
         attempts=2,
-        symbols=[],
+        symbols=list(symbols),
         dex=None,
         include_closed=False,
-        all_derivative_scopes=True,
+        all_derivative_scopes=all_derivative_scopes,
     )
     bitget_accounts = [account for account in accounts if account.exchange_id == "bitget"]
     account_groups = ([bitget_accounts] if bitget_accounts else []) + [
@@ -57,7 +68,7 @@ def collect_positions_snapshot(config_path: str) -> dict[str, Any]:
             collect_one(
                 account.name,
                 account.exchange_id,
-                "swap",
+                account_type,
                 account.config,
                 args,
                 log_progress=False,
@@ -93,3 +104,28 @@ def collect_positions_snapshot(config_path: str) -> dict[str, Any]:
             ),
         },
     }
+
+
+def collect_positions_snapshot(config_path: str) -> dict[str, Any]:
+    """Collect every configured account without exposing credentials to the parent."""
+
+    return _collect_positions_snapshot(config_path)
+
+
+def collect_positions_snapshot_scope(
+    config_path: str,
+    exchange_id: str,
+    account_names: tuple[str, ...],
+    symbol: str,
+    account_type: str,
+) -> dict[str, Any]:
+    """Collect current positions only for one session's account candidates."""
+
+    return _collect_positions_snapshot(
+        config_path,
+        account_names=account_names,
+        exchange_id=exchange_id,
+        symbols=(symbol,),
+        account_type=account_type,
+        all_derivative_scopes=False,
+    )

--- a/ai/INSTRUCTIONS.md
+++ b/ai/INSTRUCTIONS.md
@@ -171,6 +171,50 @@ internals when an existing script already provides the required data.
   once. Reuse the returned evidence instead of refreshing it during the same
   evaluation. Recollect only when the tool explicitly rejects a stale or
   changed generation.
+- Classify requests by meaning and conversation context, not by a fixed list of
+  words or languages. A user who reports an observed mismatch, asks for deeper
+  verification, or challenges a previous claim is requesting diagnosis even if
+  the message is a short reaction such as doubt or disagreement. If the target
+  claim cannot be identified from the conversation, ask what should be checked.
+- Use `detail_level=standard` for normal session evaluation. For mismatch
+  diagnosis or verification, use `detail_level=compact`, then call
+  `compare_session_evidence` with the exact session and generation from that
+  same user turn. Call the comparison at most once and omit `max_events` unless
+  a smaller result is specifically required. Also call it when
+  `evidence_summary.diagnostic_recommended` is true. The comparison reuses
+  cached evidence and must not be replaced with another context call or ad hoc
+  account collector.
+- Separate observations from interpretations. Find the earliest chronological
+  divergence before explaining the final value, test evidence that would
+  disprove each plausible hypothesis, and lower confidence in a prior claim
+  when the user challenges it. `first_divergence` is an observation, not a root
+  cause by itself.
+- Before diagnosing a reported historical value, compare the user's stated
+  price, quantity, time, or state with the current snapshot. If the key reported
+  state is not reproduced, say so before any explanation. Do not call the cause
+  clear or diagnose the historical discrepancy from a different current
+  lifecycle; report current observations separately and request the matching
+  historical snapshot or execution records.
+- State a cause as confirmed only when the divergence is reproduced, source
+  execution logic directly accounts for it, or two independent evidence
+  sources support the same explanation. Otherwise label it as a hypothesis and
+  state what evidence is missing.
+- Treat an unmatched account event as an account-only execution, not proof of a
+  strategy, webhook, or engine action. It may be a manual or other external
+  order. Confirm its origin from the conversation or execution records before
+  using it as a cause; otherwise present the possible origins and ask for the
+  missing fact when it changes the conclusion.
+- Honor `investigation_constraints` from the comparison. When the earliest
+  divergence is an account-only execution with unknown origin, stop strategy-side
+  attribution: do not inspect unrelated source branches, rerun the strategy,
+  capture the chart, or rank repainting, webhook, or engine hypotheses. Report
+  the unmatched execution and request its order origin or corresponding
+  alert/webhook record.
+- Read the returned structured events and `source_excerpts` before using shell
+  searches. Use repository search only when the cached source is unavailable or
+  the excerpt shows that another local file is required. Do not rerun a strategy
+  or browse the web to invent missing historical execution evidence; report the
+  required alert, webhook, or order-origin record instead.
 - Use only one ready calculation generation in an evaluation. If the generation
   changes, recollect the context instead of combining old plots or trades with
   new OHLCV.
@@ -197,8 +241,10 @@ internals when an existing script already provides the required data.
   settled, even when Pine FIFO attribution leaves a trade row carrying that ID.
   Do not describe an entry-specific close as partial or "mostly" closed unless
   this ledger or another structured quantity shows a positive remainder.
-- The exact-session context call automatically reads current positions and
-  recent order history from configured `providers.toml` accounts. Use the
+- The exact-session context call reads Account Center's cached current positions,
+  order history, and position history for configured accounts on the session
+  exchange. Missing or stale scopes are refreshed only for that exchange and
+  symbol. Use the
   returned `account_match` evidence; do not rerun those collectors through shell.
 - When the user explicitly names an account, pass that human-readable name in
   the context tool's `account` argument. The user-selected account takes

--- a/ai/provider/codex_service.py
+++ b/ai/provider/codex_service.py
@@ -74,10 +74,33 @@ DEFAULT_DEVELOPER_INSTRUCTIONS = (
     "that ID and wait_for_ready=true. Within one user turn, call the session list at most once, the "
     "exact session context at most once, and the chart capture at most once. Reuse those results "
     "instead of refreshing them unless the tool explicitly rejects a changed generation. If the user "
+    "reports a mismatch, asks for verification, or challenges a prior claim in any language, infer "
+    "that intent from the conversation rather than fixed keywords. Use detail_level=compact for that "
+    "exact context and call compare_session_evidence once with the same session and generation, omitting "
+    "max_events unless a smaller result is specifically required. Also compare "
+    "when evidence_summary recommends diagnostics. For normal evaluation use detail_level=standard. "
+    "Separate observations from interpretations, locate the earliest chronological divergence, and "
+    "try to disprove plausible causes before accepting one. A first divergence is not itself a root "
+    "cause. Confirm a cause only through direct source execution logic, reproduction, or two independent "
+    "supporting observations; otherwise label it as a hypothesis and state missing evidence. "
+    "Before diagnosing a user-reported historical value, verify that the current snapshot reproduces "
+    "that value and lifecycle. If it does not, state that the historical issue is not reproduced and "
+    "do not diagnose it from the different current state. "
+    "An unmatched account event proves only an account-side execution. It may be manual or external, "
+    "so confirm its origin before attributing it to the strategy, webhook, or engine. "
+    "Honor comparison investigation_constraints. If strategy-source attribution is disallowed, stop "
+    "after reporting the account-only execution and required order-origin evidence; do not inspect "
+    "source branches, rerun the strategy, capture a chart, or rank repainting or webhook hypotheses. "
+    "Read structured events and source_excerpts before using shell searches. "
+    "Do not rerun a strategy or browse the web to invent missing historical execution evidence; state "
+    "which alert, webhook, or order-origin record is needed instead. "
+    "When a user challenges the prior answer, lower that answer's confidence and recheck contrary "
+    "evidence before defending it. If the user "
     "explicitly names a configured account, pass the "
     "human-readable account name in the account argument; that selection must not be replaced by "
-    "another account. Otherwise omit account so the server matches configured accounts from current "
-    "positions and recent order history. Treat the returned confirmed bars, simulation state, plots, "
+    "another account. Otherwise omit account so the server matches accounts on the session exchange "
+    "from Account Center's cached current positions, order history, and position history, with a "
+    "scoped refresh only when that cache is missing or stale. Treat the returned confirmed bars, simulation state, plots, "
     "trades, source, logs, calculation generation, and warnings as the authoritative session evidence. "
     "For live-risk evaluation, prefer simulation.position.aggregate_avg_price and "
     "simulation.pnl.aggregate_openprofit. Use avg_price, openprofit, and open_trade_ledger for Pine "
@@ -195,6 +218,7 @@ class CodexService:
         project_root: Path,
         session_registry: Any,
         calendar_store: Any,
+        account_data_service: Any | None = None,
         developer_instructions: str = DEFAULT_DEVELOPER_INSTRUCTIONS,
         timeout_seconds: float = 600,
         chat_state_path: Path | None = None,
@@ -206,6 +230,7 @@ class CodexService:
             self.project_root,
             session_registry=session_registry,
             calendar_store=calendar_store,
+            account_data_service=account_data_service,
         )
         self.file_tools = self.dynamic_tools.file_tools
         self.developer_instructions = (

--- a/ai/scripts/account_match.py
+++ b/ai/scripts/account_match.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import math
 import re
+from datetime import UTC, datetime
 from typing import Any
+
+
+MAX_RECENT_MATCHED_ORDERS = 50
 
 
 def canonical_symbol(value: Any) -> str:
@@ -58,11 +62,19 @@ def _relative_distance(left: Any, right: Any) -> float | None:
 
 def _timestamp_milliseconds(value: Any) -> int | None:
     number = _number(value)
-    if number is None or number <= 0:
-        return None
-    if number < 10_000_000_000:
-        number *= 1000
-    return int(number)
+    if number is not None and number > 0:
+        if number < 10_000_000_000:
+            number *= 1000
+        return int(number)
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=UTC)
+        return int(parsed.timestamp() * 1000)
+    return None
 
 
 def _simulation_values(
@@ -95,6 +107,7 @@ def match_session_account(
     context: dict[str, Any],
     positions_payload: dict[str, Any],
     orders_payload: dict[str, Any],
+    position_history_payload: dict[str, Any] | None = None,
     *,
     explicit_account: str | None = None,
 ) -> dict[str, Any]:
@@ -118,6 +131,7 @@ def match_session_account(
             "reasons": [],
             "positions": [],
             "recent_orders": [],
+            "recent_positions": [],
             "collection_status": {},
         })
         if exchange == target_exchange and "same_exchange" not in item["reasons"]:
@@ -189,7 +203,9 @@ def match_session_account(
             and canonical_symbol(order.get("symbol")) == target_symbol
         ]
         if matching_orders:
-            item["recent_orders"].extend(matching_orders[:20])
+            item["recent_orders"].extend(
+                matching_orders[:MAX_RECENT_MATCHED_ORDERS]
+            )
             item["score"] += 300 + min(len(matching_orders), 10) * 20
             item["reasons"].append("recent_orders_same_symbol")
             if any(order.get("status") == "open" for order in matching_orders):
@@ -258,19 +274,46 @@ def match_session_account(
                     item["score"] += 30
                     item["reasons"].append("order_time_within_1_day")
 
+    for row in _account_rows(position_history_payload or {}):
+        account = str(row.get("account") or "")
+        exchange = str(row.get("exchange") or "").lower()
+        if not account:
+            continue
+        item = candidate(account, exchange)
+        item["collection_status"]["position_history"] = row.get("status")
+        matching_positions = [
+            position for position in (row.get("positions") or [])
+            if isinstance(position, dict)
+            and canonical_symbol(position.get("symbol")) == target_symbol
+        ]
+        if not matching_positions:
+            continue
+        item["recent_positions"].extend(matching_positions[:20])
+        item["score"] += 180 + min(len(matching_positions), 5) * 20
+        item["reasons"].append("position_history_same_symbol")
+
+        historical_sides = {
+            str(position.get("side") or "").lower()
+            for position in matching_positions
+        }
+        if simulation_side in {"long", "short"} and simulation_side in historical_sides:
+            item["score"] += 40
+            item["reasons"].append("position_history_side_matches_simulation")
+
     ranked = sorted(
         candidates.values(),
         key=lambda item: (
             int(item["score"]),
             len(item["positions"]),
             len(item["recent_orders"]),
+            len(item["recent_positions"]),
             item["account"],
         ),
         reverse=True,
     )
     evidence_candidates = [
         item for item in ranked
-        if item["positions"] or item["recent_orders"]
+        if item["positions"] or item["recent_orders"] or item["recent_positions"]
     ]
     selected = evidence_candidates[0] if evidence_candidates else None
     status = "no_match"
@@ -287,6 +330,7 @@ def match_session_account(
                 "reasons": ["user_selected_account"],
                 "positions": [],
                 "recent_orders": [],
+                "recent_positions": [],
                 "collection_status": {},
             }
         elif "user_selected_account" not in selected["reasons"]:
@@ -305,7 +349,11 @@ def match_session_account(
             confidence = "high" if top_score >= 1000 else "medium"
 
     collection_errors = []
-    for source, payload in (("positions", positions_payload), ("orders", orders_payload)):
+    for source, payload in (
+        ("positions", positions_payload),
+        ("orders", orders_payload),
+        ("position_history", position_history_payload or {}),
+    ):
         summary = payload.get("summary") if isinstance(payload, dict) else None
         if isinstance(summary, dict) and int(summary.get("failed") or 0) > 0:
             collection_errors.append({
@@ -325,11 +373,15 @@ def match_session_account(
         "collection": {
             "positions_collected_at": positions_payload.get("collected_at"),
             "orders_collected_at": orders_payload.get("collected_at"),
+            "position_history_collected_at": (
+                (position_history_payload or {}).get("collected_at")
+            ),
             "errors": collection_errors,
         },
         "rule": (
-            "No static account binding is used. Matching requires same-symbol position "
-            "or recent order evidence; exchange, side, entry price, size, and order time "
-            "refine ranking. An explicitly selected account always takes precedence."
+            "No static account binding is used. Matching requires same-symbol current "
+            "position, order, or position-history evidence from the session exchange; "
+            "side, entry price, size, and order time refine ranking. An explicitly "
+            "selected account always takes precedence."
         ),
     }

--- a/ai/scripts/dynamic_tools.py
+++ b/ai/scripts/dynamic_tools.py
@@ -14,11 +14,22 @@ from .telegram_tool import TelegramMessageTool
 class AIDynamicTools:
     """Route app-server dynamic tool calls to server-controlled handlers."""
 
-    def __init__(self, project_root: Path, *, session_registry: Any, calendar_store: Any) -> None:
+    def __init__(
+        self,
+        project_root: Path,
+        *,
+        session_registry: Any,
+        calendar_store: Any,
+        account_data_service: Any | None = None,
+    ) -> None:
         self.file_tools = RestrictedFileTools(project_root)
         self.manual_alert = ManualAlertTools(session_registry)
         self.calendar = CalendarTools(session_registry, calendar_store)
-        self.session_evaluation = SessionEvaluationTools(project_root, session_registry)
+        self.session_evaluation = SessionEvaluationTools(
+            project_root,
+            session_registry,
+            account_data_service,
+        )
         self.telegram = TelegramMessageTool()
 
     @property

--- a/ai/scripts/evidence_compare.py
+++ b/ai/scripts/evidence_compare.py
@@ -1,0 +1,776 @@
+"""Build compact, source-neutral evidence comparisons for session evaluation."""
+
+from __future__ import annotations
+
+import copy
+import math
+import re
+from typing import Any
+
+
+PRICE_RELATIVE_TOLERANCE = 0.001
+QUANTITY_SCALE_RELATIVE_TOLERANCE = 0.02
+MAX_CURRENT_POSITION_EVENTS = 60
+MAX_COMPARISON_EVENTS = 40
+MAX_SOURCE_EXCERPTS = 3
+
+
+def _number(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _relative_difference(left: Any, right: Any) -> float | None:
+    a = _number(left)
+    b = _number(right)
+    if a is None or b is None:
+        return None
+    denominator = max(abs(a), abs(b))
+    if denominator == 0:
+        return 0.0
+    return abs(a - b) / denominator
+
+
+def _timestamp_seconds(value: Any) -> int | None:
+    number = _number(value)
+    if number is None or number <= 0:
+        return None
+    if number > 10_000_000_000:
+        number /= 1000
+    return int(number)
+
+
+def _timeframe_seconds(value: Any) -> int | None:
+    match = re.fullmatch(r"\s*(\d+)\s*([smhdwSMHDW])\s*", str(value or ""))
+    if not match:
+        return None
+    amount = int(match.group(1))
+    scale = {
+        "s": 1,
+        "m": 60,
+        "h": 60 * 60,
+        "d": 24 * 60 * 60,
+        "w": 7 * 24 * 60 * 60,
+    }[match.group(2).lower()]
+    return amount * scale
+
+
+def current_position_events(
+    simulation: dict[str, Any] | None,
+    events: list[dict[str, Any]] | None,
+    *,
+    limit: int = MAX_CURRENT_POSITION_EVENTS,
+) -> dict[str, Any]:
+    simulation = simulation if isinstance(simulation, dict) else {}
+    position = simulation.get("position") or {}
+    lifecycle = simulation.get("position_lifecycle") or {}
+    direction = str(position.get("direction") or "flat").lower()
+    opened_at_ms = lifecycle.get("opened_at_ms")
+    opened_at_seconds = _timestamp_seconds(opened_at_ms)
+    rows = [copy.deepcopy(row) for row in (events or []) if isinstance(row, dict)]
+
+    if direction == "flat" or not (_number(position.get("size")) or 0):
+        return {
+            "status": "flat",
+            "opened_at_ms": None,
+            "coverage_start": None,
+            "coverage_complete": True,
+            "events": [],
+            "truncated": False,
+        }
+    if opened_at_seconds is None:
+        return {
+            "status": "unavailable",
+            "opened_at_ms": opened_at_ms,
+            "coverage_start": None,
+            "coverage_complete": False,
+            "events": [],
+            "truncated": False,
+        }
+
+    filtered = [
+        row for row in rows
+        if (_timestamp_seconds(row.get("time")) or 0) >= opened_at_seconds
+    ]
+    coverage_start = min(
+        (_timestamp_seconds(row.get("time")) for row in filtered),
+        default=None,
+    )
+    coverage_complete = coverage_start == opened_at_seconds
+    truncated = len(filtered) > limit or not coverage_complete
+    return {
+        "status": "available" if filtered else "unavailable",
+        "opened_at_ms": int(opened_at_seconds * 1000),
+        "coverage_start": coverage_start,
+        "coverage_complete": coverage_complete,
+        "events": filtered[-limit:],
+        "truncated": truncated,
+    }
+
+
+def _selected_account_position(context: dict[str, Any]) -> tuple[dict[str, Any] | None, str]:
+    account_match = context.get("account_match") or {}
+    if account_match.get("status") != "matched":
+        return None, str(account_match.get("status") or "unavailable")
+    selected = account_match.get("selected") or {}
+    positions = [
+        item for item in (selected.get("positions") or [])
+        if isinstance(item, dict)
+    ]
+    if len(positions) == 1:
+        return positions[0], "matched"
+    if not positions:
+        return None, "no_open_position"
+
+    simulation = ((context.get("strategy") or {}).get("simulation") or {})
+    direction = str((simulation.get("position") or {}).get("direction") or "").lower()
+    side_matches = [
+        item for item in positions
+        if str(item.get("side") or "").lower() == direction
+    ]
+    if len(side_matches) == 1:
+        return side_matches[0], "matched"
+    return None, "multiple_open_positions"
+
+
+def build_evidence_summary(context: dict[str, Any]) -> dict[str, Any]:
+    strategy = context.get("strategy") or {}
+    simulation = strategy.get("simulation") or {}
+    simulated = simulation.get("position") or {}
+    simulated_direction = str(simulated.get("direction") or "flat").lower()
+    simulated_size = abs(_number(simulated.get("size")) or 0.0)
+    simulated_average = _number(
+        simulated.get("aggregate_avg_price")
+        if simulated.get("aggregate_avg_price") is not None
+        else simulated.get("avg_price")
+    )
+    real, account_status = _selected_account_position(context)
+    account_match = context.get("account_match") or {}
+    selected = account_match.get("selected") or {}
+
+    sources = {
+        "strategy": {
+            "direction": simulated_direction,
+            "quantity": simulated_size,
+            "average_price": simulated_average,
+        },
+        "account": {
+            "status": account_status,
+            "account": selected.get("account"),
+            "exchange": selected.get("exchange"),
+            "direction": str((real or {}).get("side") or "flat").lower(),
+            "quantity": abs(_number((real or {}).get("quantity")) or 0.0),
+            "average_price": _number((real or {}).get("entry_price")),
+        },
+    }
+    differences: list[dict[str, Any]] = []
+    simulated_open = simulated_direction in {"long", "short"} and simulated_size > 0
+    account_open = real is not None and sources["account"]["quantity"] > 0
+
+    if account_match.get("status") != "matched":
+        return {
+            "status": "unresolved",
+            "sources": sources,
+            "observed_differences": [],
+            "diagnostic_recommended": False,
+            "reason": f"account_match_{account_match.get('status') or 'unavailable'}",
+        }
+
+    if simulated_open != account_open:
+        differences.append({
+            "field": "position.presence",
+            "strategy": simulated_open,
+            "account": account_open,
+            "material": True,
+        })
+    if simulated_open and account_open:
+        real_direction = sources["account"]["direction"]
+        if real_direction and real_direction != simulated_direction:
+            differences.append({
+                "field": "position.direction",
+                "strategy": simulated_direction,
+                "account": real_direction,
+                "material": True,
+            })
+
+        quantity_difference = _relative_difference(
+            simulated_size,
+            sources["account"]["quantity"],
+        )
+        if quantity_difference is not None and quantity_difference > 1e-9:
+            differences.append({
+                "field": "position.quantity",
+                "strategy": simulated_size,
+                "account": sources["account"]["quantity"],
+                "relative_difference": quantity_difference,
+                # Absolute quantities can use different account capital. A quantity
+                # difference is observable but requires event-scale comparison.
+                "material": False,
+            })
+
+        average_difference = _relative_difference(
+            simulated_average,
+            sources["account"]["average_price"],
+        )
+        if average_difference is not None and average_difference > 1e-9:
+            differences.append({
+                "field": "position.average_price",
+                "strategy": simulated_average,
+                "account": sources["account"]["average_price"],
+                "relative_difference": average_difference,
+                "material": average_difference > PRICE_RELATIVE_TOLERANCE,
+            })
+
+    material = any(bool(item.get("material")) for item in differences)
+    return {
+        "status": "differences_observed" if differences else "consistent",
+        "sources": sources,
+        "observed_differences": differences,
+        "diagnostic_recommended": material,
+        "reason": "material_cross_source_difference" if material else None,
+    }
+
+
+def _group_strategy_events(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    grouped: list[dict[str, Any]] = []
+    by_key: dict[tuple[Any, ...], dict[str, Any]] = {}
+    for row in rows:
+        event_type = str(row.get("type") or "")
+        if event_type not in {"trade_entry", "trade_close"}:
+            continue
+        timestamp = _timestamp_seconds(row.get("time"))
+        price = _number(row.get("price"))
+        quantity = abs(_number(row.get("size")) or 0.0)
+        if timestamp is None or price is None or quantity <= 0:
+            continue
+        action = "entry" if event_type == "trade_entry" else "reduction"
+        intent = (
+            str(row.get("id") or "") + "|" + str(row.get("comment") or "")
+            if action == "entry"
+            else str(row.get("exit_id") or row.get("comment") or "reduction")
+        )
+        key = (timestamp, action, intent, round(price, 12))
+        item = by_key.get(key)
+        if item is None:
+            item = {
+                "source": "strategy",
+                "action": action,
+                "time": timestamp,
+                "price": price,
+                "quantity": 0.0,
+                "id": row.get("id"),
+                "exit_id": row.get("exit_id"),
+                "comment": row.get("comment"),
+                "records": [],
+            }
+            by_key[key] = item
+            grouped.append(item)
+        item["quantity"] += quantity
+        item["records"].append(copy.deepcopy(row))
+    return sorted(grouped, key=lambda item: (item["time"], item["action"]))
+
+
+def _account_action(order: dict[str, Any], strategy_direction: str) -> str:
+    if order.get("reduce_only") is True:
+        return "reduction"
+    side = str(order.get("side") or "").lower()
+    if strategy_direction == "long" and side == "sell":
+        return "reduction"
+    if strategy_direction == "short" and side == "buy":
+        return "reduction"
+    return "entry"
+
+
+def _group_account_orders(
+    rows: list[dict[str, Any]],
+    strategy_direction: str,
+) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        timestamp = _timestamp_seconds(row.get("timestamp") or row.get("last_trade_timestamp"))
+        price = _number(row.get("average_price") or row.get("price"))
+        quantity_value = (
+            row.get("filled")
+            if row.get("filled") is not None
+            else row.get("amount")
+        )
+        quantity = abs(_number(quantity_value) or 0.0)
+        if timestamp is None or price is None or quantity <= 0:
+            continue
+        normalized.append({
+            "source": "account",
+            "action": _account_action(row, strategy_direction),
+            "time": timestamp,
+            "price": price,
+            "quantity": quantity,
+            "side": row.get("side"),
+            "order_ids": [row.get("id")],
+            "records": [copy.deepcopy(row)],
+        })
+    normalized.sort(key=lambda item: (item["time"], item["action"]))
+
+    grouped: list[dict[str, Any]] = []
+    for item in normalized:
+        previous = grouped[-1] if grouped else None
+        can_merge = (
+            previous is not None
+            and previous["action"] == item["action"]
+            and str(previous.get("side") or "") == str(item.get("side") or "")
+            and item["time"] - previous["time"] <= 3
+            and (_relative_difference(previous["price"], item["price"]) or 0.0) <= 0.005
+        )
+        if not can_merge:
+            grouped.append(item)
+            continue
+        total = previous["quantity"] + item["quantity"]
+        previous["price"] = (
+            previous["price"] * previous["quantity"]
+            + item["price"] * item["quantity"]
+        ) / total
+        previous["quantity"] = total
+        previous["order_ids"].extend(item["order_ids"])
+        previous["records"].extend(item["records"])
+    return grouped
+
+
+def _event_view(event: dict[str, Any]) -> dict[str, Any]:
+    keys = (
+        "source", "action", "time", "price", "quantity", "side",
+        "id", "exit_id", "comment", "order_ids",
+    )
+    return {key: copy.deepcopy(event.get(key)) for key in keys if event.get(key) is not None}
+
+
+def _source_excerpts(
+    source: dict[str, Any],
+    strategy_event: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    if not strategy_event:
+        return []
+    content = str(source.get("content") or "")
+    if not content:
+        return []
+    terms = []
+    for value in (
+        strategy_event.get("comment"),
+        strategy_event.get("exit_id"),
+        strategy_event.get("id"),
+    ):
+        term = str(value or "").strip()
+        if len(term) >= 3 and term not in terms:
+            terms.append(term)
+    lines = content.splitlines()
+    excerpts = []
+    covered: list[tuple[int, int]] = []
+    for term in terms:
+        for index, line in enumerate(lines):
+            if term not in line:
+                continue
+            start = max(0, index - 10)
+            end = min(len(lines), index + 11)
+            if any(start < old_end and end > old_start for old_start, old_end in covered):
+                continue
+            covered.append((start, end))
+            excerpts.append({
+                "source": source.get("name"),
+                "matched_term": term,
+                "start_line": start + 1,
+                "end_line": end,
+                "content": "\n".join(
+                    f"{line_number + 1}: {lines[line_number]}"
+                    for line_number in range(start, end)
+                ),
+            })
+            if len(excerpts) >= MAX_SOURCE_EXCERPTS:
+                return excerpts
+    return excerpts
+
+
+def compare_session_evidence(
+    context: dict[str, Any],
+    *,
+    max_events: int = MAX_COMPARISON_EVENTS,
+) -> dict[str, Any]:
+    strategy = context.get("strategy") or {}
+    simulation = strategy.get("simulation") or {}
+    position = simulation.get("position") or {}
+    event_summary = strategy.get("current_position_events") or current_position_events(
+        simulation,
+        strategy.get("recent_trade_events"),
+    )
+    strategy_rows = _group_strategy_events(event_summary.get("events") or [])[-max_events:]
+    account_match = context.get("account_match") or {}
+    selected = account_match.get("selected") or {}
+    account_rows = _group_account_orders(
+        [row for row in (selected.get("recent_orders") or []) if isinstance(row, dict)],
+        str(position.get("direction") or "").lower(),
+    )
+
+    lifecycle_start = _timestamp_seconds(event_summary.get("opened_at_ms"))
+    timeframe = _timeframe_seconds((context.get("session") or {}).get("timeframe"))
+    match_window = max(120, min(900, timeframe or 300))
+    if lifecycle_start is not None:
+        account_rows = [
+            row for row in account_rows
+            if row["time"] >= lifecycle_start - match_window
+        ]
+
+    insufficient: list[str] = []
+    if account_match.get("status") != "matched":
+        insufficient.append("A single account was not matched for this session snapshot.")
+    if not strategy_rows:
+        insufficient.append("No current-position strategy events were available.")
+    if event_summary.get("coverage_complete") is False:
+        insufficient.append(
+            "The retained strategy events do not cover the start of the current position."
+        )
+    if not account_rows:
+        insufficient.append("No matching account orders were available for the position lifecycle.")
+    elif (
+        lifecycle_start is not None
+        and min(row["time"] for row in account_rows) > lifecycle_start + match_window
+    ):
+        insufficient.append(
+            "The available account orders do not cover the start of the current position."
+        )
+
+    used_accounts: set[int] = set()
+    pairs: list[tuple[dict[str, Any], dict[str, Any]]] = []
+    unmatched_strategy: list[dict[str, Any]] = []
+    account_coverage_start = min((row["time"] for row in account_rows), default=None)
+    for strategy_event in strategy_rows:
+        candidates = [
+            (index, account_event)
+            for index, account_event in enumerate(account_rows)
+            if index not in used_accounts
+            and account_event["action"] == strategy_event["action"]
+            and abs(account_event["time"] - strategy_event["time"]) <= match_window
+        ]
+        if not candidates:
+            item = _event_view(strategy_event)
+            if (
+                account_coverage_start is not None
+                and strategy_event["time"] < account_coverage_start - match_window
+            ):
+                item["coverage"] = "before_available_account_orders"
+            unmatched_strategy.append(item)
+            continue
+        index, account_event = min(
+            candidates,
+            key=lambda pair: (
+                abs(pair[1]["time"] - strategy_event["time"]),
+                _relative_difference(pair[1]["price"], strategy_event["price"])
+                if _relative_difference(pair[1]["price"], strategy_event["price"]) is not None
+                else math.inf,
+            ),
+        )
+        used_accounts.add(index)
+        pairs.append((strategy_event, account_event))
+
+    unmatched_account = [
+        _event_view(row) for index, row in enumerate(account_rows)
+        if index not in used_accounts
+    ]
+    for item in unmatched_account:
+        item["classification"] = "account_only_execution"
+        item["cause_confirmed"] = False
+        item["possible_explanations"] = [
+            "manual_or_external_account_execution",
+            "missing_or_incomplete_strategy_event_history",
+            "execution_outside_the_event_matching_window",
+        ]
+        item["confirmation_needed"] = (
+            "Confirm the order origin or inspect the corresponding alert/webhook "
+            "record before attributing this execution to the strategy."
+        )
+    baseline_pair = next(
+        (
+            pair for pair in pairs
+            if pair[0]["action"] == "entry"
+            and pair[0]["quantity"] > 0
+            and pair[1]["quantity"] > 0
+        ),
+        None,
+    )
+    baseline_scale = (
+        baseline_pair[1]["quantity"] / baseline_pair[0]["quantity"]
+        if baseline_pair else None
+    )
+    if baseline_scale is None:
+        insufficient.append("A matched entry was not available to establish quantity scale.")
+
+    matched_events: list[dict[str, Any]] = []
+    divergences: list[dict[str, Any]] = []
+    for strategy_event, account_event in pairs:
+        price_difference = _relative_difference(
+            strategy_event["price"], account_event["price"]
+        )
+        quantity_scale = account_event["quantity"] / strategy_event["quantity"]
+        scale_drift = (
+            _relative_difference(quantity_scale, baseline_scale)
+            if baseline_scale is not None else None
+        )
+        differences = []
+        if price_difference is not None and price_difference > PRICE_RELATIVE_TOLERANCE:
+            differences.append({
+                "field": "event.price",
+                "relative_difference": price_difference,
+                "material": True,
+            })
+        if scale_drift is not None and scale_drift > QUANTITY_SCALE_RELATIVE_TOLERANCE:
+            differences.append({
+                "field": "event.quantity_scale",
+                "relative_difference": scale_drift,
+                "material": True,
+            })
+        item = {
+            "time": strategy_event["time"],
+            "action": strategy_event["action"],
+            "time_difference_seconds": account_event["time"] - strategy_event["time"],
+            "strategy": _event_view(strategy_event),
+            "account": _event_view(account_event),
+            "price_relative_difference": price_difference,
+            "quantity_scale": quantity_scale,
+            "quantity_scale_relative_difference": scale_drift,
+            "differences": differences,
+        }
+        matched_events.append(item)
+        if differences:
+            divergences.append({
+                "time": strategy_event["time"],
+                "kind": "matched_event_difference",
+                "comparison": item,
+                "strategy_event": strategy_event,
+            })
+
+    for item in unmatched_strategy:
+        if item.get("coverage") == "before_available_account_orders":
+            continue
+        divergences.append({
+            "time": item.get("time") or 0,
+            "kind": "unmatched_strategy_event",
+            "strategy": item,
+            "strategy_event": item,
+        })
+    for item in unmatched_account:
+        divergences.append({
+            "time": item.get("time") or 0,
+            "kind": "unmatched_account_event",
+            "account": item,
+            "strategy_event": None,
+        })
+    divergences.sort(key=lambda item: (item.get("time") or 0, item["kind"]))
+    first = divergences[0] if divergences else None
+    public_first = None
+    if first:
+        public_first = {
+            key: copy.deepcopy(value)
+            for key, value in first.items()
+            if key != "strategy_event"
+        }
+    observed_differences = [
+        {
+            key: copy.deepcopy(value)
+            for key, value in item.items()
+            if key != "strategy_event"
+        }
+        for item in divergences
+    ]
+    first_is_account_only = bool(
+        public_first
+        and public_first.get("kind") == "unmatched_account_event"
+        and (public_first.get("account") or {}).get("classification")
+        == "account_only_execution"
+    )
+
+    return {
+        "status": "compared" if pairs else "insufficient_evidence",
+        "session": copy.deepcopy(context.get("session") or {}),
+        "generation_id": (context.get("calculation") or {}).get("generation_id"),
+        "account": {
+            "status": account_match.get("status"),
+            "account": selected.get("account"),
+            "exchange": selected.get("exchange"),
+        },
+        "snapshot": build_evidence_summary(context),
+        "comparison_scope": {
+            "position_lifecycle_opened_at_ms": event_summary.get("opened_at_ms"),
+            "strategy_event_count": len(strategy_rows),
+            "account_event_count": len(account_rows),
+            "match_window_seconds": match_window,
+            "price_relative_tolerance": PRICE_RELATIVE_TOLERANCE,
+            "quantity_scale_relative_tolerance": QUANTITY_SCALE_RELATIVE_TOLERANCE,
+        },
+        "baseline_quantity_scale": baseline_scale,
+        "matched_events": matched_events,
+        "observed_differences": observed_differences,
+        "unmatched_strategy_events": unmatched_strategy,
+        "unmatched_account_events": unmatched_account,
+        "first_divergence": public_first,
+        "source_excerpts": _source_excerpts(
+            strategy.get("source") or {},
+            first.get("strategy_event") if first else None,
+        ),
+        "insufficient_evidence": list(dict.fromkeys(insufficient)),
+        "investigation_constraints": {
+            "cause_status": "unresolved" if first_is_account_only else "not_determined",
+            "strategy_source_attribution_allowed": not first_is_account_only,
+            "next_required_evidence": (
+                "order_origin_or_corresponding_alert_webhook_record"
+                if first_is_account_only else None
+            ),
+            "rule": (
+                "Stop strategy-side root-cause attribution when the earliest "
+                "divergence is an account-only execution with unknown origin."
+                if first_is_account_only else None
+            ),
+        },
+        "interpretation_rule": (
+            "This comparison reports observations and the earliest divergence only. "
+            "Treat a cause as confirmed only after the event difference is reproduced "
+            "or supported by source execution logic; otherwise report it as a hypothesis. "
+            "An account_only_execution proves only that no strategy event was matched "
+            "in the available snapshot. It may be a manual or external order and must "
+            "not be attributed to the strategy, webhook, or engine without confirming "
+            "the order origin."
+        ),
+    }
+
+
+def compact_session_context(context: dict[str, Any]) -> dict[str, Any]:
+    strategy = context.get("strategy") or {}
+    simulation = strategy.get("simulation") or {}
+    compact_simulation_keys = (
+        "position", "pnl", "trade_counts", "open_trades", "open_trade_ledger",
+        "entry_open_ledger", "position_lifecycle", "accounting", "consistency",
+        "recent_closed_trades", "active_orders", "risk", "statistics", "current_bar",
+    )
+    compact_simulation = {
+        key: copy.deepcopy(simulation.get(key))
+        for key in compact_simulation_keys
+        if key in simulation
+    }
+    market = context.get("market") or {}
+    account_match = context.get("account_match") or {}
+    selected = account_match.get("selected") or {}
+    candidates = []
+    for item in account_match.get("candidates") or []:
+        if not isinstance(item, dict):
+            continue
+        candidates.append({
+            "account": item.get("account"),
+            "exchange": item.get("exchange"),
+            "score": item.get("score"),
+            "reasons": copy.deepcopy(item.get("reasons") or []),
+            "position_count": len(item.get("positions") or []),
+            "recent_order_count": len(item.get("recent_orders") or []),
+            "recent_position_count": len(item.get("recent_positions") or []),
+            "collection_status": copy.deepcopy(item.get("collection_status") or {}),
+        })
+    compact_account_match = {
+        "status": account_match.get("status"),
+        "confidence": account_match.get("confidence"),
+        "selection_mode": account_match.get("selection_mode"),
+        "selected": {
+            "account": selected.get("account"),
+            "exchange": selected.get("exchange"),
+            "score": selected.get("score"),
+            "reasons": copy.deepcopy(selected.get("reasons") or []),
+            "positions": copy.deepcopy(selected.get("positions") or []),
+            "recent_orders": copy.deepcopy((selected.get("recent_orders") or [])[:20]),
+            "recent_positions": copy.deepcopy(
+                (selected.get("recent_positions") or [])[:10]
+            ),
+            "collection_status": copy.deepcopy(selected.get("collection_status") or {}),
+        } if selected else None,
+        "candidates": candidates,
+        "collection": copy.deepcopy(account_match.get("collection") or {}),
+        "rule": account_match.get("rule"),
+    }
+
+    def compact_series(rows: Any) -> list[dict[str, Any]]:
+        result = []
+        for item in rows or []:
+            if not isinstance(item, dict):
+                continue
+            copy_item = {key: copy.deepcopy(value) for key, value in item.items() if key != "points"}
+            copy_item["points"] = copy.deepcopy((item.get("points") or [])[-10:])
+            result.append(copy_item)
+        return result
+
+    return {
+        "schema_version": context.get("schema_version"),
+        "collected_at": context.get("collected_at"),
+        "detail_level": "compact",
+        "session": copy.deepcopy(context.get("session") or {}),
+        "calculation": copy.deepcopy(context.get("calculation") or {}),
+        "market": {
+            "confirmed_bars": copy.deepcopy((market.get("confirmed_bars") or [])[-20:]),
+            "forming_bar": copy.deepcopy(market.get("forming_bar")),
+            "quality": copy.deepcopy(market.get("quality") or {}),
+        },
+        "strategy": {
+            "source": {
+                "name": (strategy.get("source") or {}).get("name"),
+                "available": bool((strategy.get("source") or {}).get("content")),
+                "truncated": bool((strategy.get("source") or {}).get("truncated")),
+            },
+            "source_hashes": copy.deepcopy(strategy.get("source_hashes") or []),
+            "config": copy.deepcopy(strategy.get("config") or {}),
+            "inputs": copy.deepcopy(strategy.get("inputs") or []),
+            "simulation": compact_simulation,
+            "current_position_events": copy.deepcopy(
+                strategy.get("current_position_events") or {}
+            ),
+            "plots": compact_series(strategy.get("plots")),
+            "plotchars": copy.deepcopy((strategy.get("plotchars") or [])[-20:]),
+            "backgrounds": compact_series(strategy.get("backgrounds")),
+            "recent_logs": str(strategy.get("recent_logs") or "")[-4_000:],
+        },
+        "account_match": compact_account_match,
+        "evidence_summary": copy.deepcopy(context.get("evidence_summary") or {}),
+        "warnings": copy.deepcopy(context.get("warnings") or []),
+    }
+
+
+def comparison_context(context: dict[str, Any]) -> dict[str, Any]:
+    """Keep only the same-turn evidence required by the comparison tool."""
+    strategy = context.get("strategy") or {}
+    simulation = strategy.get("simulation") or {}
+    account_match = context.get("account_match") or {}
+    selected = account_match.get("selected") or {}
+    return {
+        "session": copy.deepcopy(context.get("session") or {}),
+        "calculation": {
+            "generation_id": (context.get("calculation") or {}).get("generation_id"),
+        },
+        "strategy": {
+            "source": copy.deepcopy(strategy.get("source") or {}),
+            "simulation": {
+                "position": copy.deepcopy(simulation.get("position") or {}),
+                "position_lifecycle": copy.deepcopy(
+                    simulation.get("position_lifecycle") or {}
+                ),
+            },
+            "current_position_events": copy.deepcopy(
+                strategy.get("current_position_events") or {}
+            ),
+        },
+        "account_match": {
+            "status": account_match.get("status"),
+            "confidence": account_match.get("confidence"),
+            "selection_mode": account_match.get("selection_mode"),
+            "selected": {
+                "account": selected.get("account"),
+                "exchange": selected.get("exchange"),
+                "positions": copy.deepcopy(selected.get("positions") or []),
+                "recent_orders": copy.deepcopy(selected.get("recent_orders") or []),
+            } if selected else None,
+        },
+        "evidence_summary": copy.deepcopy(context.get("evidence_summary") or {}),
+    }

--- a/ai/scripts/session_evaluation_tool.py
+++ b/ai/scripts/session_evaluation_tool.py
@@ -23,9 +23,17 @@ from data_service.evaluation_context import (
 
 from .account_match import match_session_account, resolve_account_hint
 from .asset import configured_accounts, read_provider_config
+from .evidence_compare import (
+    build_evidence_summary,
+    compact_session_context,
+    compare_session_evidence,
+    comparison_context,
+    current_position_events,
+)
 
 
 _CONTEXT_TOOL_NAME = "get_session_evaluation_context"
+_COMPARE_TOOL_NAME = "compare_session_evidence"
 _CAPTURE_TOOL_NAME = "capture_session_chart"
 _MAX_CONFIRMED_BARS = 2_000
 _DEFAULT_CONFIRMED_BARS = 500
@@ -41,9 +49,15 @@ class SessionEvaluationToolError(ValueError):
 
 
 class SessionEvaluationBridge:
-    def __init__(self, project_root: Path, registry: Any) -> None:
+    def __init__(
+        self,
+        project_root: Path,
+        registry: Any,
+        account_data_service: Any | None = None,
+    ) -> None:
         self._project_root = project_root.resolve()
         self._registry = registry
+        self._account_data_service = account_data_service
         self._loop: asyncio.AbstractEventLoop | None = None
         self._loop_thread_id: int | None = None
 
@@ -174,6 +188,7 @@ class SessionEvaluationBridge:
             account_match,
             positions_payload,
             orders_payload,
+            position_history_payload,
             explicit_account,
         ) = await self._collect_account_match(
             context,
@@ -212,6 +227,7 @@ class SessionEvaluationBridge:
                 refreshed,
                 positions_payload,
                 orders_payload,
+                position_history_payload,
                 explicit_account=explicit_account,
             )
             context = refreshed
@@ -225,12 +241,19 @@ class SessionEvaluationBridge:
             )
         elif account_match["status"] == "no_match":
             context["warnings"].append(
-                "No configured account had a same-symbol position or recent order history."
+                "No account on the session exchange had same-symbol position, order, "
+                "or position-history evidence."
             )
         if account_match["collection"]["errors"]:
             context["warnings"].append(
                 "Some account position or order-history collectors were incomplete."
             )
+        strategy = context.get("strategy") or {}
+        strategy["current_position_events"] = current_position_events(
+            strategy.get("simulation"),
+            strategy.get("recent_trade_events"),
+        )
+        context["evidence_summary"] = build_evidence_summary(context)
         return context
 
     async def _collect_account_match(
@@ -238,7 +261,13 @@ class SessionEvaluationBridge:
         context: dict[str, Any],
         *,
         account_hint: str | None,
-    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], str | None]:
+    ) -> tuple[
+        dict[str, Any],
+        dict[str, Any],
+        dict[str, Any],
+        dict[str, Any],
+        str | None,
+    ]:
         explicit_account: str | None = None
         if account_hint:
             config_path = self._project_root / "workdir" / "config" / "providers.toml"
@@ -256,13 +285,57 @@ class SessionEvaluationBridge:
         if market_type not in {"spot", "linear", "inverse"}:
             market_type = "linear" if ":" in symbol else "spot"
 
+        if self._account_data_service is not None:
+            try:
+                evidence = await self._account_data_service.session_evaluation_evidence(
+                    exchange=str(session.get("exchange") or ""),
+                    symbol=symbol,
+                    market_type=market_type,
+                    account=explicit_account,
+                )
+                positions_payload = evidence.get("positions") or {}
+                orders_payload = evidence.get("orders") or {}
+                position_history_payload = evidence.get("position_history") or {}
+                result = match_session_account(
+                    context,
+                    positions_payload,
+                    orders_payload,
+                    position_history_payload,
+                    explicit_account=explicit_account,
+                )
+                result["collection"]["source"] = evidence.get("source")
+                result["collection"]["refreshes"] = evidence.get("refreshes") or []
+                result["collection"]["account_candidates"] = (
+                    evidence.get("account_candidates") or []
+                )
+                return (
+                    result,
+                    positions_payload,
+                    orders_payload,
+                    position_history_payload,
+                    explicit_account,
+                )
+            except Exception as exc:
+                print(
+                    f"[ai] Account Center evidence unavailable: "
+                    f"{type(exc).__name__}: {str(exc)[:300]}"
+                )
+
+        exchange_args = account_args or [
+            "--exchange", str(session.get("exchange") or "")
+        ]
+        position_args = ["--symbol", symbol, *exchange_args]
+        if market_type == "inverse":
+            position_args.extend(["--account-type", "delivery"])
+        elif market_type == "linear":
+            position_args.extend(["--account-type", "swap"])
         positions_task = asyncio.create_task(self._run_account_collector(
             "position.py",
-            account_args,
+            position_args,
         ))
         orders_task = asyncio.create_task(self._run_account_collector(
             "order_history.py",
-            ["--symbol", symbol, "--market-type", market_type, *account_args],
+            ["--symbol", symbol, "--market-type", market_type, *exchange_args],
         ))
         positions_payload, orders_payload = await asyncio.gather(
             positions_task,
@@ -274,7 +347,18 @@ class SessionEvaluationBridge:
             orders_payload,
             explicit_account=explicit_account,
         )
-        return result, positions_payload, orders_payload, explicit_account
+        position_history_payload: dict[str, Any] = {
+            "results": [],
+            "summary": {"requested": 0, "succeeded": 0, "failed": 0},
+        }
+        result["collection"]["source"] = "scoped_exchange_collectors"
+        return (
+            result,
+            positions_payload,
+            orders_payload,
+            position_history_payload,
+            explicit_account,
+        )
 
     async def _run_account_collector(
         self,
@@ -419,14 +503,26 @@ class SessionEvaluationBridge:
 
 
 class SessionEvaluationTools:
-    def __init__(self, project_root: Path, registry: Any) -> None:
-        self.bridge = SessionEvaluationBridge(project_root, registry)
+    def __init__(
+        self,
+        project_root: Path,
+        registry: Any,
+        account_data_service: Any | None = None,
+    ) -> None:
+        self.bridge = SessionEvaluationBridge(
+            project_root,
+            registry,
+            account_data_service,
+        )
         self._turn_cache: OrderedDict[str, dict[str, dict[str, Any]]] = OrderedDict()
+        self._comparison_contexts: OrderedDict[str, dict[str, dict[str, Any]]] = (
+            OrderedDict()
+        )
         self._turn_cache_lock = threading.Lock()
 
     @property
     def names(self) -> set[str]:
-        return {_CONTEXT_TOOL_NAME, _CAPTURE_TOOL_NAME}
+        return {_CONTEXT_TOOL_NAME, _COMPARE_TOOL_NAME, _CAPTURE_TOOL_NAME}
 
     @property
     def specs(self) -> list[dict[str, Any]]:
@@ -441,9 +537,11 @@ class SessionEvaluationTools:
                     "ID. Then resolve exactly one returned session and call again with its ID. "
                     "When wait_for_ready is true, an in-progress pre-run is allowed to finish before "
                     "market bars, simulation state, trades, plots, source, and logs are returned. "
-                    "The exact-session call also reads configured account positions and recent "
-                    "orders. Pass account only when the user explicitly names one; otherwise the "
-                    "tool returns a deterministic evidence-based account match. Call the session "
+                    "The exact-session call reads Account Center's cached current positions, "
+                    "orders, and position history for accounts on the session exchange. Stale or "
+                    "missing cache scopes are refreshed only for that exchange and symbol. Pass "
+                    "account only when the user explicitly names one; otherwise the tool returns "
+                    "a deterministic evidence-based account match. Call the session "
                     "list at most once and each exact session at most once per user turn; repeated "
                     "calls return the first snapshot from that turn."
                 ),
@@ -474,11 +572,47 @@ class SessionEvaluationTools:
                             "minLength": 1,
                             "description": (
                                 "Human-readable configured account name explicitly supplied by "
-                                "the user, for example 'bitget sub2'. Omit it to match across all "
-                                "configured accounts from positions and recent order history."
+                                "the user, for example 'bitget sub2'. Omit it to match accounts "
+                                "on the session exchange from cached positions and history."
+                            ),
+                        },
+                        "detail_level": {
+                            "type": "string",
+                            "enum": ["standard", "compact"],
+                            "default": "standard",
+                            "description": (
+                                "Use compact only for mismatch diagnosis or verification. "
+                                "Standard preserves the normal session-evaluation response."
                             ),
                         },
                     },
+                    "additionalProperties": False,
+                },
+            },
+            {
+                "type": "function",
+                "name": _COMPARE_TOOL_NAME,
+                "description": (
+                    "Compare strategy lifecycle events with matched account orders from the "
+                    "same user-turn snapshot. Use after an exact session context when the user "
+                    "reports a mismatch, challenges a prior conclusion, requests verification, "
+                    "or evidence_summary recommends diagnostics. This tool performs no REST "
+                    "request and no strategy recalculation. It reports observations and the "
+                    "earliest divergence, not a guaranteed root cause."
+                ),
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "session_id": {"type": "string", "minLength": 1},
+                        "generation_id": {"type": "string", "minLength": 1},
+                        "max_events": {
+                            "type": "integer",
+                            "minimum": 5,
+                            "maximum": 80,
+                            "default": 40,
+                        },
+                    },
+                    "required": ["session_id", "generation_id"],
                     "additionalProperties": False,
                 },
             },
@@ -523,6 +657,7 @@ class SessionEvaluationTools:
         self.bridge.unbind_loop()
         with self._turn_cache_lock:
             self._turn_cache.clear()
+            self._comparison_contexts.clear()
 
     def handle_server_request(
         self,
@@ -549,8 +684,23 @@ class SessionEvaluationTools:
                         f"tool={tool} session={arguments.get('session_id') or 'list'}"
                     )
                     return cached
-            operation = "context" if tool == _CONTEXT_TOOL_NAME else "capture"
-            result = self.bridge.execute(operation, arguments)
+            if tool == _COMPARE_TOOL_NAME:
+                if not turn_id:
+                    raise SessionEvaluationToolError(
+                        "Evidence comparison requires a user-turn context"
+                    )
+                result = compare_session_evidence(
+                    self._comparison_context(
+                        turn_id,
+                        arguments["session_id"],
+                        arguments["generation_id"],
+                    ),
+                    max_events=arguments["max_events"],
+                )
+                operation = "compare"
+            else:
+                operation = "context" if tool == _CONTEXT_TOOL_NAME else "capture"
+                result = self.bridge.execute(operation, arguments)
             if operation == "capture":
                 image_path = Path(result.pop("image_path"))
                 image_url = "data:image/png;base64," + base64.b64encode(
@@ -563,6 +713,19 @@ class SessionEvaluationTools:
                         {"type": "inputImage", "imageUrl": image_url},
                     ],
                 }
+            elif operation == "context":
+                if turn_id and arguments.get("session_id"):
+                    self._cache_comparison_context(
+                        turn_id,
+                        arguments["session_id"],
+                        comparison_context(result),
+                    )
+                if (
+                    arguments.get("session_id")
+                    and arguments.get("detail_level") == "compact"
+                ):
+                    result = compact_session_context(result)
+                response = self._tool_response(True, result)
             else:
                 response = self._tool_response(True, result)
             if turn_id:
@@ -586,9 +749,12 @@ class SessionEvaluationTools:
     @staticmethod
     def _turn_cache_key(tool: str, arguments: dict[str, Any]) -> str:
         session_id = arguments.get("session_id") or "list"
-        if tool == _CAPTURE_TOOL_NAME:
+        if tool in {_CAPTURE_TOOL_NAME, _COMPARE_TOOL_NAME}:
             return f"{tool}:{session_id}:{arguments.get('generation_id')}"
-        return f"{tool}:{session_id}:{arguments.get('account') or 'auto'}"
+        return (
+            f"{tool}:{session_id}:{arguments.get('account') or 'auto'}:"
+            f"{arguments.get('detail_level') or 'standard'}"
+        )
 
     def _cached_response(self, turn_id: str, cache_key: str) -> dict[str, Any] | None:
         with self._turn_cache_lock:
@@ -611,19 +777,56 @@ class SessionEvaluationTools:
             while len(self._turn_cache) > _MAX_CACHED_TURNS:
                 self._turn_cache.popitem(last=False)
 
+    def _cache_comparison_context(
+        self,
+        turn_id: str,
+        session_id: str,
+        context: dict[str, Any],
+    ) -> None:
+        with self._turn_cache_lock:
+            turn = self._comparison_contexts.setdefault(turn_id, {})
+            turn[session_id] = context
+            self._comparison_contexts.move_to_end(turn_id)
+            while len(self._comparison_contexts) > _MAX_CACHED_TURNS:
+                self._comparison_contexts.popitem(last=False)
+
+    def _comparison_context(
+        self,
+        turn_id: str,
+        session_id: str,
+        generation_id: str,
+    ) -> dict[str, Any]:
+        with self._turn_cache_lock:
+            turn = self._comparison_contexts.get(turn_id)
+            context = turn.get(session_id) if turn else None
+            if context is None:
+                raise SessionEvaluationToolError(
+                    "Collect the exact session context in this user turn before comparing evidence"
+                )
+            cached_generation = (context.get("calculation") or {}).get("generation_id")
+            if cached_generation != generation_id:
+                raise SessionEvaluationToolError(
+                    "generation_id must match the exact session context from this user turn"
+                )
+            self._comparison_contexts.move_to_end(turn_id)
+            return copy.deepcopy(context)
+
     def _invalidate_session_cache(self, turn_id: str, session_id: Any) -> None:
         if not isinstance(session_id, str) or not session_id:
             return
         prefixes = (
             f"{_CONTEXT_TOOL_NAME}:{session_id}:",
+            f"{_COMPARE_TOOL_NAME}:{session_id}:",
             f"{_CAPTURE_TOOL_NAME}:{session_id}:",
         )
         with self._turn_cache_lock:
             turn = self._turn_cache.get(turn_id)
-            if turn is None:
-                return
-            for key in [key for key in turn if key.startswith(prefixes)]:
-                turn.pop(key, None)
+            if turn is not None:
+                for key in [key for key in turn if key.startswith(prefixes)]:
+                    turn.pop(key, None)
+            comparison_turn = self._comparison_contexts.get(turn_id)
+            if comparison_turn is not None:
+                comparison_turn.pop(session_id, None)
 
     @staticmethod
     def _validate(tool: str, raw_arguments: Any) -> dict[str, Any]:
@@ -636,6 +839,7 @@ class SessionEvaluationTools:
                 "confirmed_bar_limit",
                 "include_recent_logs",
                 "account",
+                "detail_level",
             }
             unexpected = sorted(set(raw_arguments) - allowed)
             if unexpected:
@@ -659,12 +863,44 @@ class SessionEvaluationTools:
                 raise SessionEvaluationToolError(
                     f"confirmed_bar_limit must be between 50 and {_MAX_CONFIRMED_BARS}"
                 )
+            detail_level = raw_arguments.get("detail_level", "standard")
+            if detail_level not in {"standard", "compact"}:
+                raise SessionEvaluationToolError(
+                    "detail_level must be either standard or compact"
+                )
             return {
                 "session_id": session_id.strip() if isinstance(session_id, str) else None,
                 "wait_for_ready": bool(raw_arguments.get("wait_for_ready", True)),
                 "confirmed_bar_limit": limit,
                 "include_recent_logs": bool(raw_arguments.get("include_recent_logs", True)),
                 "account": account.strip() if isinstance(account, str) else None,
+                "detail_level": detail_level,
+            }
+
+        if tool == _COMPARE_TOOL_NAME:
+            allowed = {"session_id", "generation_id", "max_events"}
+            unexpected = sorted(set(raw_arguments) - allowed)
+            if unexpected:
+                raise SessionEvaluationToolError(
+                    f"Unexpected argument field(s): {', '.join(unexpected)}"
+                )
+            for field in ("session_id", "generation_id"):
+                value = raw_arguments.get(field)
+                if not isinstance(value, str) or not value.strip():
+                    raise SessionEvaluationToolError(f"{field} must be a non-empty string")
+            max_events = raw_arguments.get("max_events", 40)
+            if (
+                not isinstance(max_events, int)
+                or isinstance(max_events, bool)
+                or not 5 <= max_events <= 80
+            ):
+                raise SessionEvaluationToolError(
+                    "max_events must be an integer between 5 and 80"
+                )
+            return {
+                "session_id": raw_arguments["session_id"].strip(),
+                "generation_id": raw_arguments["generation_id"].strip(),
+                "max_events": max_events,
             }
 
         allowed = {"session_id", "generation_id", "width", "height"}

--- a/ai/workflows/evaluate_position.md
+++ b/ai/workflows/evaluate_position.md
@@ -18,21 +18,39 @@ read-only evidence.
    description must be resolved. Select exactly one active session using its
    symbol, exchange, timeframe, strategy title, and script path.
 2. Call `get_session_evaluation_context` for that session with
-   `wait_for_ready=true`. Pass `account=<human-readable account>` only when the
-   user explicitly names one. If pre-run is active, wait for it instead of
-   reading a partial generation. Treat confirmed bars and the engine simulation
-   snapshot as authoritative; keep the forming bar separate. Call the session
-   list and exact-session context only once each in the user turn, then reuse
-   that snapshot unless the tool rejects its generation.
-3. When visual confirmation is useful, call `capture_session_chart` with the
+   `wait_for_ready=true`. Use `detail_level=standard` for a normal evaluation and
+   `detail_level=compact` when the user reports a mismatch, challenges an earlier
+   conclusion, or requests verification. Infer that intent from the full
+   conversation in any language rather than matching fixed phrases. Pass
+   `account=<human-readable account>` only when the user explicitly names one.
+   If pre-run is active, wait for it instead of reading a partial generation.
+   Treat confirmed bars and the engine simulation snapshot as authoritative;
+   keep the forming bar separate. Call the session list and exact-session context
+   only once each in the user turn, then reuse that snapshot unless the tool
+   rejects its generation.
+3. For a diagnostic request, or when
+   `evidence_summary.diagnostic_recommended=true`, call
+   `compare_session_evidence` with the exact session ID and generation. It uses
+   the same-turn cached account and strategy evidence and performs no new REST
+   lookup or calculation. Call it once with its default event limit. Read the
+   earliest divergence and source excerpts,
+   then try to disprove plausible causes before accepting one. Do not present
+   the comparison's first divergence as a confirmed cause without direct source
+   support, reproduction, or a second independent piece of evidence. An
+   unmatched account event is only an account-side execution; confirm whether
+   it was manual or external before attributing it to the strategy or webhook.
+   Honor `investigation_constraints`: if strategy-source attribution is not
+   allowed, stop after reporting the observation and required evidence.
+4. When visual confirmation is useful, call `capture_session_chart` with the
    exact ready generation returned by the context tool. Capture it only once in
    the user turn and reuse that image.
-4. Read `account_match` from the same context response. The server already
-   queried current positions and recent order history. A user-selected account
+5. Read `account_match` from the same context response. The server already read
+   Account Center's current positions, order history, and position history for
+   the session exchange, refreshing only stale or missing scopes. A user-selected account
    is authoritative. Without one, accept the automatic match only when status is
    `matched`; report `ambiguous` or `no_match` without guessing. Do not rerun the
    account collectors through shell.
-5. Verify that timestamps, symbols, position sides, and quantities agree across
+6. Verify that timestamps, symbols, position sides, and quantities agree across
    the collected sources. For live-risk exposure and unrealized PnL, use the
    aggregate average-cost fields. Keep the Pine FIFO fields for trade attribution
    and backtest statistics; do not treat a difference between those bases as a
@@ -41,7 +59,11 @@ read-only evidence.
    evaluation basis. Calculate continuous holding time only from
    `position_lifecycle`, and determine an entry ID's remaining quantity from
    `entry_open_ledger`, not from surviving FIFO trade rows.
-6. Evaluate exposure, trade history, drawdown/run-up, active orders, plotted
+   Before explaining a historical value supplied by the user, verify that the
+   current snapshot reproduces that value and lifecycle. If it does not, clearly
+   separate the user's historical report from the current evidence and do not
+   diagnose one from the other.
+7. Evaluate exposure, trade history, drawdown/run-up, active orders, plotted
    levels, invalidation conditions, and plausible response choices. Infer a
    strategy-specific entry stage or regime only from explicit, source-supported
    state in logs or plots. Do not use an `open_trades` entry ID as the stage:
@@ -53,6 +75,12 @@ read-only evidence.
 
 Report the observation time, factual position summary, strategy state, primary
 risks, missing evidence, and a concise evaluation. Separate facts from judgment.
+For diagnostics, separately report observed differences, the earliest divergence,
+the supported explanation or hypotheses, and unresolved evidence. If the user
+challenges a prior answer, explicitly correct it when the evidence no longer
+supports it rather than defending it by default.
+Do not rerun the strategy or use web search to replace missing historical alert,
+webhook, or order-origin evidence. State which record is needed instead.
 During collection, report only the account, exchange, or market currently being
 queried and material partial failures. Do not narrate instruction reading,
 repository exploration, workflow selection, script option checks, or plans for

--- a/data_service/account_data.py
+++ b/data_service/account_data.py
@@ -25,7 +25,10 @@ from account_service.csv_import import (
     preview_history_files,
 )
 from account_service.live_positions import run_positions_stream
-from account_service.positions import collect_positions_snapshot
+from account_service.positions import (
+    collect_positions_snapshot,
+    collect_positions_snapshot_scope,
+)
 from ai.scripts.asset import (
     ExchangeAccount,
     build_exchange,
@@ -38,6 +41,25 @@ from ws_manager import WSManager
 
 class AccountDataError(RuntimeError):
     pass
+
+
+_EVALUATION_POSITION_MAX_AGE_SECONDS = 6 * 60.0
+_EVALUATION_HISTORY_MAX_AGE_SECONDS = 35 * 60.0
+
+
+def _evaluation_position_account_type(
+    exchange: str,
+    symbol: str,
+    market_type: str,
+) -> str:
+    if market_type == "inverse":
+        return "delivery"
+    if market_type == "spot":
+        return "spot"
+    settlement = symbol.rsplit(":", 1)[1].split("-", 1)[0].upper() if ":" in symbol else ""
+    if exchange == "bitget" and settlement == "USDC":
+        return "usdc"
+    return "swap"
 
 
 def _fetch_okx_account_uid(account: ExchangeAccount) -> str:
@@ -201,6 +223,166 @@ class AccountDataService:
             output = copy.deepcopy(result)
             output["cached"] = False
             return output
+
+    async def session_evaluation_evidence(
+        self,
+        *,
+        exchange: str,
+        symbol: str,
+        market_type: str,
+        account: str | None = None,
+    ) -> dict[str, Any]:
+        """Return cache-first evidence, refreshing only stale session scope."""
+
+        normalized_exchange = exchange.strip().lower()
+        normalized_symbol = symbol.strip()
+        data = await asyncio.to_thread(read_provider_config, self.config_path)
+        candidates = [
+            item
+            for item in configured_accounts(data)
+            if item.exchange_id == normalized_exchange
+            and (account is None or item.name == account)
+        ]
+        account_names = [item.name for item in candidates]
+        cache = AccountCache(self.cache_path)
+
+        async def read_cache() -> dict[str, Any]:
+            return await asyncio.to_thread(
+                cache.session_evaluation_evidence,
+                accounts=account_names,
+                exchange=normalized_exchange,
+                symbol=normalized_symbol,
+                position_max_age_seconds=_EVALUATION_POSITION_MAX_AGE_SECONDS,
+                history_max_age_seconds=_EVALUATION_HISTORY_MAX_AGE_SECONDS,
+            )
+
+        evidence = await read_cache()
+        freshness = evidence.get("freshness") or {}
+        refreshes: list[dict[str, Any]] = []
+
+        stale_position_accounts = list(
+            (freshness.get("positions") or {}).get("stale_accounts") or []
+        )
+        if stale_position_accounts and market_type != "spot":
+            loop = asyncio.get_running_loop()
+            try:
+                snapshot = await loop.run_in_executor(
+                    self._ensure_executor(),
+                    collect_positions_snapshot_scope,
+                    str(self.config_path),
+                    normalized_exchange,
+                    tuple(stale_position_accounts),
+                    normalized_symbol,
+                    _evaluation_position_account_type(
+                        normalized_exchange,
+                        normalized_symbol,
+                        market_type,
+                    ),
+                )
+                failed_accounts = [
+                    str(row.get("account") or "")
+                    for row in snapshot.get("results", [])
+                    if isinstance(row, dict) and row.get("status") != "ok"
+                ]
+                refreshes.append({
+                    "source": "positions",
+                    "status": "ok" if not failed_accounts else "partial",
+                    "accounts": stale_position_accounts,
+                    "failed_accounts": failed_accounts,
+                })
+                fresh_rows = {
+                    str(row.get("account") or ""): row
+                    for row in snapshot.get("results", [])
+                    if isinstance(row, dict)
+                }
+                cached_rows = {
+                    str(row.get("account") or ""): row
+                    for row in evidence["positions"].get("results", [])
+                    if isinstance(row, dict)
+                }
+                cached_rows.update(fresh_rows)
+                evidence["positions"] = snapshot
+                evidence["positions"]["results"] = [
+                    cached_rows[name]
+                    for name in account_names
+                    if name in cached_rows
+                ]
+                position_results = evidence["positions"]["results"]
+                evidence["positions"]["summary"] = {
+                    "requested": len(position_results),
+                    "succeeded": sum(
+                        row.get("status") == "ok" for row in position_results
+                    ),
+                    "failed": sum(
+                        row.get("status") != "ok" for row in position_results
+                    ),
+                }
+            except Exception as exc:
+                refreshes.append({
+                    "source": "positions",
+                    "status": "error",
+                    "accounts": stale_position_accounts,
+                    "error": {"type": type(exc).__name__, "message": str(exc)[:500]},
+                })
+
+        for source, kind in (("orders", "order"), ("position_history", "position")):
+            stale_accounts = list(
+                (freshness.get(source) or {}).get("stale_accounts") or []
+            )
+            if not stale_accounts:
+                continue
+            try:
+                await self.refresh_history(
+                    kind=kind,
+                    exchange=normalized_exchange,
+                    symbol=normalized_symbol,
+                    accounts=stale_accounts,
+                )
+                refreshes.append({
+                    "source": source,
+                    "status": "ok",
+                    "accounts": stale_accounts,
+                })
+            except Exception as exc:
+                refreshes.append({
+                    "source": source,
+                    "status": "error",
+                    "accounts": stale_accounts,
+                    "error": {"type": type(exc).__name__, "message": str(exc)[:500]},
+                })
+
+        if any(item["source"] != "positions" and item["status"] == "ok" for item in refreshes):
+            refreshed = await read_cache()
+            for source in ("orders", "position_history"):
+                successful_accounts = {
+                    account_name
+                    for item in refreshes
+                    if item["source"] == source and item["status"] == "ok"
+                    for account_name in item["accounts"]
+                }
+                if not successful_accounts:
+                    continue
+                evidence[source] = refreshed[source]
+                rows = evidence[source].get("results", [])
+                for row in rows:
+                    if isinstance(row, dict) and row.get("account") in successful_accounts:
+                        row["status"] = "ok"
+                evidence[source]["summary"] = {
+                    "requested": len(rows),
+                    "succeeded": sum(
+                        isinstance(row, dict) and row.get("status") == "ok"
+                        for row in rows
+                    ),
+                    "failed": sum(
+                        not isinstance(row, dict) or row.get("status") != "ok"
+                        for row in rows
+                    ),
+                }
+
+        evidence["account_candidates"] = account_names
+        evidence["refreshes"] = refreshes
+        evidence["source"] = "account_center_cache"
+        return evidence
 
     def _sync_live_snapshot(self, snapshot: dict[str, Any]) -> None:
         input_queue = self._live_input
@@ -829,24 +1011,26 @@ class AccountDataService:
         account: str = "",
         exchange: str = "",
         symbol: str = "",
+        accounts: list[str] | None = None,
     ) -> dict[str, Any]:
         normalized_kind = kind.strip().lower()
         if normalized_kind not in {"order", "position"}:
             raise AccountDataError("history kind must be order or position")
 
         account_filter = account.strip()
-        account_names: list[str] = []
+        account_names = list(dict.fromkeys(accounts or []))
         if not account_filter:
-            try:
-                account_names = await asyncio.to_thread(
-                    AccountCache(self.cache_path).history_accounts,
-                    kind=normalized_kind,
-                    exchange=exchange,
-                    symbol=symbol,
-                )
-            except Exception as exc:
-                message = str(exc).replace("\n", " ").strip()
-                raise AccountDataError(message[:500] or type(exc).__name__) from exc
+            if not account_names:
+                try:
+                    account_names = await asyncio.to_thread(
+                        AccountCache(self.cache_path).history_accounts,
+                        kind=normalized_kind,
+                        exchange=exchange,
+                        symbol=symbol,
+                    )
+                except Exception as exc:
+                    message = str(exc).replace("\n", " ").strip()
+                    raise AccountDataError(message[:500] or type(exc).__name__) from exc
             if not account_names:
                 raise AccountDataError(
                     "no cached accounts match the selected history scope"

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -225,6 +225,7 @@ async def main() -> None:
         project_root=_PROJECT_ROOT,
         session_registry=registry,
         calendar_store=calendar_store,
+        account_data_service=account_data_service,
         startup_enabled=os.environ.get("PYNEREAL_UPDATE_AI_ENABLED") != "0",
     )
     update_shutdown = asyncio.Event()


### PR DESCRIPTION
## 변경사항
- 일반 세션 평가와 불일치 진단을 standard/compact 경로로 분리
- 동일 계산 세대와 계정 스냅샷을 재사용하는 증거 비교 도구 추가
- 전략 이벤트와 계정 주문 및 포지션 이력의 최초 불일치 탐지
- 계정 단독 실행을 전략 오류로 단정하지 않도록 진단 제한 적용
- Account Center 캐시를 우선 사용하고 세션 거래소와 심볼 범위에서만 제한적으로 갱신
- AI 평가 지침과 포지션 평가 워크플로 문서 보완

## 검증
- 로컬 SPCX 세션에서 일반 평가와 불일치 진단 흐름 반복 확인
- 계정 전체 재조회 대신 세션 범위 캐시를 사용하는 응답 흐름 확인
- 전략 계산, 차트 및 알림 경로는 변경하지 않음