### PR TITLE
Account Center 자산 전송 이력 조회 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,7 +516,16 @@ secret = "your_binance_secret"
 apiKey = "your_bitget_api_key"
 secret = "your_bitget_secret"
 password = "your_bitget_passphrase"
+
+[ccxt.hyperliquid]
+walletAddress = "0x_your_main_account_address"
 ```
+
+Hyperliquid account inspection requires only the main account's public
+`walletAddress`. PyneReal treats Hyperliquid accounts as read-only in Account
+Center and does not support wallet, Spot/Perps, or main/sub-account transfers in
+any account abstraction mode. Do not add a main-wallet private key for this
+integration.
 
 Multiple accounts on the same exchange can be configured with named account
 tables:

--- a/account_service/cache.py
+++ b/account_service/cache.py
@@ -2046,6 +2046,19 @@ class AccountCache:
                 if not all((record_account, record_exchange, transfer_id, occurred_at)):
                     continue
                 if str(record.get("source") or "native") == "native":
+                    if self._native_transfer_has_local_account_record(
+                        connection,
+                        record,
+                        account=record_account,
+                        exchange=record_exchange,
+                    ):
+                        continue
+                    self._remove_legacy_okx_transfer_key(
+                        connection,
+                        record,
+                        account=record_account,
+                        exchange=record_exchange,
+                    )
                     self._remove_matching_local_transfer(
                         connection,
                         record,
@@ -2148,6 +2161,96 @@ class AccountCache:
         except BaseException:
             connection.rollback()
             raise
+
+    @staticmethod
+    def _native_transfer_has_local_account_record(
+        connection: sqlite3.Connection,
+        record: dict[str, Any],
+        *,
+        account: str,
+        exchange: str,
+    ) -> bool:
+        payload = record.get("payload")
+        if not isinstance(payload, dict) or payload.get("transfer_kind") != "account":
+            return False
+        occurred_at = str(record.get("occurred_at") or "")
+        try:
+            occurred = datetime.fromisoformat(occurred_at.replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        start = (occurred - timedelta(minutes=5)).astimezone(UTC).isoformat().replace(
+            "+00:00", "Z"
+        )
+        end = (occurred + timedelta(minutes=5)).astimezone(UTC).isoformat().replace(
+            "+00:00", "Z"
+        )
+        candidates = connection.execute(
+            """
+            SELECT asset, amount, direction, payload_json
+            FROM transfer_history
+            WHERE account = ? AND exchange = ? AND source = 'local'
+              AND occurred_at BETWEEN ? AND ?
+            """,
+            (account, exchange, start, end),
+        ).fetchall()
+        for candidate in candidates:
+            candidate_payload = _payload_object(candidate["payload_json"])
+            if candidate_payload.get("transfer_kind") != "account":
+                continue
+            try:
+                same_amount = Decimal(str(candidate["amount"])) == Decimal(
+                    str(record.get("amount") or "0")
+                )
+            except (InvalidOperation, TypeError, ValueError):
+                same_amount = str(candidate["amount"]) == str(record.get("amount") or "")
+            if (
+                str(candidate["asset"]) == str(record.get("asset") or "")
+                and same_amount
+                and str(candidate["direction"]) == str(record.get("direction") or "")
+            ):
+                return True
+        return False
+
+    @staticmethod
+    def _remove_legacy_okx_transfer_key(
+        connection: sqlite3.Connection,
+        record: dict[str, Any],
+        *,
+        account: str,
+        exchange: str,
+    ) -> None:
+        if exchange != "okx":
+            return
+        payload = record.get("payload")
+        info = payload.get("info") if isinstance(payload, dict) else None
+        if not isinstance(info, dict):
+            return
+        bill_id = str(info.get("billId") or "")
+        legacy_id = str(info.get("transId") or "")
+        if not bill_id or not legacy_id or bill_id == legacy_id:
+            return
+        row = connection.execute(
+            """
+            SELECT payload_json
+            FROM transfer_history
+            WHERE account = ? AND exchange = 'okx' AND transfer_id = ?
+              AND source = 'native'
+            """,
+            (account, legacy_id),
+        ).fetchone()
+        if row is None:
+            return
+        legacy_payload = _payload_object(row["payload_json"])
+        legacy_info = legacy_payload.get("info")
+        if isinstance(legacy_info, dict) and str(legacy_info.get("billId") or "") == bill_id:
+            connection.execute(
+                """
+                DELETE FROM transfer_history
+                WHERE account = ? AND exchange = 'okx' AND transfer_id = ?
+                  AND source = 'native'
+                """,
+                (account, legacy_id),
+            )
 
     @staticmethod
     def _remove_matching_local_transfer(
@@ -2293,29 +2396,31 @@ class AccountCache:
                 """,
                 [*parameters, normalized_limit + 1],
             ).fetchall()
+            has_more = len(rows) > normalized_limit
+            selected = rows[:normalized_limit]
+            results: list[dict[str, Any]] = []
+            for row in selected:
+                payload = _payload_object(row["payload_json"])
+                payload.update({
+                    "account": str(row["account"]),
+                    "exchange": str(row["exchange"]),
+                    "id": str(row["transfer_id"]),
+                    "datetime": str(row["occurred_at"]),
+                    "currency": str(row["asset"]),
+                    "amount": str(row["amount"]),
+                    "direction": str(row["direction"]),
+                    "status": str(row["status"]),
+                    "source": str(row["source"]),
+                })
+                results.append(payload)
+            self._match_okx_transfer_accounts(connection, results)
+            self._match_transfer_account_ids(connection, results)
         except sqlite3.OperationalError as exc:
             if "no such table" in str(exc).lower():
                 return {"results": [], "next_cursor": None, "total": 0}
             raise
         finally:
             connection.close()
-        has_more = len(rows) > normalized_limit
-        selected = rows[:normalized_limit]
-        results: list[dict[str, Any]] = []
-        for row in selected:
-            payload = _payload_object(row["payload_json"])
-            payload.update({
-                "account": str(row["account"]),
-                "exchange": str(row["exchange"]),
-                "id": str(row["transfer_id"]),
-                "datetime": str(row["occurred_at"]),
-                "currency": str(row["asset"]),
-                "amount": str(row["amount"]),
-                "direction": str(row["direction"]),
-                "status": str(row["status"]),
-                "source": str(row["source"]),
-            })
-            results.append(payload)
         next_cursor = None
         if has_more and selected:
             last = selected[-1]
@@ -2324,6 +2429,123 @@ class AccountCache:
                 str(last["transfer_id"]),
             ])
         return {"results": results, "next_cursor": next_cursor, "total": total}
+
+    @staticmethod
+    def _match_okx_transfer_accounts(
+        connection: sqlite3.Connection,
+        results: list[dict[str, Any]],
+    ) -> None:
+        counterpart_types = {"20": "23", "21": "22", "22": "21", "23": "20"}
+        account_fields = {
+            "20": "to_account",
+            "21": "from_account",
+            "22": "to_account",
+            "23": "from_account",
+        }
+        generic_accounts = {"main_account", "sub_account"}
+        for payload in results:
+            if (
+                payload.get("exchange") != "okx"
+                or payload.get("transfer_kind") != "account"
+            ):
+                continue
+            info = payload.get("info")
+            bill_type = str(info.get("type") or "") if isinstance(info, dict) else ""
+            field = account_fields.get(bill_type)
+            if field is None or str(payload.get(field) or "") not in generic_accounts:
+                continue
+            occurred = _iso_timestamp(payload.get("datetime"))
+            if occurred is None:
+                continue
+            start = datetime.fromtimestamp(occurred - 2, UTC).isoformat().replace(
+                "+00:00", "Z"
+            )
+            end = datetime.fromtimestamp(occurred + 2, UTC).isoformat().replace(
+                "+00:00", "Z"
+            )
+            candidates = connection.execute(
+                """
+                SELECT account, amount, payload_json
+                FROM transfer_history
+                WHERE exchange = 'okx' AND account != ? AND asset = ?
+                  AND occurred_at BETWEEN ? AND ?
+                """,
+                (
+                    str(payload.get("account") or ""),
+                    str(payload.get("currency") or ""),
+                    start,
+                    end,
+                ),
+            ).fetchall()
+            matches: list[str] = []
+            for candidate in candidates:
+                candidate_payload = _payload_object(candidate["payload_json"])
+                candidate_info = candidate_payload.get("info")
+                candidate_type = (
+                    str(candidate_info.get("type") or "")
+                    if isinstance(candidate_info, dict)
+                    else ""
+                )
+                if candidate_type != counterpart_types[bill_type]:
+                    continue
+                try:
+                    same_amount = Decimal(str(candidate["amount"])) == Decimal(
+                        str(payload.get("amount") or "0")
+                    )
+                except (InvalidOperation, TypeError, ValueError):
+                    same_amount = str(candidate["amount"]) == str(
+                        payload.get("amount") or ""
+                    )
+                if same_amount:
+                    matches.append(str(candidate["account"]))
+            if len(matches) == 1:
+                payload[field] = matches[0]
+
+    @staticmethod
+    def _match_transfer_account_ids(
+        connection: sqlite3.Connection,
+        results: list[dict[str, Any]],
+    ) -> None:
+        exchanges = {
+            str(payload.get("exchange") or "")
+            for payload in results
+            if payload.get("exchange") in {
+                "binance",
+                "bitget",
+                "bybit",
+                "hyperliquid",
+            }
+        }
+        for exchange in exchanges:
+            rows = connection.execute(
+                """
+                SELECT account, direction, payload_json
+                FROM transfer_history
+                WHERE exchange = ? AND direction IN ('in', 'out')
+                """,
+                (exchange,),
+            ).fetchall()
+            accounts_by_id: dict[str, set[str]] = {}
+            for row in rows:
+                payload = _payload_object(row["payload_json"])
+                direction = str(row["direction"] or "")
+                field = "from_account" if direction == "out" else "to_account"
+                external_id = str(payload.get(field) or "").strip()
+                account_name = str(row["account"] or "").strip()
+                if external_id and account_name:
+                    accounts_by_id.setdefault(external_id, set()).add(account_name)
+            resolved = {
+                external_id: next(iter(account_names))
+                for external_id, account_names in accounts_by_id.items()
+                if len(account_names) == 1
+            }
+            for payload in results:
+                if payload.get("exchange") != exchange:
+                    continue
+                for field in ("from_account", "to_account"):
+                    external_id = str(payload.get(field) or "").strip()
+                    if external_id in resolved:
+                        payload[field] = resolved[external_id]
 
     def rows(self, table: str) -> list[dict[str, Any]]:
         if table not in {

--- a/account_service/cache.py
+++ b/account_service/cache.py
@@ -371,6 +371,31 @@ class AccountCache:
                 PRIMARY KEY (account, exchange, event_id, event_type)
             );
 
+            CREATE TABLE IF NOT EXISTS transfer_history (
+                account TEXT NOT NULL,
+                exchange TEXT NOT NULL,
+                transfer_id TEXT NOT NULL,
+                occurred_at TEXT NOT NULL,
+                asset TEXT NOT NULL DEFAULT '',
+                amount TEXT NOT NULL DEFAULT '',
+                direction TEXT NOT NULL DEFAULT 'internal',
+                status TEXT NOT NULL DEFAULT '',
+                source TEXT NOT NULL DEFAULT 'native',
+                payload_json TEXT NOT NULL,
+                PRIMARY KEY (account, exchange, transfer_id)
+            );
+
+            CREATE TABLE IF NOT EXISTS transfer_sync_status (
+                account TEXT PRIMARY KEY,
+                exchange TEXT NOT NULL,
+                status TEXT NOT NULL,
+                last_attempt_at TEXT NOT NULL,
+                last_success_at TEXT,
+                last_error TEXT,
+                warnings_json TEXT NOT NULL DEFAULT '[]',
+                updated_at TEXT NOT NULL
+            );
+
             CREATE TABLE IF NOT EXISTS account_sync_status (
                 account TEXT PRIMARY KEY,
                 exchange TEXT NOT NULL,
@@ -426,6 +451,8 @@ class AccountCache:
                 ON fills (occurred_at DESC, account);
             CREATE INDEX IF NOT EXISTS idx_pnl_events_occurred
                 ON pnl_events (occurred_at DESC, account);
+            CREATE INDEX IF NOT EXISTS idx_transfer_history_occurred
+                ON transfer_history (account, occurred_at DESC);
             CREATE INDEX IF NOT EXISTS idx_csv_imports_imported
                 ON csv_imports (imported_at DESC);
             """
@@ -1985,6 +2012,319 @@ class AccountCache:
             connection.rollback()
             raise
 
+    def apply_transfer_batch(
+        self,
+        transfers: list[dict[str, Any]],
+        *,
+        account: str,
+        exchange: str,
+        cursor: str | None = None,
+        warnings: list[str] | None = None,
+        status: str = "ok",
+        error: str = "",
+        update_sync: bool = True,
+    ) -> dict[str, Any]:
+        normalized_account = account.strip()
+        normalized_exchange = exchange.strip().lower()
+        if not normalized_account or not normalized_exchange:
+            raise ValueError("transfer account and exchange are required")
+        now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        connection = self._connect()
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            stored = 0
+            for record in transfers:
+                if not isinstance(record, dict):
+                    continue
+                payload = record.get("payload")
+                if not isinstance(payload, dict):
+                    continue
+                record_account = str(record.get("account") or "").strip()
+                record_exchange = str(record.get("exchange") or "").strip().lower()
+                transfer_id = str(record.get("transfer_id") or "").strip()
+                occurred_at = str(record.get("occurred_at") or "").strip()
+                if not all((record_account, record_exchange, transfer_id, occurred_at)):
+                    continue
+                if str(record.get("source") or "native") == "native":
+                    self._remove_matching_local_transfer(
+                        connection,
+                        record,
+                        account=record_account,
+                        exchange=record_exchange,
+                    )
+                connection.execute(
+                    """
+                    INSERT INTO transfer_history (
+                        account, exchange, transfer_id, occurred_at, asset,
+                        amount, direction, status, source, payload_json
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account, exchange, transfer_id) DO UPDATE SET
+                        occurred_at = excluded.occurred_at,
+                        asset = excluded.asset,
+                        amount = excluded.amount,
+                        direction = excluded.direction,
+                        status = excluded.status,
+                        source = excluded.source,
+                        payload_json = excluded.payload_json
+                    WHERE transfer_history.source != 'native'
+                       OR excluded.source = 'native'
+                    """,
+                    (
+                        record_account,
+                        record_exchange,
+                        transfer_id,
+                        occurred_at,
+                        str(record.get("asset") or ""),
+                        str(record.get("amount") or ""),
+                        str(record.get("direction") or "internal"),
+                        str(record.get("status") or ""),
+                        str(record.get("source") or "native"),
+                        _json(payload),
+                    ),
+                )
+                stored += 1
+            if cursor is not None:
+                connection.execute(
+                    """
+                    INSERT INTO sync_cursors (
+                        account, exchange, stream, market_scope, cursor, updated_at
+                    ) VALUES (?, ?, 'transfers', '', ?, ?)
+                    ON CONFLICT(account, exchange, stream, market_scope)
+                    DO UPDATE SET cursor = excluded.cursor, updated_at = excluded.updated_at
+                    """,
+                    (
+                        normalized_account,
+                        normalized_exchange,
+                        str(cursor),
+                        now,
+                    ),
+                )
+            if update_sync:
+                previous = connection.execute(
+                    """
+                    SELECT last_success_at
+                    FROM transfer_sync_status
+                    WHERE account = ?
+                    """,
+                    (normalized_account,),
+                ).fetchone()
+                last_success = (
+                    now
+                    if status in {"ok", "partial"}
+                    else (
+                        str(previous["last_success_at"])
+                        if previous and previous["last_success_at"]
+                        else None
+                    )
+                )
+                connection.execute(
+                    """
+                    INSERT INTO transfer_sync_status (
+                        account, exchange, status, last_attempt_at, last_success_at,
+                        last_error, warnings_json, updated_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(account) DO UPDATE SET
+                        exchange = excluded.exchange,
+                        status = excluded.status,
+                        last_attempt_at = excluded.last_attempt_at,
+                        last_success_at = excluded.last_success_at,
+                        last_error = excluded.last_error,
+                        warnings_json = excluded.warnings_json,
+                        updated_at = excluded.updated_at
+                    """,
+                    (
+                        normalized_account,
+                        normalized_exchange,
+                        status,
+                        now,
+                        last_success,
+                        error or None,
+                        _json(warnings or []),
+                        now,
+                    ),
+                )
+            connection.commit()
+            return {"status": status, "stored": stored}
+        except BaseException:
+            connection.rollback()
+            raise
+
+    @staticmethod
+    def _remove_matching_local_transfer(
+        connection: sqlite3.Connection,
+        record: dict[str, Any],
+        *,
+        account: str,
+        exchange: str,
+    ) -> None:
+        payload = record.get("payload")
+        if not isinstance(payload, dict):
+            return
+        occurred_at = str(record.get("occurred_at") or "")
+        try:
+            occurred = datetime.fromisoformat(occurred_at.replace("Z", "+00:00"))
+        except ValueError:
+            return
+        start = (occurred - timedelta(minutes=5)).astimezone(UTC).isoformat().replace(
+            "+00:00", "Z"
+        )
+        end = (occurred + timedelta(minutes=5)).astimezone(UTC).isoformat().replace(
+            "+00:00", "Z"
+        )
+        candidates = connection.execute(
+            """
+            SELECT transfer_id, asset, amount, direction, payload_json
+            FROM transfer_history
+            WHERE account = ? AND exchange = ? AND source = 'local'
+              AND occurred_at BETWEEN ? AND ?
+            """,
+            (account, exchange, start, end),
+        ).fetchall()
+
+        def matches(candidate: sqlite3.Row) -> bool:
+            candidate_payload = _payload_object(candidate["payload_json"])
+            try:
+                same_amount = Decimal(str(candidate["amount"])) == Decimal(
+                    str(record.get("amount") or "0")
+                )
+            except (InvalidOperation, TypeError, ValueError):
+                same_amount = str(candidate["amount"]) == str(record.get("amount") or "")
+            return (
+                str(candidate["asset"]) == str(record.get("asset") or "")
+                and same_amount
+                and str(candidate["direction"]) == str(record.get("direction") or "")
+                and str(candidate_payload.get("from_account_type") or "")
+                == str(payload.get("from_account_type") or "")
+                and str(candidate_payload.get("to_account_type") or "")
+                == str(payload.get("to_account_type") or "")
+            )
+
+        matching_ids = [str(row["transfer_id"]) for row in candidates if matches(row)]
+        if len(matching_ids) == 1 and matching_ids[0] != str(record.get("transfer_id") or ""):
+            connection.execute(
+                """
+                DELETE FROM transfer_history
+                WHERE account = ? AND exchange = ? AND transfer_id = ? AND source = 'local'
+                """,
+                (account, exchange, matching_ids[0]),
+            )
+
+    def transfer_sync_state(self, account: str, exchange: str) -> dict[str, Any]:
+        connection = self._read_connection()
+        if connection is None:
+            return {}
+        try:
+            row = connection.execute(
+                """
+                SELECT status, last_attempt_at, last_success_at, last_error,
+                       warnings_json, updated_at
+                FROM transfer_sync_status
+                WHERE account = ? AND exchange = ?
+                """,
+                (account.strip(), exchange.strip().lower()),
+            ).fetchone()
+            cursor = connection.execute(
+                """
+                SELECT cursor, updated_at
+                FROM sync_cursors
+                WHERE account = ? AND exchange = ?
+                  AND stream = 'transfers' AND market_scope = ''
+                """,
+                (account.strip(), exchange.strip().lower()),
+            ).fetchone()
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return {}
+            raise
+        finally:
+            connection.close()
+        if row is None:
+            return {}
+        try:
+            warnings = json.loads(str(row["warnings_json"] or "[]"))
+        except json.JSONDecodeError:
+            warnings = []
+        return {
+            "status": str(row["status"] or ""),
+            "last_attempt_at": row["last_attempt_at"],
+            "last_success_at": row["last_success_at"],
+            "last_error": row["last_error"],
+            "warnings": warnings if isinstance(warnings, list) else [],
+            "cursor": str(cursor["cursor"] or "") if cursor else "",
+            "cursor_updated_at": cursor["updated_at"] if cursor else None,
+        }
+
+    def transfer_history_page(
+        self,
+        *,
+        account: str,
+        exchange: str,
+        cursor: str | None = None,
+        limit: int = 50,
+    ) -> dict[str, Any]:
+        normalized_limit = _page_limit(limit)
+        decoded_cursor = _decode_cursor(cursor, 2)
+        connection = self._read_connection()
+        if connection is None:
+            return {"results": [], "next_cursor": None, "total": 0}
+        clauses = ["account = ?", "exchange = ?"]
+        parameters: list[Any] = [account.strip(), exchange.strip().lower()]
+        if decoded_cursor is not None:
+            occurred_at, transfer_id = decoded_cursor
+            if not isinstance(occurred_at, str) or not isinstance(transfer_id, str):
+                connection.close()
+                raise ValueError("invalid history cursor")
+            clauses.append("(occurred_at < ? OR (occurred_at = ? AND transfer_id < ?))")
+            parameters.extend([occurred_at, occurred_at, transfer_id])
+        where = " AND ".join(clauses)
+        try:
+            total = int(connection.execute(
+                "SELECT COUNT(*) FROM transfer_history WHERE account = ? AND exchange = ?",
+                (account.strip(), exchange.strip().lower()),
+            ).fetchone()[0])
+            rows = connection.execute(
+                f"""
+                SELECT account, exchange, transfer_id, occurred_at, asset,
+                       amount, direction, status, source, payload_json
+                FROM transfer_history
+                WHERE {where}
+                ORDER BY occurred_at DESC, transfer_id DESC
+                LIMIT ?
+                """,
+                [*parameters, normalized_limit + 1],
+            ).fetchall()
+        except sqlite3.OperationalError as exc:
+            if "no such table" in str(exc).lower():
+                return {"results": [], "next_cursor": None, "total": 0}
+            raise
+        finally:
+            connection.close()
+        has_more = len(rows) > normalized_limit
+        selected = rows[:normalized_limit]
+        results: list[dict[str, Any]] = []
+        for row in selected:
+            payload = _payload_object(row["payload_json"])
+            payload.update({
+                "account": str(row["account"]),
+                "exchange": str(row["exchange"]),
+                "id": str(row["transfer_id"]),
+                "datetime": str(row["occurred_at"]),
+                "currency": str(row["asset"]),
+                "amount": str(row["amount"]),
+                "direction": str(row["direction"]),
+                "status": str(row["status"]),
+                "source": str(row["source"]),
+            })
+            results.append(payload)
+        next_cursor = None
+        if has_more and selected:
+            last = selected[-1]
+            next_cursor = _encode_cursor([
+                str(last["occurred_at"]),
+                str(last["transfer_id"]),
+            ])
+        return {"results": results, "next_cursor": next_cursor, "total": total}
+
     def rows(self, table: str) -> list[dict[str, Any]]:
         if table not in {
             "current_positions",
@@ -1992,6 +2332,8 @@ class AccountCache:
             "orders",
             "fills",
             "pnl_events",
+            "transfer_history",
+            "transfer_sync_status",
             "account_sync_status",
             "csv_imports",
         }:

--- a/account_service/live_positions.py
+++ b/account_service/live_positions.py
@@ -57,6 +57,11 @@ from account_service.history import (  # noqa: E402
     okx_history_market_scope,
 )
 from account_service.positions import collect_positions_snapshot  # noqa: E402
+from account_service.transfers import (  # noqa: E402
+    TRANSFER_INITIAL_DAYS,
+    TRANSFER_REFRESH_OVERLAP_MS,
+    collect_transfer_history,
+)
 from data_service.schedule_utils import (  # noqa: E402
     seconds_until_manual_refresh_guard_end,
     seconds_until_post_bar_task_window,
@@ -1273,6 +1278,151 @@ async def _put_control_message(output_queue: Any, payload: dict[str, Any]) -> No
         pass
 
 
+async def _refresh_transfers_from_parent(
+    request: dict[str, Any],
+    *,
+    accounts: list[ExchangeAccount],
+    cursors: dict[tuple[str, str, str, str], str],
+    backfill_semaphore: asyncio.Semaphore,
+    backfill_locks: dict[str, asyncio.Lock],
+    cache: AccountCache,
+    cache_executor: ThreadPoolExecutor,
+    stop: asyncio.Event,
+) -> dict[str, Any]:
+    account_name = str(request.get("account") or "").strip()
+    exchange_id = str(request.get("exchange") or "").strip().lower()
+    account = next(
+        (
+            item
+            for item in accounts
+            if item.name == account_name and item.exchange_id == exchange_id
+        ),
+        None,
+    )
+    if account is None:
+        raise ValueError("configured transfer account was not found")
+    if exchange_id not in TRANSFER_INITIAL_DAYS:
+        raise ValueError(f"transfer history is not supported for {exchange_id}")
+
+    now_ms = int(time.time() * 1000)
+    cursor_key = (account.name, exchange_id, "transfers", "")
+    previous_cursor = cursors.get(cursor_key, "")
+    try:
+        previous_ms = int(previous_cursor)
+    except (TypeError, ValueError):
+        previous_ms = 0
+    initial_since = now_ms - TRANSFER_INITIAL_DAYS[exchange_id] * 24 * 60 * 60 * 1000
+    since_ms = max(
+        initial_since,
+        previous_ms - TRANSFER_REFRESH_OVERLAP_MS if previous_ms else initial_since,
+    )
+    assets = request.get("assets")
+    assets = assets if isinstance(assets, list) else []
+    account_types = request.get("account_types")
+    account_types = account_types if isinstance(account_types, list) else []
+
+    try:
+        async with backfill_semaphore:
+            async with backfill_locks[account.name]:
+                result = await asyncio.to_thread(
+                    collect_transfer_history,
+                    account,
+                    since_ms=since_ms,
+                    until_ms=now_ms,
+                    asset_hints=assets,
+                    account_type_hints=account_types,
+                )
+                post_bar_delay = seconds_until_manual_refresh_guard_end()
+                if post_bar_delay > 0.0:
+                    try:
+                        await asyncio.wait_for(stop.wait(), timeout=post_bar_delay)
+                        raise asyncio.CancelledError
+                    except TimeoutError:
+                        pass
+                status = "partial" if result.get("partial") else "ok"
+                await asyncio.get_running_loop().run_in_executor(
+                    cache_executor,
+                    partial(
+                        cache.apply_transfer_batch,
+                        result.get("records") or [],
+                        account=account.name,
+                        exchange=exchange_id,
+                        cursor=str(now_ms),
+                        warnings=result.get("warnings") or [],
+                        status=status,
+                    ),
+                )
+                cursors[cursor_key] = str(now_ms)
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        message = redact_error(exc, secret_values(account.config))
+        post_bar_delay = seconds_until_manual_refresh_guard_end()
+        if post_bar_delay > 0.0:
+            try:
+                await asyncio.wait_for(stop.wait(), timeout=post_bar_delay)
+                raise asyncio.CancelledError
+            except TimeoutError:
+                pass
+        await asyncio.get_running_loop().run_in_executor(
+            cache_executor,
+            partial(
+                cache.apply_transfer_batch,
+                [],
+                account=account.name,
+                exchange=exchange_id,
+                status="error",
+                error=str(message)[:500],
+            ),
+        )
+        raise RuntimeError(str(message)[:500] or type(exc).__name__) from exc
+    return {
+        "status": "ok",
+        "account": account.name,
+        "exchange": exchange_id,
+        "records": len(result.get("records") or []),
+        "partial": bool(result.get("partial")),
+        "warnings": result.get("warnings") or [],
+    }
+
+
+async def _record_transfer_from_parent(
+    request: dict[str, Any],
+    *,
+    cache: AccountCache,
+    cache_executor: ThreadPoolExecutor,
+) -> dict[str, Any]:
+    records = request.get("records")
+    records = records if isinstance(records, list) else []
+    if not records:
+        return {"status": "ok", "stored": 0}
+    grouped: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    for record in records:
+        if not isinstance(record, dict):
+            continue
+        key = (
+            str(record.get("account") or "").strip(),
+            str(record.get("exchange") or "").strip().lower(),
+        )
+        if all(key):
+            grouped.setdefault(key, []).append(record)
+    stored = 0
+    loop = asyncio.get_running_loop()
+    for (account, exchange), account_records in grouped.items():
+        result = await loop.run_in_executor(
+            cache_executor,
+            partial(
+                cache.apply_transfer_batch,
+                account_records,
+                account=account,
+                exchange=exchange,
+                update_sync=False,
+            ),
+        )
+        stored += int(result.get("stored") or 0)
+    return {"status": "ok", "stored": stored}
+
+
 async def _import_history_from_parent(
     request: dict[str, Any],
     *,
@@ -1514,6 +1664,59 @@ async def _apply_parent_messages(
         except queue.Empty:
             continue
         if not isinstance(message, dict):
+            continue
+        if message.get("type") == "transfer.refresh":
+            request_id = str(message.get("request_id") or "")
+            try:
+                result = await _refresh_transfers_from_parent(
+                    message,
+                    accounts=accounts,
+                    cursors=cursors,
+                    backfill_semaphore=backfill_semaphore,
+                    backfill_locks=backfill_locks,
+                    cache=cache,
+                    cache_executor=cache_executor,
+                    stop=stop,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                result = {
+                    "status": "error",
+                    "error": {
+                        "type": type(exc).__name__,
+                        "message": str(exc).replace("\n", " ")[:500],
+                    },
+                }
+            await _put_control_message(control_output_queue, {
+                "type": "transfer.refresh.result",
+                "request_id": request_id,
+                "payload": result,
+            })
+            continue
+        if message.get("type") == "transfer.record":
+            request_id = str(message.get("request_id") or "")
+            try:
+                result = await _record_transfer_from_parent(
+                    message,
+                    cache=cache,
+                    cache_executor=cache_executor,
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                result = {
+                    "status": "error",
+                    "error": {
+                        "type": type(exc).__name__,
+                        "message": str(exc).replace("\n", " ")[:500],
+                    },
+                }
+            await _put_control_message(control_output_queue, {
+                "type": "transfer.record.result",
+                "request_id": request_id,
+                "payload": result,
+            })
             continue
         if message.get("type") == "history.refresh":
             request_id = str(message.get("request_id") or "")

--- a/account_service/transfers.py
+++ b/account_service/transfers.py
@@ -1,0 +1,858 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from datetime import UTC, datetime
+from decimal import Decimal, InvalidOperation
+from typing import Any, Callable
+
+import ccxt
+
+from ai.scripts.asset import (
+    ExchangeAccount,
+    build_exchange,
+    redact_error,
+    secret_values,
+)
+
+
+TRANSFER_INITIAL_DAYS = {
+    "binance": 180,
+    "bitget": 90,
+    "bybit": 90,
+    "okx": 90,
+    "hyperliquid": 365,
+}
+TRANSFER_REFRESH_OVERLAP_MS = 24 * 60 * 60 * 1000
+TRANSFER_CACHE_TTL_SECONDS = 30 * 60
+
+_BINANCE_ROUTES = {
+    "MAIN_UMFUTURE": ("spot", "swap"),
+    "MAIN_MARGIN": ("spot", "margin"),
+    "MAIN_FUNDING": ("spot", "funding"),
+    "UMFUTURE_MAIN": ("swap", "spot"),
+    "UMFUTURE_MARGIN": ("swap", "margin"),
+    "UMFUTURE_FUNDING": ("swap", "funding"),
+    "MARGIN_MAIN": ("margin", "spot"),
+    "MARGIN_UMFUTURE": ("margin", "swap"),
+    "MARGIN_FUNDING": ("margin", "funding"),
+    "FUNDING_MAIN": ("funding", "spot"),
+    "FUNDING_UMFUTURE": ("funding", "swap"),
+    "FUNDING_MARGIN": ("funding", "margin"),
+}
+_BINANCE_ACCOUNT_TYPES = {
+    "SPOT": "spot",
+    "USDT_FUTURE": "swap",
+    "USDT_FUTURES": "swap",
+    "MARGIN": "margin",
+    "FUNDING": "funding",
+}
+_BITGET_ACCOUNT_TYPES = {
+    "spot": "spot",
+    "p2p": "funding",
+    "usdt_futures": "swap",
+    "usdc_futures": "swap",
+    "coin_futures": "swap",
+    "crossed_margin": "margin",
+    "isolated_margin": "margin",
+    "uta": "swap",
+    "unified": "swap",
+}
+_BITGET_FROM_TYPES = {
+    "spot": "spot",
+    "swap": "usdt_futures",
+    "margin": "crossed_margin",
+    "funding": "p2p",
+}
+_BYBIT_ACCOUNT_TYPES = {
+    "SPOT": "spot",
+    "UNIFIED": "swap",
+    "CONTRACT": "swap",
+    "OPTION": "swap",
+    "FUND": "funding",
+    "INVESTMENT": "funding",
+}
+_OKX_ACCOUNT_TYPES = {
+    "6": "funding",
+    "18": "spot",
+}
+_NETWORK_ERRORS = (
+    ccxt.NetworkError,
+    ccxt.RequestTimeout,
+    ccxt.ExchangeNotAvailable,
+)
+
+
+def utc_now() -> str:
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _iso_time(value: Any) -> str:
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            return parsed.astimezone(UTC).isoformat().replace("+00:00", "Z")
+        except ValueError:
+            pass
+    try:
+        milliseconds = int(float(value))
+    except (TypeError, ValueError, OverflowError):
+        return utc_now()
+    if abs(milliseconds) < 10_000_000_000:
+        milliseconds *= 1000
+    try:
+        return (
+            datetime.fromtimestamp(milliseconds / 1000, UTC)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    except (OSError, OverflowError, ValueError):
+        return utc_now()
+
+
+def _decimal_text(value: Any) -> str:
+    try:
+        amount = abs(Decimal(str(value)))
+    except (InvalidOperation, TypeError, ValueError):
+        return "0"
+    if not amount.is_finite():
+        return "0"
+    text = format(amount, "f")
+    normalized = text.rstrip("0").rstrip(".") if "." in text else text
+    return normalized or "0"
+
+
+def _rows(response: Any, *keys: str) -> list[dict[str, Any]]:
+    value = response
+    for _ in range(4):
+        if isinstance(value, list):
+            return [item for item in value if isinstance(item, dict)]
+        if not isinstance(value, dict):
+            return []
+        candidate = next(
+            (
+                value.get(key)
+                for key in (*keys, "data", "result", "rows", "list")
+                if isinstance(value.get(key), (dict, list))
+            ),
+            None,
+        )
+        if candidate is None:
+            return []
+        value = candidate
+    return [item for item in value if isinstance(item, dict)] if isinstance(value, list) else []
+
+
+def _stable_id(prefix: str, values: list[Any]) -> str:
+    encoded = json.dumps(values, ensure_ascii=True, separators=(",", ":"), default=str)
+    return f"{prefix}:{hashlib.sha256(encoded.encode('utf-8')).hexdigest()[:32]}"
+
+
+def _record(
+    account: str,
+    exchange: str,
+    transfer_id: Any,
+    *,
+    asset: Any,
+    amount: Any,
+    occurred_at: Any,
+    from_type: Any,
+    to_type: Any,
+    status: Any = "success",
+    direction: str = "internal",
+    from_account: Any = "",
+    to_account: Any = "",
+    client_id: Any = "",
+    source: str = "native",
+    info: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    occurred = _iso_time(occurred_at)
+    currency = str(asset or "").strip().upper() or "UNKNOWN"
+    normalized_amount = _decimal_text(amount)
+    identifier = str(transfer_id or "").strip() or _stable_id(
+        exchange,
+        [
+            account,
+            occurred,
+            currency,
+            normalized_amount,
+            from_type,
+            to_type,
+            from_account,
+            to_account,
+        ],
+    )
+    payload = {
+        "id": identifier,
+        "client_id": str(client_id or ""),
+        "timestamp": int(datetime.fromisoformat(occurred.replace("Z", "+00:00")).timestamp() * 1000),
+        "datetime": occurred,
+        "currency": currency,
+        "amount": normalized_amount,
+        "direction": direction,
+        "from_account": str(from_account or account),
+        "to_account": str(to_account or account),
+        "from_account_type": str(from_type or "").strip().lower(),
+        "to_account_type": str(to_type or "").strip().lower(),
+        "status": str(status or "unknown").strip().lower(),
+        "source": source,
+    }
+    if info:
+        payload["info"] = info
+    return {
+        "account": account,
+        "exchange": exchange,
+        "transfer_id": identifier,
+        "occurred_at": occurred,
+        "asset": currency,
+        "amount": normalized_amount,
+        "direction": direction,
+        "status": payload["status"],
+        "source": source,
+        "payload": payload,
+    }
+
+
+def _request(callback: Callable[[], Any]) -> Any:
+    for attempt in range(2):
+        try:
+            return callback()
+        except _NETWORK_ERRORS:
+            if attempt:
+                raise
+            time.sleep(1.0)
+    raise RuntimeError("unreachable")
+
+
+def _deduplicate(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduplicated: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for record in records:
+        key = (
+            str(record.get("account") or ""),
+            str(record.get("exchange") or ""),
+            str(record.get("transfer_id") or ""),
+        )
+        deduplicated[key] = record
+    return sorted(
+        deduplicated.values(),
+        key=lambda item: str(item.get("occurred_at") or ""),
+        reverse=True,
+    )
+
+
+def _append_warning(warnings: list[str], exchange: str, exc: Exception, secrets: list[str]) -> None:
+    message = redact_error(exc, secrets).replace("\n", " ").strip()
+    warning = f"{exchange} transfer history is partial: {message[:300] or type(exc).__name__}"
+    if warning not in warnings:
+        warnings.append(warning)
+
+
+def _collect_binance(
+    exchange: ccxt.Exchange,
+    account: ExchangeAccount,
+    since_ms: int,
+    until_ms: int,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    secrets = secret_values(account.config)
+    for transfer_type, (source, destination) in _BINANCE_ROUTES.items():
+        try:
+            page = 1
+            while page <= 20:
+                response = _request(lambda page=page, transfer_type=transfer_type: (
+                    exchange.sapiGetAssetTransfer({
+                        "type": transfer_type,
+                        "startTime": since_ms,
+                        "endTime": until_ms,
+                        "current": page,
+                        "size": 100,
+                    })
+                ))
+                items = _rows(response, "rows")
+                for item in items:
+                    records.append(_record(
+                        account.name,
+                        "binance",
+                        item.get("tranId"),
+                        asset=item.get("asset"),
+                        amount=item.get("amount"),
+                        occurred_at=item.get("timestamp"),
+                        from_type=source,
+                        to_type=destination,
+                        status=item.get("status"),
+                        info=item,
+                    ))
+                total = int(response.get("total") or 0) if isinstance(response, dict) else 0
+                if len(items) < 100 or page * 100 >= total:
+                    break
+                page += 1
+        except Exception as exc:
+            _append_warning(warnings, "Binance", exc, secrets)
+            break
+
+    if account.name not in {"binance", "binance_main"}:
+        return records
+    try:
+        window_start = since_ms
+        window_ms = 29 * 24 * 60 * 60 * 1000
+        while window_start <= until_ms:
+            window_end = min(until_ms, window_start + window_ms)
+            page = 1
+            while page <= 20:
+                response = _request(lambda page=page, start=window_start, end=window_end: (
+                    exchange.sapiGetSubAccountUniversalTransfer({
+                        "startTime": start,
+                        "endTime": end,
+                        "page": page,
+                        "limit": 500,
+                    })
+                ))
+                items = _rows(response, "result")
+                for item in items:
+                    from_email = str(item.get("fromEmail") or account.name)
+                    to_email = str(item.get("toEmail") or account.name)
+                    from_type = _BINANCE_ACCOUNT_TYPES.get(
+                        str(item.get("fromAccountType") or "").upper(),
+                        str(item.get("fromAccountType") or "").lower(),
+                    )
+                    to_type = _BINANCE_ACCOUNT_TYPES.get(
+                        str(item.get("toAccountType") or "").upper(),
+                        str(item.get("toAccountType") or "").lower(),
+                    )
+                    direction = "out"
+                    records.append(_record(
+                        account.name,
+                        "binance",
+                        item.get("tranId"),
+                        asset=item.get("asset"),
+                        amount=item.get("qty") or item.get("amount"),
+                        occurred_at=item.get("time") or item.get("timestamp"),
+                        from_type=from_type,
+                        to_type=to_type,
+                        status=item.get("status"),
+                        direction=direction,
+                        from_account=from_email,
+                        to_account=to_email,
+                        client_id=item.get("clientTranId"),
+                        info=item,
+                    ))
+                if len(items) < 500:
+                    break
+                page += 1
+            window_start = window_end + 1
+    except Exception as exc:
+        _append_warning(warnings, "Binance account transfer", exc, secrets)
+    return records
+
+
+def _collect_bitget(
+    exchange: ccxt.Exchange,
+    account: ExchangeAccount,
+    since_ms: int,
+    until_ms: int,
+    asset_hints: list[str],
+    account_type_hints: list[str],
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    secrets = secret_values(account.config)
+    currencies = list(dict.fromkeys([
+        *[str(value).upper() for value in asset_hints if value],
+        "USDT",
+        "USDC",
+    ]))[:20]
+    source_types = list(dict.fromkeys(
+        _BITGET_FROM_TYPES[value]
+        for value in account_type_hints
+        if value in _BITGET_FROM_TYPES
+    )) or ["spot", "usdt_futures", "crossed_margin", "p2p"]
+    try:
+        for currency in currencies:
+            for source_type in source_types:
+                older_than = ""
+                for _ in range(10):
+                    params: dict[str, Any] = {
+                        "coin": currency,
+                        "fromType": source_type,
+                        "startTime": since_ms,
+                        "endTime": until_ms,
+                        "limit": 500,
+                    }
+                    if older_than:
+                        params["idLessThan"] = older_than
+                    response = _request(
+                        lambda params=params: exchange.privateSpotGetV2SpotAccountTransferRecords(params)
+                    )
+                    items = _rows(response, "data")
+                    for item in items:
+                        records.append(_record(
+                            account.name,
+                            "bitget",
+                            item.get("transferId") or item.get("newTransferId"),
+                            asset=item.get("coin"),
+                            amount=item.get("size") or item.get("amount"),
+                            occurred_at=item.get("ts") or item.get("createdTime"),
+                            from_type=_BITGET_ACCOUNT_TYPES.get(
+                                str(item.get("fromType") or "").lower(),
+                                item.get("fromType"),
+                            ),
+                            to_type=_BITGET_ACCOUNT_TYPES.get(
+                                str(item.get("toType") or "").lower(),
+                                item.get("toType"),
+                            ),
+                            status=item.get("status"),
+                            client_id=item.get("clientOid"),
+                            info=item,
+                        ))
+                    if len(items) < 500:
+                        break
+                    older_than = str(items[-1].get("transferId") or "")
+                    if not older_than:
+                        break
+    except Exception as exc:
+        _append_warning(warnings, "Bitget", exc, secrets)
+
+    for role, direction in (("initiator", "out"), ("receiver", "in")):
+        try:
+            older_than = ""
+            for _ in range(10):
+                params = {
+                    "role": role,
+                    "startTime": since_ms,
+                    "endTime": until_ms,
+                    "limit": 100,
+                }
+                if older_than:
+                    params["idLessThan"] = older_than
+                response = _request(lambda params=params: exchange.request(
+                    "v2/spot/account/sub-main-trans-record",
+                    ["private", "spot"],
+                    "GET",
+                    params,
+                ))
+                items = _rows(response, "list")
+                for item in items:
+                    records.append(_record(
+                        account.name,
+                        "bitget",
+                        item.get("newTransferId") or item.get("transferId"),
+                        asset=item.get("coin"),
+                        amount=item.get("size") or item.get("amount"),
+                        occurred_at=item.get("ts") or item.get("createdTime"),
+                        from_type=_BITGET_ACCOUNT_TYPES.get(
+                            str(item.get("fromType") or "").lower(),
+                            item.get("fromType"),
+                        ),
+                        to_type=_BITGET_ACCOUNT_TYPES.get(
+                            str(item.get("toType") or "").lower(),
+                            item.get("toType"),
+                        ),
+                        status=item.get("status"),
+                        direction=direction,
+                        from_account=item.get("fromUserId"),
+                        to_account=item.get("toUserId"),
+                        client_id=item.get("clientOid"),
+                        info=item,
+                    ))
+                next_older_than = str(
+                    items[-1].get("transferId") or items[-1].get("newTransferId") or ""
+                ) if items else ""
+                if (
+                    len(items) < 100
+                    or not next_older_than
+                    or next_older_than == older_than
+                ):
+                    break
+                older_than = next_older_than
+        except Exception as exc:
+            _append_warning(warnings, "Bitget account transfer", exc, secrets)
+            break
+    return records
+
+
+def _bybit_pages(
+    exchange: ccxt.Exchange,
+    method: Callable[[dict[str, Any]], Any],
+    since_ms: int,
+    until_ms: int,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    window_ms = 7 * 24 * 60 * 60 * 1000
+    start = since_ms
+    while start <= until_ms:
+        end = min(until_ms, start + window_ms - 1000)
+        cursor = ""
+        for _ in range(20):
+            params: dict[str, Any] = {
+                "startTime": start,
+                "endTime": end,
+                "limit": 50,
+            }
+            if cursor:
+                params["cursor"] = cursor
+            response = _request(lambda params=params: method(params))
+            items = _rows(response, "list")
+            records.extend(items)
+            result = response.get("result", {}) if isinstance(response, dict) else {}
+            next_cursor = str(result.get("nextPageCursor") or "") if isinstance(result, dict) else ""
+            if len(items) < 50 or not next_cursor or next_cursor == cursor:
+                break
+            cursor = next_cursor
+        start = end + 1000
+    return records
+
+
+def _collect_bybit(
+    exchange: ccxt.Exchange,
+    account: ExchangeAccount,
+    since_ms: int,
+    until_ms: int,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    secrets = secret_values(account.config)
+    own_uid = str(account.config.get("uid") or "")
+    if not own_uid:
+        try:
+            response = _request(lambda: exchange.privateGetV5UserQueryApi({}))
+            data = response.get("result", {}) if isinstance(response, dict) else {}
+            own_uid = str(data.get("userID") or data.get("userId") or "")
+        except Exception:
+            own_uid = ""
+    try:
+        for item in _bybit_pages(
+            exchange,
+            exchange.privateGetV5AssetTransferQueryInterTransferList,
+            since_ms,
+            until_ms,
+        ):
+            records.append(_record(
+                account.name,
+                "bybit",
+                item.get("transferId"),
+                asset=item.get("coin"),
+                amount=item.get("amount"),
+                occurred_at=item.get("timestamp"),
+                from_type=_BYBIT_ACCOUNT_TYPES.get(
+                    str(item.get("fromAccountType") or "").upper(),
+                    item.get("fromAccountType"),
+                ),
+                to_type=_BYBIT_ACCOUNT_TYPES.get(
+                    str(item.get("toAccountType") or "").upper(),
+                    item.get("toAccountType"),
+                ),
+                status=item.get("status"),
+                info=item,
+            ))
+    except Exception as exc:
+        _append_warning(warnings, "Bybit", exc, secrets)
+    try:
+        for item in _bybit_pages(
+            exchange,
+            exchange.privateGetV5AssetTransferQueryUniversalTransferList,
+            since_ms,
+            until_ms,
+        ):
+            from_uid = str(item.get("fromMemberId") or "")
+            to_uid = str(item.get("toMemberId") or "")
+            direction = "out" if own_uid and from_uid == own_uid else (
+                "in" if own_uid and to_uid == own_uid else "internal"
+            )
+            records.append(_record(
+                account.name,
+                "bybit",
+                item.get("transferId"),
+                asset=item.get("coin"),
+                amount=item.get("amount"),
+                occurred_at=item.get("timestamp"),
+                from_type=_BYBIT_ACCOUNT_TYPES.get(
+                    str(item.get("fromAccountType") or "").upper(),
+                    item.get("fromAccountType"),
+                ),
+                to_type=_BYBIT_ACCOUNT_TYPES.get(
+                    str(item.get("toAccountType") or "").upper(),
+                    item.get("toAccountType"),
+                ),
+                status=item.get("status"),
+                direction=direction,
+                from_account=from_uid,
+                to_account=to_uid,
+                info=item,
+            ))
+    except Exception as exc:
+        _append_warning(warnings, "Bybit account transfer", exc, secrets)
+    return records
+
+
+def _okx_bill_pages(
+    method: Callable[[dict[str, Any]], Any],
+    since_ms: int,
+    until_ms: int,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    after = ""
+    for _ in range(20):
+        params: dict[str, Any] = {
+            "type": "1",
+            "begin": since_ms,
+            "end": until_ms,
+            "limit": 100,
+        }
+        if after:
+            params["after"] = after
+        response = _request(lambda params=params: method(params))
+        items = _rows(response, "data")
+        records.extend(items)
+        next_after = str(items[-1].get("billId") or "") if items else ""
+        if len(items) < 100 or not next_after or next_after == after:
+            break
+        after = next_after
+    return records
+
+
+def _collect_okx(
+    exchange: ccxt.Exchange,
+    account: ExchangeAccount,
+    since_ms: int,
+    until_ms: int,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    secrets = secret_values(account.config)
+    bills: list[dict[str, Any]] = []
+    successes = 0
+    for label, method in (
+        ("recent", exchange.privateGetAccountBills),
+        ("archive", exchange.privateGetAccountBillsArchive),
+    ):
+        try:
+            bills.extend(_okx_bill_pages(method, since_ms, until_ms))
+            successes += 1
+        except Exception as exc:
+            _append_warning(warnings, f"OKX {label}", exc, secrets)
+    if not successes and warnings:
+        return records
+    for item in bills:
+        source = _OKX_ACCOUNT_TYPES.get(str(item.get("from") or ""), item.get("from"))
+        destination = _OKX_ACCOUNT_TYPES.get(str(item.get("to") or ""), item.get("to"))
+        amount = item.get("sz") or item.get("balChg")
+        records.append(_record(
+            account.name,
+            "okx",
+            item.get("transId") or item.get("billId"),
+            asset=item.get("ccy"),
+            amount=amount,
+            occurred_at=item.get("ts"),
+            from_type=source,
+            to_type=destination,
+            status="success",
+            from_account=item.get("fromSubAcct") or account.name,
+            to_account=item.get("toSubAcct") or item.get("subAcct") or account.name,
+            client_id=item.get("clientId"),
+            info=item,
+        ))
+    return records
+
+
+def _collect_hyperliquid(
+    exchange: ccxt.Exchange,
+    account: ExchangeAccount,
+    since_ms: int,
+    until_ms: int,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    address = str(
+        account.config.get("walletAddress")
+        or getattr(exchange, "walletAddress", "")
+        or ""
+    ).strip().lower()
+    if not address:
+        warnings.append("Hyperliquid transfer history is partial: walletAddress is missing")
+        return []
+    secrets = secret_values(account.config)
+    try:
+        response = _request(lambda: exchange.publicPostInfo({
+            "type": "userNonFundingLedgerUpdates",
+            "user": address,
+            "startTime": since_ms,
+            "endTime": until_ms,
+        }))
+    except Exception as exc:
+        _append_warning(warnings, "Hyperliquid", exc, secrets)
+        return []
+    records: list[dict[str, Any]] = []
+    for item in _rows(response):
+        delta = item.get("delta")
+        if not isinstance(delta, dict):
+            continue
+        kind = str(delta.get("type") or "")
+        if kind not in {
+            "internalTransfer",
+            "subAccountTransfer",
+            "spotTransfer",
+            "accountClassTransfer",
+        }:
+            continue
+        sender = str(delta.get("user") or address).lower()
+        recipient = str(delta.get("destination") or address).lower()
+        direction = "out" if sender == address and recipient != address else (
+            "in" if recipient == address and sender != address else "internal"
+        )
+        if kind == "accountClassTransfer":
+            to_perp = bool(delta.get("toPerp"))
+            source = "spot" if to_perp else "swap"
+            destination = "swap" if to_perp else "spot"
+            asset = "USDC"
+            amount = delta.get("usdc")
+            direction = "internal"
+        elif kind == "spotTransfer":
+            source = "spot"
+            destination = "spot"
+            asset = delta.get("token")
+            amount = delta.get("amount")
+        else:
+            source = "swap"
+            destination = "swap"
+            asset = "USDC"
+            amount = delta.get("usdc")
+        records.append(_record(
+            account.name,
+            "hyperliquid",
+            _stable_id(
+                "hyperliquid",
+                [item.get("hash"), item.get("time"), kind, delta],
+            ),
+            asset=asset,
+            amount=amount,
+            occurred_at=item.get("time"),
+            from_type=source,
+            to_type=destination,
+            status="success",
+            direction=direction,
+            from_account=sender,
+            to_account=recipient,
+            info=item,
+        ))
+    return records
+
+
+def collect_transfer_history(
+    account: ExchangeAccount,
+    *,
+    since_ms: int,
+    until_ms: int,
+    asset_hints: list[str] | None = None,
+    account_type_hints: list[str] | None = None,
+    timeout_ms: int = 30_000,
+) -> dict[str, Any]:
+    exchange_id = account.exchange_id
+    collector = {
+        "binance": _collect_binance,
+        "bitget": _collect_bitget,
+        "bybit": _collect_bybit,
+        "okx": _collect_okx,
+        "hyperliquid": _collect_hyperliquid,
+    }.get(exchange_id)
+    if collector is None:
+        raise ValueError(f"transfer history is not supported for {exchange_id}")
+    exchange = build_exchange(exchange_id, account.config, timeout_ms, None)
+    warnings: list[str] = []
+    try:
+        if exchange_id == "bitget":
+            records = collector(
+                exchange,
+                account,
+                since_ms,
+                until_ms,
+                list(asset_hints or []),
+                list(account_type_hints or []),
+                warnings,
+            )
+        else:
+            records = collector(
+                exchange,
+                account,
+                since_ms,
+                until_ms,
+                warnings,
+            )
+    finally:
+        try:
+            exchange.close()
+        except Exception:
+            pass
+    records = _deduplicate(records)
+    return {
+        "account": account.name,
+        "exchange": exchange_id,
+        "records": records,
+        "warnings": warnings,
+        "partial": bool(warnings),
+        "since_ms": since_ms,
+        "until_ms": until_ms,
+    }
+
+
+def records_from_transfer_result(result: dict[str, Any]) -> list[dict[str, Any]]:
+    account = str(result.get("account") or "").strip()
+    target_account = str(result.get("target_account") or account).strip() or account
+    exchange = str(result.get("exchange") or "").strip().lower()
+    occurred_at = result.get("completed_at") or utc_now()
+    asset = result.get("asset")
+    amount = result.get("amount")
+    records: list[dict[str, Any]] = []
+    for index, step in enumerate(result.get("steps") or []):
+        if not isinstance(step, dict) or step.get("action") not in {
+            "transfer",
+            "account_transfer",
+            "redeem",
+        }:
+            continue
+        identifier = (
+            step.get("transaction_id")
+            or step.get("redeem_id")
+            or _stable_id(
+                f"local-{exchange}",
+                [account, target_account, occurred_at, asset, amount, index],
+            )
+        )
+        is_account_transfer = step.get("action") == "account_transfer"
+        source_record = _record(
+            account,
+            exchange,
+            identifier,
+            asset=asset,
+            amount=amount,
+            occurred_at=occurred_at,
+            from_type=step.get("source"),
+            to_type=step.get("destination"),
+            status=step.get("status") or result.get("status"),
+            direction="out" if is_account_transfer else "internal",
+            from_account=account,
+            to_account=target_account,
+            source="local",
+            info=step,
+        )
+        records.append(source_record)
+        if is_account_transfer and target_account != account:
+            records.append(_record(
+                target_account,
+                exchange,
+                identifier,
+                asset=asset,
+                amount=amount,
+                occurred_at=occurred_at,
+                from_type=step.get("source"),
+                to_type=step.get("destination"),
+                status=step.get("status") or result.get("status"),
+                direction="in",
+                from_account=account,
+                to_account=target_account,
+                source="local",
+                info=step,
+            ))
+    return _deduplicate(records)

--- a/account_service/transfers.py
+++ b/account_service/transfers.py
@@ -77,6 +77,7 @@ _OKX_ACCOUNT_TYPES = {
     "6": "funding",
     "18": "spot",
 }
+_OKX_ACCOUNT_TRANSFER_TYPES = {"20", "21", "22", "23"}
 _NETWORK_ERRORS = (
     ccxt.NetworkError,
     ccxt.RequestTimeout,
@@ -167,6 +168,9 @@ def _record(
     to_account: Any = "",
     client_id: Any = "",
     source: str = "native",
+    transfer_kind: str = "wallet",
+    from_account_label: Any = "",
+    to_account_label: Any = "",
     info: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     occurred = _iso_time(occurred_at)
@@ -195,8 +199,11 @@ def _record(
         "direction": direction,
         "from_account": str(from_account or account),
         "to_account": str(to_account or account),
+        "from_account_label": str(from_account_label or ""),
+        "to_account_label": str(to_account_label or ""),
         "from_account_type": str(from_type or "").strip().lower(),
         "to_account_type": str(to_type or "").strip().lower(),
+        "transfer_kind": "account" if transfer_kind == "account" else "wallet",
         "status": str(status or "unknown").strip().lower(),
         "source": source,
     }
@@ -323,7 +330,15 @@ def _collect_binance(
                         str(item.get("toAccountType") or "").upper(),
                         str(item.get("toAccountType") or "").lower(),
                     )
-                    direction = "out"
+                    direction = (
+                        "out"
+                        if from_email == account.name and to_email != account.name
+                        else (
+                            "in"
+                            if to_email == account.name and from_email != account.name
+                            else "internal"
+                        )
+                    )
                     records.append(_record(
                         account.name,
                         "binance",
@@ -337,6 +352,7 @@ def _collect_binance(
                         direction=direction,
                         from_account=from_email,
                         to_account=to_email,
+                        transfer_kind="account",
                         client_id=item.get("clientTranId"),
                         info=item,
                     ))
@@ -455,6 +471,7 @@ def _collect_bitget(
                         direction=direction,
                         from_account=item.get("fromUserId"),
                         to_account=item.get("toUserId"),
+                        transfer_kind="account",
                         client_id=item.get("clientOid"),
                         info=item,
                     ))
@@ -581,6 +598,7 @@ def _collect_bybit(
                 direction=direction,
                 from_account=from_uid,
                 to_account=to_uid,
+                transfer_kind="account",
                 info=item,
             ))
     except Exception as exc:
@@ -614,6 +632,60 @@ def _okx_bill_pages(
     return records
 
 
+def _okx_asset_bill_pages(
+    method: Callable[[dict[str, Any]], Any],
+    since_ms: int,
+    until_ms: int,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    after = str(until_ms + 1)
+    before = str(max(0, since_ms - 1))
+    for page in range(20):
+        params: dict[str, Any] = {
+            "after": after,
+            "before": before,
+            "limit": 100,
+            "pagingType": "1",
+        }
+        response = _request(lambda params=params: method(params))
+        items = _rows(response, "data")
+        records.extend(
+            item
+            for item in items
+            if str(item.get("type") or "") in _OKX_ACCOUNT_TRANSFER_TYPES
+        )
+        timestamps = [
+            int(item["ts"])
+            for item in items
+            if str(item.get("ts") or "").isdigit()
+        ]
+        next_after = str(min(timestamps)) if timestamps else ""
+        if (
+            len(items) < 100
+            or not next_after
+            or next_after == after
+            or int(next_after) <= since_ms
+        ):
+            break
+        after = next_after
+        if page < 19:
+            time.sleep(1.05)
+    return records
+
+
+def _okx_account_transfer_route(
+    account: ExchangeAccount,
+    bill_type: str,
+) -> tuple[str, str, str]:
+    if bill_type == "20":
+        return account.name, "sub_account", "out"
+    if bill_type == "21":
+        return "sub_account", account.name, "in"
+    if bill_type == "22":
+        return account.name, "main_account", "out"
+    return "main_account", account.name, "in"
+
+
 def _collect_okx(
     exchange: ccxt.Exchange,
     account: ExchangeAccount,
@@ -643,7 +715,7 @@ def _collect_okx(
         records.append(_record(
             account.name,
             "okx",
-            item.get("transId") or item.get("billId"),
+            item.get("billId") or item.get("transId"),
             asset=item.get("ccy"),
             amount=amount,
             occurred_at=item.get("ts"),
@@ -652,6 +724,39 @@ def _collect_okx(
             status="success",
             from_account=item.get("fromSubAcct") or account.name,
             to_account=item.get("toSubAcct") or item.get("subAcct") or account.name,
+            client_id=item.get("clientId"),
+            info=item,
+        ))
+
+    try:
+        asset_bills = _okx_asset_bill_pages(
+            exchange.privateGetAssetBillsHistory,
+            since_ms,
+            until_ms,
+        )
+    except Exception as exc:
+        _append_warning(warnings, "OKX account transfer", exc, secrets)
+        return records
+    for item in asset_bills:
+        bill_type = str(item.get("type") or "")
+        from_account, to_account, direction = _okx_account_transfer_route(
+            account,
+            bill_type,
+        )
+        records.append(_record(
+            account.name,
+            "okx",
+            f"asset:{item.get('billId')}",
+            asset=item.get("ccy"),
+            amount=item.get("balChg"),
+            occurred_at=item.get("ts"),
+            from_type="funding",
+            to_type="funding",
+            status="success",
+            direction=direction,
+            from_account=from_account,
+            to_account=to_account,
+            transfer_kind="account",
             client_id=item.get("clientId"),
             info=item,
         ))
@@ -735,6 +840,7 @@ def _collect_hyperliquid(
             direction=direction,
             from_account=sender,
             to_account=recipient,
+            transfer_kind="account" if kind == "subAccountTransfer" else "wallet",
             info=item,
         ))
     return records
@@ -835,6 +941,9 @@ def records_from_transfer_result(result: dict[str, Any]) -> list[dict[str, Any]]
             from_account=account,
             to_account=target_account,
             source="local",
+            transfer_kind="account" if is_account_transfer else "wallet",
+            from_account_label=step.get("source_account"),
+            to_account_label=step.get("target_account"),
             info=step,
         )
         records.append(source_record)
@@ -853,6 +962,9 @@ def records_from_transfer_result(result: dict[str, Any]) -> list[dict[str, Any]]
                 from_account=account,
                 to_account=target_account,
                 source="local",
+                transfer_kind="account",
+                from_account_label=step.get("source_account"),
+                to_account_label=step.get("target_account"),
                 info=step,
             ))
     return _deduplicate(records)

--- a/data_service/account_data.py
+++ b/data_service/account_data.py
@@ -26,6 +26,10 @@ from account_service.csv_import import (
 )
 from account_service.live_positions import run_positions_stream
 from account_service.positions import collect_positions_snapshot
+from account_service.transfers import (
+    TRANSFER_CACHE_TTL_SECONDS,
+    records_from_transfer_result,
+)
 from ai.scripts.asset import (
     ExchangeAccount,
     build_exchange,
@@ -104,6 +108,8 @@ class AccountDataService:
         self._live_control_reader: asyncio.Task[None] | None = None
         self._history_refresh_waiters: dict[str, asyncio.Future[dict[str, Any]]] = {}
         self._history_import_waiters: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._transfer_waiters: dict[str, asyncio.Future[dict[str, Any]]] = {}
+        self._transfer_refresh_locks: dict[str, asyncio.Lock] = {}
         self._history_import_previews: dict[str, dict[str, Any]] = {}
         self._history_import_jobs: dict[str, dict[str, Any]] = {}
         self._history_import_tasks: dict[str, asyncio.Task[None]] = {}
@@ -302,6 +308,180 @@ class AccountDataService:
             message = str(exc).replace("\n", " ").strip()
             raise AccountDataError(message[:500] or type(exc).__name__) from exc
         return self._history_group_response(groups, exchange=exchange)
+
+    async def transfer_history(
+        self,
+        *,
+        account: str,
+        exchange: str,
+        cursor: str | None = None,
+        limit: int = 50,
+        force: bool = False,
+        assets: list[str] | None = None,
+        account_types: list[str] | None = None,
+    ) -> dict[str, Any]:
+        normalized_account = account.strip()
+        normalized_exchange = exchange.strip().lower()
+        if not normalized_account or not normalized_exchange:
+            raise AccountDataError("transfer account and exchange are required")
+        asset_hints = list(dict.fromkeys(
+            str(value).strip().upper()
+            for value in (assets or [])
+            if str(value).strip()
+        ))[:20]
+        type_hints = list(dict.fromkeys(
+            str(value).strip().lower()
+            for value in (account_types or [])
+            if str(value).strip()
+        ))[:10]
+
+        lock = self._transfer_refresh_locks.setdefault(
+            f"{normalized_exchange}:{normalized_account}",
+            asyncio.Lock(),
+        )
+        refresh_error = ""
+        async with lock:
+            state = await asyncio.to_thread(
+                AccountCache(self.cache_path).transfer_sync_state,
+                normalized_account,
+                normalized_exchange,
+            )
+            last_success = str(state.get("last_success_at") or "")
+            stale = True
+            if last_success:
+                try:
+                    age = datetime.now(UTC).timestamp() - datetime.fromisoformat(
+                        last_success.replace("Z", "+00:00")
+                    ).timestamp()
+                    stale = age >= TRANSFER_CACHE_TTL_SECONDS
+                except ValueError:
+                    stale = True
+            if force or stale:
+                try:
+                    await self._refresh_transfers(
+                        normalized_account,
+                        normalized_exchange,
+                        asset_hints,
+                        type_hints,
+                    )
+                except AccountDataError as exc:
+                    refresh_error = str(exc)
+
+        try:
+            page, state = await asyncio.gather(
+                asyncio.to_thread(
+                    AccountCache(self.cache_path).transfer_history_page,
+                    account=normalized_account,
+                    exchange=normalized_exchange,
+                    cursor=cursor,
+                    limit=limit,
+                ),
+                asyncio.to_thread(
+                    AccountCache(self.cache_path).transfer_sync_state,
+                    normalized_account,
+                    normalized_exchange,
+                ),
+            )
+        except ValueError:
+            raise
+        except Exception as exc:
+            message = str(exc).replace("\n", " ").strip()
+            raise AccountDataError(message[:500] or type(exc).__name__) from exc
+        results = page.get("results") if isinstance(page, dict) else []
+        results = results if isinstance(results, list) else []
+        if refresh_error and not results:
+            raise AccountDataError(refresh_error)
+        if refresh_error:
+            state = {**state, "status": "error", "last_error": refresh_error}
+        return {
+            "schema_version": "1.0",
+            "collected_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "read_only": True,
+            "cached": True,
+            "account": normalized_account,
+            "exchange": normalized_exchange,
+            "results": results,
+            "next_cursor": page.get("next_cursor"),
+            "sync": state,
+            "summary": {
+                "total": int(page.get("total") or 0),
+                "returned": len(results),
+                "has_more": bool(page.get("next_cursor")),
+            },
+        }
+
+    async def _refresh_transfers(
+        self,
+        account: str,
+        exchange: str,
+        assets: list[str],
+        account_types: list[str],
+    ) -> dict[str, Any]:
+        await self._ensure_live_stream()
+        process = self._live_process
+        input_queue = self._live_input
+        if process is None or not process.is_alive() or input_queue is None:
+            raise AccountDataError("account worker is not available")
+        request_id = uuid4().hex
+        waiter = asyncio.get_running_loop().create_future()
+        self._transfer_waiters[request_id] = waiter
+        try:
+            await asyncio.to_thread(input_queue.put, {
+                "type": "transfer.refresh",
+                "request_id": request_id,
+                "account": account,
+                "exchange": exchange,
+                "assets": assets,
+                "account_types": account_types,
+            }, True, 5.0)
+            result = await asyncio.wait_for(asyncio.shield(waiter), timeout=300.0)
+        except (queue.Full, ValueError, OSError) as exc:
+            raise AccountDataError("account worker request queue is unavailable") from exc
+        except TimeoutError as exc:
+            raise AccountDataError("transfer history refresh timed out") from exc
+        finally:
+            self._transfer_waiters.pop(request_id, None)
+            if not waiter.done():
+                waiter.cancel()
+        if result.get("status") == "error":
+            error = result.get("error")
+            error = error if isinstance(error, dict) else {}
+            raise AccountDataError(
+                str(error.get("message") or "transfer history refresh failed")[:500]
+            )
+        return result
+
+    async def record_transfer_result(self, result: dict[str, Any]) -> None:
+        records = records_from_transfer_result(result)
+        if not records:
+            return
+        await self._ensure_live_stream()
+        process = self._live_process
+        input_queue = self._live_input
+        if process is None or not process.is_alive() or input_queue is None:
+            raise AccountDataError("account worker is not available")
+        request_id = uuid4().hex
+        waiter = asyncio.get_running_loop().create_future()
+        self._transfer_waiters[request_id] = waiter
+        try:
+            await asyncio.to_thread(input_queue.put, {
+                "type": "transfer.record",
+                "request_id": request_id,
+                "records": records,
+                "account": str(result.get("account") or ""),
+                "exchange": str(result.get("exchange") or ""),
+            }, True, 5.0)
+            response = await asyncio.wait_for(asyncio.shield(waiter), timeout=30.0)
+            if response.get("status") == "error":
+                error = response.get("error")
+                error = error if isinstance(error, dict) else {}
+                raise AccountDataError(
+                    str(error.get("message") or "transfer history write failed")[:500]
+                )
+        finally:
+            self._transfer_waiters.pop(request_id, None)
+            if not waiter.done():
+                waiter.cancel()
 
     async def pnl(
         self,
@@ -1026,6 +1206,7 @@ class AccountDataService:
                 waiters = [
                     *self._history_refresh_waiters.values(),
                     *self._history_import_waiters.values(),
+                    *self._transfer_waiters.values(),
                 ]
                 for waiter in waiters:
                     if not waiter.done():
@@ -1042,6 +1223,11 @@ class AccountDataService:
                 "history.import.delete.result",
             }:
                 waiter_map = self._history_import_waiters
+            elif message_type in {
+                "transfer.refresh.result",
+                "transfer.record.result",
+            }:
+                waiter_map = self._transfer_waiters
             else:
                 continue
             request_id = str(message.get("request_id") or "")
@@ -1070,9 +1256,11 @@ class AccountDataService:
         waiters = [
             *self._history_refresh_waiters.values(),
             *self._history_import_waiters.values(),
+            *self._transfer_waiters.values(),
         ]
         self._history_refresh_waiters.clear()
         self._history_import_waiters.clear()
+        self._transfer_waiters.clear()
         for waiter in waiters:
             if not waiter.done():
                 waiter.set_exception(AccountDataError("account worker stopped"))

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -1093,6 +1093,36 @@ def build_control_router(
             return JSONResponse({"error": str(exc)}, status_code=400)
         except AccountDataError as exc:
             return JSONResponse({"error": str(exc)}, status_code=503)
+        external_accounts = [
+            str(record.get(field) or "").strip().lower()
+            for record in result.get("results", [])
+            if isinstance(record, dict)
+            for field in ("from_account", "to_account")
+        ]
+        needs_aliases = any(
+            value.isdigit()
+            or "@" in value
+            or (value.startswith("0x") and len(value) == 42)
+            for value in external_accounts
+        )
+        if needs_aliases:
+            try:
+                aliases = await asyncio.to_thread(
+                    asset_transfer_service.account_name_aliases,
+                    exchange,
+                )
+            except Exception:
+                aliases = {}
+        else:
+            aliases = {}
+        for record in result.get("results", []):
+            if not isinstance(record, dict):
+                continue
+            for field in ("from_account", "to_account"):
+                external_id = str(record.get(field) or "").strip().lower()
+                account_name = aliases.get(external_id)
+                if account_name:
+                    record[field] = account_name
         return JSONResponse(result)
 
     @r.post("/api/assets/transfer")

--- a/data_service/api.py
+++ b/data_service/api.py
@@ -1067,6 +1067,34 @@ def build_control_router(
             )
         return JSONResponse(result)
 
+    @r.get("/api/assets/transfer/history")
+    async def get_asset_transfer_history(
+        exchange: str,
+        account: str,
+        cursor: str = "",
+        limit: int = 50,
+        force: bool = False,
+        assets: str = "",
+        account_types: str = "",
+    ) -> JSONResponse:
+        try:
+            result = await account_data_service.transfer_history(
+                exchange=exchange,
+                account=account,
+                cursor=cursor or None,
+                limit=limit,
+                force=force,
+                assets=[value for value in assets.split(",") if value],
+                account_types=[
+                    value for value in account_types.split(",") if value
+                ],
+            )
+        except ValueError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=400)
+        except AccountDataError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=503)
+        return JSONResponse(result)
+
     @r.post("/api/assets/transfer")
     async def execute_asset_transfer(
         payload: dict = Body(default_factory=dict),
@@ -1081,6 +1109,11 @@ def build_control_router(
                 status_code=exc.status_code,
             )
         await asset_portfolio_service.invalidate()
+        try:
+            await account_data_service.record_transfer_result(result)
+        except AccountDataError as exc:
+            timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+            print(f"[{timestamp}][account] transfer history write failed: {exc}")
         return JSONResponse(result)
 
     @r.get("/api/ai/chat")

--- a/data_service/asset_transfer.py
+++ b/data_service/asset_transfer.py
@@ -32,7 +32,6 @@ _SOURCES = {
     "bitget": {"spot", "swap", "margin", "funding", "earn"},
     "bybit": {"spot", "swap", "margin", "funding"},
     "okx": {"spot", "funding"},
-    "hyperliquid": {"spot", "swap"},
 }
 _DESTINATIONS = {
     "binance": {
@@ -58,10 +57,6 @@ _DESTINATIONS = {
     "okx": {
         "spot": ("funding",),
         "funding": ("spot",),
-    },
-    "hyperliquid": {
-        "spot": ("swap",),
-        "swap": ("spot",),
     },
 }
 _BINANCE_TRANSFER_TYPES = {
@@ -601,6 +596,20 @@ class AssetTransferService:
             self._hierarchy_cache[exchange_id] = (revision, now, hierarchy)
         return hierarchy
 
+    def account_name_aliases(self, exchange_id: str) -> dict[str, str]:
+        normalized_exchange = str(exchange_id or "").strip().lower()
+        hierarchy = self._account_hierarchy(normalized_exchange)
+        aliases: dict[str, str] = {}
+        for identity in hierarchy.accounts.values():
+            values = [identity.key, identity.label, identity.external_id]
+            if identity.role == "main":
+                values.append(identity.group_id)
+            for value in values:
+                normalized = str(value or "").strip().lower()
+                if normalized:
+                    aliases[normalized] = identity.key
+        return aliases
+
     def _discover_bitget_hierarchy(
         self,
         accounts: list[ExchangeAccount],
@@ -1076,10 +1085,6 @@ class AssetTransferService:
             return ("spot", "funding")
         if exchange_id == "okx":
             return ("spot", "funding")
-        if exchange_id == "hyperliquid" and effective_source == "swap":
-            # Hyperliquid's sub-account USDC transfer moves Perps collateral.
-            if source_account.role == "main" or target_account.role == "main":
-                return ("swap",)
         return ()
 
     def _target_account_options(
@@ -1219,16 +1224,7 @@ class AssetTransferService:
                     self.read_attempts,
                     secrets,
                 )
-                if exchange_id == "hyperliquid":
-                    assets = _wallet_assets(
-                        balance,
-                        allowed_assets={"USDC"},
-                        unsupported_note=(
-                            "Hyperliquid Spot/Perp internal transfer supports USDC only."
-                        ),
-                    )
-                else:
-                    assets = _wallet_assets(balance)
+                assets = _wallet_assets(balance)
             hierarchy = self._account_hierarchy(exchange_id, account)
             source_identity = hierarchy.identity(account.name)
             target_accounts = (
@@ -1301,9 +1297,6 @@ class AssetTransferService:
         amount = _decimal(payload.get("amount"), "amount")
         if amount <= 0:
             raise AssetTransferError("amount must be greater than zero")
-        if exchange_id == "hyperliquid" and asset != "USDC":
-            raise AssetTransferError("Hyperliquid transfer supports USDC only")
-
         account = _account_by_name(
             self.config_path,
             payload.get("account"),
@@ -1639,25 +1632,7 @@ class AssetTransferService:
             first = rows[0] if isinstance(rows, list) and rows else {}
             transaction_id = first.get("transId") if isinstance(first, dict) else None
         else:
-            response = _state_change(
-                lambda: exchange.transfer(
-                    asset,
-                    _amount_text(amount),
-                    source,
-                    destination,
-                ),
-                operation="Hyperliquid Spot/Perp transfer",
-                exchange_label="Hyperliquid",
-                secrets=secrets,
-            )
-            if response.get("status") != "ok":
-                raise AssetTransferError(
-                    "Hyperliquid rejected the Spot/Perp transfer",
-                    status_code=502,
-                    details={"status": "failed"},
-                )
-            transaction_id = response.get("id")
-            return str(transaction_id) if transaction_id else None
+            raise AssetTransferError("internal transfer is not supported for this exchange")
 
         if transaction_id is None:
             raise AssetTransferError(
@@ -1807,47 +1782,7 @@ class AssetTransferService:
             rows = _response_rows(response, "data")
             transaction_id = rows[0].get("transId") if rows else None
         else:
-            if (
-                source_account.role == "main"
-                and target_account.role == "sub"
-                and target_account.external_id
-            ):
-                from_account = "main"
-                to_account = target_account.external_id
-            elif (
-                source_account.role == "sub"
-                and target_account.role == "main"
-                and source_account.external_id
-            ):
-                from_account = source_account.external_id
-                to_account = "main"
-            else:
-                raise AssetTransferError(
-                    "Hyperliquid supports account transfer only between main and sub accounts"
-                )
-            response = _state_change(
-                lambda: exchange.transfer(
-                    asset,
-                    amount_value,
-                    from_account,
-                    to_account,
-                ),
-                operation="Hyperliquid account transfer",
-                exchange_label="Hyperliquid",
-                secrets=secrets,
-            )
-            status = _external_id(response.get("status")).lower()
-            if status and status not in {"ok", "success"}:
-                raise AssetTransferError(
-                    "Hyperliquid rejected the account transfer",
-                    status_code=502,
-                    details={"status": "failed"},
-                )
-            transaction_id = response.get("id")
-            return (
-                str(transaction_id) if transaction_id else None,
-                "success",
-            )
+            raise AssetTransferError("account transfer is not supported for this exchange")
 
         if transaction_id is None:
             raise AssetTransferError(

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -29,6 +29,7 @@ body {
   .history-import-log-list,
   .history-import-select-options,
   .asset-transfer-body,
+  .asset-transfer-history-body,
   .integrity-issues,
   .calendar-forecast-content,
   .calendar-forecast-error {
@@ -45,6 +46,7 @@ body {
   .history-import-log-list::-webkit-scrollbar,
   .history-import-select-options::-webkit-scrollbar,
   .asset-transfer-body::-webkit-scrollbar,
+  .asset-transfer-history-body::-webkit-scrollbar,
   .integrity-issues::-webkit-scrollbar,
   .calendar-forecast-content::-webkit-scrollbar,
   .calendar-forecast-error::-webkit-scrollbar {
@@ -61,6 +63,7 @@ body {
   .history-import-log-list::-webkit-scrollbar-track,
   .history-import-select-options::-webkit-scrollbar-track,
   .asset-transfer-body::-webkit-scrollbar-track,
+  .asset-transfer-history-body::-webkit-scrollbar-track,
   .integrity-issues::-webkit-scrollbar-track,
   .calendar-forecast-content::-webkit-scrollbar-track,
   .calendar-forecast-error::-webkit-scrollbar-track {
@@ -76,6 +79,7 @@ body {
   .history-import-log-list::-webkit-scrollbar-thumb,
   .history-import-select-options::-webkit-scrollbar-thumb,
   .asset-transfer-body::-webkit-scrollbar-thumb,
+  .asset-transfer-history-body::-webkit-scrollbar-thumb,
   .integrity-issues::-webkit-scrollbar-thumb,
   .calendar-forecast-content::-webkit-scrollbar-thumb,
   .calendar-forecast-error::-webkit-scrollbar-thumb {
@@ -93,6 +97,7 @@ body {
   .history-import-log-list::-webkit-scrollbar-thumb:hover,
   .history-import-select-options::-webkit-scrollbar-thumb:hover,
   .asset-transfer-body::-webkit-scrollbar-thumb:hover,
+  .asset-transfer-history-body::-webkit-scrollbar-thumb:hover,
   .integrity-issues::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-content::-webkit-scrollbar-thumb:hover,
   .calendar-forecast-error::-webkit-scrollbar-thumb:hover {
@@ -106,6 +111,7 @@ body {
   .account-view-body::-webkit-scrollbar-corner,
   .account-table-wrap::-webkit-scrollbar-corner,
   .asset-transfer-body::-webkit-scrollbar-corner,
+  .asset-transfer-history-body::-webkit-scrollbar-corner,
   .integrity-issues::-webkit-scrollbar-corner {
     background: #0b0e13;
   }
@@ -3713,6 +3719,39 @@ tr:last-child td { border-bottom: none; }
   font-size: 10px;
   line-height: 1.4;
 }
+.assets-portfolio-footer-primary {
+  min-width: 0;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.assets-portfolio-footer-primary > span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.assets-transfer-history-link {
+  appearance: none;
+  flex: none;
+  padding: 0;
+  border: 0;
+  border-bottom: 1px dotted currentColor;
+  border-radius: 0;
+  background: transparent;
+  color: #58a6ff;
+  font: inherit;
+  font-size: inherit;
+  line-height: inherit;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.assets-transfer-history-link:hover { color: #79b8ff; }
+.assets-transfer-history-link:focus-visible {
+  outline: 1px solid #58a6ff;
+  outline-offset: 3px;
+}
 .assets-account-list {
   overflow: hidden;
   text-overflow: ellipsis;
@@ -3744,6 +3783,9 @@ tr:last-child td { border-bottom: none; }
   animation: assets-spin 700ms linear infinite;
 }
 #assets-refresh.assets-refreshing .icon {
+  animation: assets-spin 700ms linear infinite;
+}
+#asset-transfer-history-refresh.assets-refreshing .icon {
   animation: assets-spin 700ms linear infinite;
 }
 @keyframes assets-spin { to { transform: rotate(360deg); } }
@@ -4021,6 +4063,118 @@ tr:last-child td { border-bottom: none; }
 .asset-transfer-modal button {
   touch-action: manipulation;
 }
+.asset-transfer-history-modal { z-index: 92; }
+.asset-transfer-history-box {
+  width: min(520px, 100%);
+  max-height: min(680px, calc(100vh - 32px));
+}
+.asset-transfer-history-header { align-items: flex-start; }
+.asset-transfer-history-header > div:first-child {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+.asset-transfer-history-header span {
+  color: #f2f5f8;
+  font-size: 14px;
+  font-weight: 600;
+}
+.asset-transfer-history-header small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 10px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.asset-transfer-history-body {
+  min-height: 260px;
+  max-height: min(600px, calc(100vh - 90px));
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding: 10px 14px 14px;
+}
+.asset-transfer-history-notice {
+  margin: 4px 0 10px;
+  padding: 8px 10px;
+  border-left: 2px solid #d29922;
+  background: rgba(210, 153, 34, 0.08);
+  color: #c5a75a;
+  font-size: 10px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
+}
+.asset-transfer-history-list {
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: #11161d;
+}
+.asset-transfer-history-row {
+  display: grid;
+  gap: 5px;
+  padding: 12px;
+  border-bottom: 1px solid #222a34;
+}
+.asset-transfer-history-row:last-child { border-bottom: 0; }
+.asset-transfer-history-row-top {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
+}
+.asset-transfer-history-amount {
+  min-width: 0;
+  overflow: hidden;
+  color: #f2f5f8;
+  font-size: 13px;
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.asset-transfer-history-status {
+  flex: none;
+  color: var(--muted);
+  font-size: 9px;
+  text-transform: capitalize;
+}
+.asset-transfer-history-status.status-success,
+.asset-transfer-history-status.status-successful,
+.asset-transfer-history-status.status-confirmed { color: #7ee787; }
+.asset-transfer-history-status.status-failed { color: #ff7b72; }
+.asset-transfer-history-status.status-pending,
+.asset-transfer-history-status.status-processing { color: #d29922; }
+.asset-transfer-history-route {
+  overflow: hidden;
+  color: #cbd2db;
+  font-size: 11px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.asset-transfer-history-meta {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  color: var(--muted);
+  font-size: 9px;
+}
+.asset-transfer-history-meta span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.asset-transfer-history-more {
+  min-height: 38px;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+}
+.asset-transfer-history-more .btn {
+  min-width: 112px;
+  font-size: 11px;
+}
+.asset-transfer-history-modal button { touch-action: manipulation; }
 .assets-legend-row.assets-legend-account-row {
   appearance: none;
   grid-template-columns: 9px minmax(46px, 1fr) auto 10px;
@@ -5260,11 +5414,13 @@ tr:last-child td { border-bottom: none; }
     grid-template-columns: 8px minmax(38px, 1fr) auto 9px;
   }
   .assets-legend-value { font-size: 9px; }
-  .asset-transfer-modal {
+  .asset-transfer-modal,
+  .asset-transfer-history-modal {
     align-items: flex-end;
     padding: 0;
   }
-  .asset-transfer-box {
+  .asset-transfer-box,
+  .asset-transfer-history-box {
     width: 100%;
     max-height: min(78dvh, 620px);
     border-right: 0;
@@ -5278,6 +5434,10 @@ tr:last-child td { border-bottom: none; }
   }
   .asset-transfer-footer {
     padding: 11px 14px calc(11px + env(safe-area-inset-bottom, 0px));
+  }
+  .asset-transfer-history-body {
+    max-height: calc(78dvh - 56px);
+    padding: 8px 12px calc(14px + env(safe-area-inset-bottom, 0px));
   }
   .clock-hour { height: 8px; }
   .clock-minute { height: 11px; }

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -5428,6 +5428,27 @@ tr:last-child td { border-bottom: none; }
     border-left: 0;
     border-radius: 8px 8px 0 0;
   }
+  .asset-transfer-history-modal.asset-transfer-history-dragging
+    .asset-transfer-history-box {
+    animation: none;
+    transition: none;
+  }
+  .asset-transfer-history-header {
+    position: relative;
+    padding-top: 18px;
+    touch-action: none;
+  }
+  .asset-transfer-history-header::before {
+    content: "";
+    position: absolute;
+    top: 7px;
+    left: 50%;
+    width: 40px;
+    height: 4px;
+    margin-left: -20px;
+    border-radius: 999px;
+    background: var(--border);
+  }
   .asset-transfer-body {
     padding: 14px;
     padding-bottom: 16px;

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -1039,6 +1039,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=145"></script>
+  <script src="/static/dashboard.js?v=148"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=136" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=137" />
 </head>
 <body>
   <header class="topbar">
@@ -835,6 +835,52 @@
     </div>
   </div>
 
+  <div id="asset-transfer-history-modal"
+       class="modal asset-transfer-history-modal hidden" aria-hidden="true">
+    <div class="modal-box asset-transfer-history-box" role="dialog" aria-modal="true"
+         aria-labelledby="asset-transfer-history-title">
+      <div class="modal-header asset-transfer-history-header">
+        <div>
+          <span id="asset-transfer-history-title">Transfer History</span>
+          <small id="asset-transfer-history-subtitle"></small>
+        </div>
+        <div class="modal-actions">
+          <button id="asset-transfer-history-refresh" class="btn btn-icon" type="button"
+                  title="Refresh transfer history" aria-label="Refresh transfer history">
+            <svg class="icon" viewBox="0 0 24 24" aria-hidden="true">
+              <path d="M3 12a9 9 0 0 1 15.7-6L21 8" />
+              <path d="M21 3v5h-5" />
+              <path d="M21 12a9 9 0 0 1-15.7 6L3 16" />
+              <path d="M3 21v-5h5" />
+            </svg>
+          </button>
+          <button id="asset-transfer-history-close" class="btn btn-icon" type="button"
+                  title="Close" aria-label="Close">&times;</button>
+        </div>
+      </div>
+      <div class="asset-transfer-history-body">
+        <div id="asset-transfer-history-loading" class="assets-state">
+          <span class="assets-spinner" aria-hidden="true"></span>
+          <span>Loading transfer history...</span>
+        </div>
+        <div id="asset-transfer-history-error"
+             class="assets-state assets-state-error hidden" role="alert"></div>
+        <div id="asset-transfer-history-empty" class="assets-state hidden">
+          No transfer history was found for this account.
+        </div>
+        <div id="asset-transfer-history-notice"
+             class="asset-transfer-history-notice hidden"></div>
+        <div id="asset-transfer-history-list"
+             class="asset-transfer-history-list hidden"></div>
+        <div class="asset-transfer-history-more">
+          <button id="asset-transfer-history-more" class="btn hidden" type="button">
+            Load more
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
   <div id="log-modal" class="modal hidden" aria-hidden="true">
     <div class="modal-box">
       <div class="modal-header">
@@ -993,6 +1039,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=144"></script>
+  <script src="/static/dashboard.js?v=145"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -79,7 +79,6 @@
     bitget: new Set(["spot", "swap", "margin", "funding", "earn"]),
     bybit: new Set(["spot", "swap", "margin", "funding"]),
     okx: new Set(["spot", "funding"]),
-    hyperliquid: new Set(["spot", "swap"]),
   };
   let assetsRequestSeq = 0;
   const assetsRefreshIntervalMs = 10000;
@@ -2304,7 +2303,11 @@
     assetTransferHistoryCursor = null;
     assetTransferHistoryLoading = false;
     const modal = el("asset-transfer-history-modal");
+    const box = modal.querySelector(".asset-transfer-history-box");
+    modal.classList.remove("asset-transfer-history-dragging");
     modal.classList.add("hidden");
+    box.style.transform = "";
+    box.style.transition = "";
     modal.setAttribute("aria-hidden", "true");
     el("asset-transfer-history-refresh").classList.remove("assets-refreshing");
   }
@@ -2312,13 +2315,34 @@
   function transferHistoryRoute(record, exchangeId) {
     const sourceAccount = String(record.from_account || record.account || "");
     const targetAccount = String(record.to_account || record.account || "");
+    const sourceAccountLabel = transferHistoryAccountLabel(
+      sourceAccount,
+      record.from_account_label,
+    );
+    const targetAccountLabel = transferHistoryAccountLabel(
+      targetAccount,
+      record.to_account_label,
+    );
     const sourceType = assetAccountTypeLabel(record.from_account_type, exchangeId);
     const targetType = assetAccountTypeLabel(record.to_account_type, exchangeId);
-    const crossAccount = sourceAccount && targetAccount && sourceAccount !== targetAccount;
+    const accountTransfer = String(record.transfer_kind || "wallet") === "account";
+    const crossAccount = accountTransfer
+      || (sourceAccount && targetAccount && sourceAccount !== targetAccount);
     if (crossAccount) {
-      return `${sourceAccount} · ${sourceType} → ${targetAccount} · ${targetType}`;
+      return `Account transfer · ${sourceAccountLabel} · ${sourceType} → ${targetAccountLabel} · ${targetType}`;
     }
     return `${sourceType} → ${targetType}`;
+  }
+
+  function transferHistoryAccountLabel(value, label) {
+    const explicit = String(label || "").trim();
+    if (explicit) return explicit;
+    const raw = String(value || "").trim();
+    if (!raw) return "Account";
+    const normalized = raw.toLowerCase();
+    if (normalized === "main_account") return "Main account";
+    if (normalized === "sub_account") return "Sub account";
+    return raw;
   }
 
   function renderAssetTransferHistory(payload, append = false) {
@@ -2454,7 +2478,10 @@
     el("asset-transfer-history-error").classList.add("hidden");
     el("asset-transfer-history-loading").classList.remove("hidden");
     const modal = el("asset-transfer-history-modal");
-    modal.classList.remove("hidden");
+    const box = modal.querySelector(".asset-transfer-history-box");
+    modal.classList.remove("asset-transfer-history-dragging", "hidden");
+    box.style.transform = "";
+    box.style.transition = "";
     modal.setAttribute("aria-hidden", "false");
     loadAssetTransferHistory();
   }
@@ -5860,6 +5887,70 @@
     header.addEventListener("pointercancel", (event) => endAssetsCloseDrag(event, true));
   }
 
+  function initMobileAssetTransferHistoryGestures() {
+    const modal = el("asset-transfer-history-modal");
+    const box = modal.querySelector(".asset-transfer-history-box");
+    const header = modal.querySelector(".asset-transfer-history-header");
+    let closeDrag = null;
+
+    header.addEventListener("pointerdown", (event) => {
+      if (!mobileHubQuery.matches || !event.isPrimary) return;
+      if (event.target && event.target.closest && event.target.closest("button")) return;
+      closeDrag = {
+        id: event.pointerId,
+        startX: event.clientX,
+        startY: event.clientY,
+        dy: 0,
+        active: false,
+      };
+      try { header.setPointerCapture(event.pointerId); } catch {}
+    });
+    header.addEventListener("pointermove", (event) => {
+      if (!closeDrag || event.pointerId !== closeDrag.id) return;
+      const dx = event.clientX - closeDrag.startX;
+      const dy = event.clientY - closeDrag.startY;
+      if (!closeDrag.active) {
+        if (Math.max(Math.abs(dx), Math.abs(dy)) < 8) return;
+        if (dy <= 0 || Math.abs(dy) <= Math.abs(dx)) {
+          closeDrag = null;
+          return;
+        }
+        closeDrag.active = true;
+        modal.classList.add("asset-transfer-history-dragging");
+      }
+      event.preventDefault();
+      closeDrag.dy = Math.max(0, dy);
+      box.style.transform = `translateY(${closeDrag.dy}px)`;
+    }, { passive: false });
+    function endCloseDrag(event, cancelled = false) {
+      if (!closeDrag || (event && event.pointerId !== closeDrag.id)) return;
+      const current = closeDrag;
+      closeDrag = null;
+      try { header.releasePointerCapture(current.id); } catch {}
+      modal.classList.remove("asset-transfer-history-dragging");
+      if (!cancelled && current.active && current.dy > 100) {
+        box.style.transition = "transform 220ms cubic-bezier(0.55, 0, 1, 0.45)";
+        box.style.transform = "translateY(100dvh)";
+        window.setTimeout(() => {
+          if (isAssetTransferHistoryOpen()) closeAssetTransferHistory();
+        }, 220);
+        return;
+      }
+      if (!current.active) return;
+      box.style.transition = "transform 180ms ease";
+      box.style.transform = "translateY(0)";
+      window.setTimeout(() => {
+        if (
+          !isAssetTransferHistoryOpen()
+        ) return;
+        box.style.transition = "";
+        box.style.transform = "";
+      }, 190);
+    }
+    header.addEventListener("pointerup", (event) => endCloseDrag(event));
+    header.addEventListener("pointercancel", (event) => endCloseDrag(event, true));
+  }
+
   function initMobileWatchlistGestures() {
     const modal = el("watchlist-modal");
     const box = modal.querySelector(".watchlist-modal-box");
@@ -6737,6 +6828,7 @@
       );
     }
     initMobileAssetsGestures();
+    initMobileAssetTransferHistoryGestures();
     initMobileAccountPager();
   }
 

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -144,6 +144,11 @@
   let assetTransferReview = null;
   let assetTransferMode = "options";
   let assetTransferSubmitting = false;
+  let assetTransferHistoryRequestSeq = 0;
+  let assetTransferHistoryPortfolio = null;
+  let assetTransferHistoryRows = [];
+  let assetTransferHistoryCursor = null;
+  let assetTransferHistoryLoading = false;
   let updateConfirmationToken = "";
   let updatePollTimer = null;
   let updateMessageTimer = null;
@@ -1467,6 +1472,7 @@
 
   function closeAssets(options = {}) {
     if (!isAssetsOpen()) return;
+    closeAssetTransferHistory();
     closeAssetTransfer();
     closePositionPnlPopover();
     const modal = el("assets-modal");
@@ -2286,6 +2292,173 @@
     }
   }
 
+  function isAssetTransferHistoryOpen() {
+    return !el("asset-transfer-history-modal").classList.contains("hidden");
+  }
+
+  function closeAssetTransferHistory() {
+    if (!isAssetTransferHistoryOpen()) return;
+    assetTransferHistoryRequestSeq += 1;
+    assetTransferHistoryPortfolio = null;
+    assetTransferHistoryRows = [];
+    assetTransferHistoryCursor = null;
+    assetTransferHistoryLoading = false;
+    const modal = el("asset-transfer-history-modal");
+    modal.classList.add("hidden");
+    modal.setAttribute("aria-hidden", "true");
+    el("asset-transfer-history-refresh").classList.remove("assets-refreshing");
+  }
+
+  function transferHistoryRoute(record, exchangeId) {
+    const sourceAccount = String(record.from_account || record.account || "");
+    const targetAccount = String(record.to_account || record.account || "");
+    const sourceType = assetAccountTypeLabel(record.from_account_type, exchangeId);
+    const targetType = assetAccountTypeLabel(record.to_account_type, exchangeId);
+    const crossAccount = sourceAccount && targetAccount && sourceAccount !== targetAccount;
+    if (crossAccount) {
+      return `${sourceAccount} · ${sourceType} → ${targetAccount} · ${targetType}`;
+    }
+    return `${sourceType} → ${targetType}`;
+  }
+
+  function renderAssetTransferHistory(payload, append = false) {
+    const incoming = Array.isArray(payload.results) ? payload.results : [];
+    if (append) {
+      const byId = new Map(assetTransferHistoryRows.map((row) => [String(row.id), row]));
+      incoming.forEach((row) => byId.set(String(row.id), row));
+      assetTransferHistoryRows = Array.from(byId.values());
+    } else {
+      assetTransferHistoryRows = incoming;
+    }
+    assetTransferHistoryCursor = payload.next_cursor || null;
+    const list = el("asset-transfer-history-list");
+    list.replaceChildren();
+    const exchangeId = String(payload.exchange || "");
+    assetTransferHistoryRows.forEach((record) => {
+      const row = document.createElement("article");
+      row.className = "asset-transfer-history-row";
+
+      const top = document.createElement("div");
+      top.className = "asset-transfer-history-row-top";
+      const amount = document.createElement("strong");
+      amount.className = "asset-transfer-history-amount mono";
+      const direction = String(record.direction || "internal");
+      const prefix = direction === "out" ? "-" : direction === "in" ? "+" : "";
+      amount.textContent = `${prefix}${formatAssetAmount(record.amount)} ${record.currency || ""}`;
+      const status = document.createElement("span");
+      const statusText = String(record.status || "unknown");
+      const statusClass = statusText.toLowerCase().replace(/[^a-z0-9_-]+/g, "-");
+      status.className = `asset-transfer-history-status status-${statusClass}`;
+      status.textContent = statusText;
+      top.append(amount, status);
+
+      const route = document.createElement("div");
+      route.className = "asset-transfer-history-route";
+      route.textContent = transferHistoryRoute(record, exchangeId);
+
+      const meta = document.createElement("div");
+      meta.className = "asset-transfer-history-meta";
+      const occurred = document.createElement("time");
+      occurred.textContent = formatAccountHistoryDate(record.datetime, true, true);
+      const identifier = document.createElement("span");
+      identifier.className = "mono";
+      const rawId = String(record.id || "");
+      identifier.textContent = rawId ? `ID ${rawId.length > 18 ? `${rawId.slice(0, 8)}…${rawId.slice(-6)}` : rawId}` : "";
+      identifier.title = rawId;
+      meta.append(occurred, identifier);
+      row.append(top, route, meta);
+      list.appendChild(row);
+    });
+
+    const sync = payload.sync && typeof payload.sync === "object" ? payload.sync : {};
+    const warnings = Array.isArray(sync.warnings) ? [...sync.warnings] : [];
+    if (sync.last_error) warnings.push(String(sync.last_error));
+    const notice = el("asset-transfer-history-notice");
+    notice.textContent = warnings.join(" ");
+    notice.classList.toggle("hidden", warnings.length === 0);
+    list.classList.toggle("hidden", assetTransferHistoryRows.length === 0);
+    el("asset-transfer-history-empty").classList.toggle(
+      "hidden",
+      assetTransferHistoryRows.length !== 0,
+    );
+    el("asset-transfer-history-more").classList.toggle(
+      "hidden",
+      !assetTransferHistoryCursor,
+    );
+  }
+
+  async function loadAssetTransferHistory({ append = false, force = false } = {}) {
+    if (!assetTransferHistoryPortfolio || assetTransferHistoryLoading) return;
+    const requestId = ++assetTransferHistoryRequestSeq;
+    const firstLoad = !assetTransferHistoryRows.length && !append;
+    assetTransferHistoryLoading = true;
+    el("asset-transfer-history-loading").classList.toggle("hidden", !firstLoad);
+    el("asset-transfer-history-error").classList.add("hidden");
+    el("asset-transfer-history-refresh").classList.add("assets-refreshing");
+    el("asset-transfer-history-more").disabled = true;
+    const portfolio = assetTransferHistoryPortfolio;
+    const assets = (Array.isArray(portfolio.assets) ? portfolio.assets : [])
+      .map((item) => String(item.currency || "").toUpperCase())
+      .filter(Boolean);
+    const accountTypes = (Array.isArray(portfolio.account_type_statuses)
+      ? portfolio.account_type_statuses
+      : [])
+      .filter((item) => item.status === "ok")
+      .map((item) => String(item.account_type || "").toLowerCase())
+      .filter(Boolean);
+    const query = new URLSearchParams({
+      exchange: String(portfolio.exchange || ""),
+      account: String(portfolio.account || ""),
+      limit: "50",
+      force: force ? "true" : "false",
+      assets: Array.from(new Set(assets)).join(","),
+      account_types: Array.from(new Set(accountTypes)).join(","),
+    });
+    if (append && assetTransferHistoryCursor) {
+      query.set("cursor", assetTransferHistoryCursor);
+    }
+    try {
+      const payload = await api(`/api/assets/transfer/history?${query}`);
+      if (requestId !== assetTransferHistoryRequestSeq || !isAssetTransferHistoryOpen()) return;
+      renderAssetTransferHistory(payload, append);
+    } catch (error) {
+      if (requestId !== assetTransferHistoryRequestSeq || !isAssetTransferHistoryOpen()) return;
+      const errorElement = el("asset-transfer-history-error");
+      errorElement.textContent = error.message || String(error);
+      errorElement.classList.remove("hidden");
+      if (!assetTransferHistoryRows.length) {
+        el("asset-transfer-history-empty").classList.add("hidden");
+      }
+    } finally {
+      if (requestId === assetTransferHistoryRequestSeq) {
+        assetTransferHistoryLoading = false;
+        el("asset-transfer-history-loading").classList.add("hidden");
+        el("asset-transfer-history-refresh").classList.remove("assets-refreshing");
+        el("asset-transfer-history-more").disabled = false;
+      }
+    }
+  }
+
+  function openAssetTransferHistory(portfolio) {
+    assetTransferHistoryPortfolio = portfolio;
+    assetTransferHistoryRows = [];
+    assetTransferHistoryCursor = null;
+    assetTransferHistoryLoading = false;
+    el("asset-transfer-history-title").textContent = "Transfer History";
+    el("asset-transfer-history-subtitle").textContent =
+      `${portfolio.account} · ${assetExchangeLabel(portfolio.exchange)}`;
+    el("asset-transfer-history-list").replaceChildren();
+    el("asset-transfer-history-list").classList.add("hidden");
+    el("asset-transfer-history-empty").classList.add("hidden");
+    el("asset-transfer-history-notice").classList.add("hidden");
+    el("asset-transfer-history-error").classList.add("hidden");
+    el("asset-transfer-history-loading").classList.remove("hidden");
+    const modal = el("asset-transfer-history-modal");
+    modal.classList.remove("hidden");
+    modal.setAttribute("aria-hidden", "false");
+    loadAssetTransferHistory();
+  }
+
   function assetExchangeLabel(exchange) {
     const value = String(exchange || "Exchange");
     const labels = {
@@ -2542,7 +2715,22 @@
     statusText.textContent = availableTypes.length
       ? `Included: ${availableTypes.join(", ")}`
       : "No account balance type was available.";
-    footer.appendChild(statusText);
+    const primaryFooter = document.createElement("div");
+    primaryFooter.className = "assets-portfolio-footer-primary";
+    const historyLink = document.createElement("button");
+    historyLink.type = "button";
+    historyLink.className = "assets-transfer-history-link";
+    historyLink.textContent = "Transfer History";
+    historyLink.setAttribute(
+      "aria-label",
+      `Show transfer history for ${portfolio.account}`,
+    );
+    historyLink.addEventListener("click", (event) => {
+      event.stopPropagation();
+      openAssetTransferHistory(portfolio);
+    });
+    primaryFooter.append(statusText, historyLink);
+    footer.appendChild(primaryFooter);
 
     const accountNames = Array.isArray(portfolio.account_names)
       ? portfolio.account_names
@@ -6451,6 +6639,20 @@
     window.addEventListener("resize", closePositionPnlPopover, { passive: true });
     window.addEventListener("resize", schedulePnlListSizing, { passive: true });
     el("asset-transfer-close").addEventListener("click", closeAssetTransfer);
+    el("asset-transfer-history-close").addEventListener(
+      "click",
+      closeAssetTransferHistory,
+    );
+    el("asset-transfer-history-refresh").addEventListener("click", () => {
+      loadAssetTransferHistory({ force: true });
+    });
+    el("asset-transfer-history-more").addEventListener("click", () => {
+      loadAssetTransferHistory({ append: true });
+    });
+    const transferHistoryModal = el("asset-transfer-history-modal");
+    transferHistoryModal.addEventListener("click", (event) => {
+      if (event.target === transferHistoryModal) closeAssetTransferHistory();
+    });
     el("asset-transfer-back").addEventListener("click", () => {
       if (assetTransferMode === "review") {
         assetTransferReview = null;
@@ -9471,7 +9673,8 @@
     }
     closeHubMenu();
     if (isCalendarOpen()) closeCalendar();
-    if (isAssetTransferOpen()) closeAssetTransfer();
+    if (isAssetTransferHistoryOpen()) closeAssetTransferHistory();
+    else if (isAssetTransferOpen()) closeAssetTransfer();
     else if (isAssetsOpen()) closeAssets();
     closeScriptDropdown();
     closeDataSinceTooltips();


### PR DESCRIPTION
## 변경사항
- 거래소 계정별 Transfer History 조회 및 캐시 저장 기능 추가
- 거래소 메인 및 서브 계정 식별자를 providers.toml의 계정명으로 표시
- OKX 전송 이력 중복 정리 및 거래소별 계정 간 전송 경로 정규화
- Assets 계정 상세 화면에서 전송 이력 진입점 제공
- 모바일 Transfer History 드래그 핸들과 아래 스와이프 닫기 지원
- Hyperliquid는 계정 모드와 무관하게 조회 전용으로 제한하고 전송 UI와 API 경로 제거
- README에 Hyperliquid Account Center 설정 및 제한사항 반영

## 검증
- 자산 전송 관련 단위 테스트 14건 통과
- Python 구문 검사 및 dashboard.js 문법 검사 통과
- 모바일 Transfer History 핸들 및 스와이프 동작 확인