### PR TITLE
세션별 pre-run 실행 시각 분산 및 warm-up 상태 UI 추가

### DIFF
--- a/data_service/api.py
+++ b/data_service/api.py
@@ -430,6 +430,8 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
         rt = _rt(session_id)
         if rt is None:
             return JSONResponse([], status_code=404)
+        if rt.runner_phase == "prerun_active":
+            return JSONResponse({"status": "warming_up"}, status_code=409)
         plot_options = rt.plot_options
         plot_path = rt.paths.plot_path
         ohlcv_path = rt.ohlcv_path
@@ -545,6 +547,9 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
             "script_title": script_title,
             "script_source_name": script_source_name,
             "has_script_source": has_script_source,
+            "runner_connected": rt.runner_count > 0,
+            "runner_phase": rt.runner_phase,
+            "next_prerun_at": rt.next_prerun_at,
         })
 
     @r.get("/api/{session_id}/script-source")
@@ -1699,6 +1704,32 @@ def build_control_router(
         except Exception as e:
             return JSONResponse({"error": f"failed to update history_since: {e}"}, status_code=500)
         return JSONResponse({"ok": True, "history_since": value})
+
+    @r.patch("/api/sessions/{session_id}/prerun-schedule")
+    async def update_prerun_schedule(
+        session_id: str,
+        payload: dict = Body(default_factory=dict),
+    ) -> JSONResponse:
+        try:
+            spec = await registry.update_prerun_schedule(
+                session_id,
+                payload.get("mode", "auto"),
+                payload.get("offset_seconds"),
+            )
+        except ValueError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
+        except SessionNotFoundError:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        except Exception as e:
+            return JSONResponse(
+                {"error": f"failed to update warm-up schedule: {e}"},
+                status_code=500,
+            )
+        return JSONResponse({
+            "ok": True,
+            "mode": spec.prerun_mode,
+            "offset_seconds": spec.prerun_offset_seconds,
+        })
 
     @r.patch("/api/sessions/{session_id}/script")
     async def update_session_script(

--- a/data_service/config.py
+++ b/data_service/config.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from pathlib import Path
 
 from pynecore.cli.app import app_state
+from prerun_scheduler import validate_prerun_schedule
 
 # Maximum number of concurrent sessions the hub will manage (decision 8-4).
 MAX_SESSIONS = 20
@@ -152,6 +153,8 @@ class SessionSpec:
     script_name: str
     webhook: dict  # {"enabled": bool, "telegram_notification": bool}  (decision 8-1)
     market_type: str = ""
+    prerun_mode: str = "auto"
+    prerun_offset_seconds: int | None = None
     manual_alert_templates: list[dict] = field(default_factory=list)
     manual_alert_triggers: list[dict] = field(default_factory=list)
 
@@ -168,6 +171,11 @@ class SessionSpec:
         script_name = (d.get("script_name") or "")
         sid = (d.get("id") or "").strip() or slugify_session_id(exchange, symbol, timeframe, script_name)
         webhook = d.get("webhook") or {}
+        prerun_mode, prerun_offset_seconds = validate_prerun_schedule(
+            timeframe,
+            d.get("prerun_mode", "auto"),
+            d.get("prerun_offset_seconds"),
+        )
         return cls(
             id=sid,
             provider=provider,
@@ -184,6 +192,8 @@ class SessionSpec:
                 "telegram_chat_id": (webhook.get("telegram_chat_id") or ""),
             },
             market_type=sanitize_market_type(d.get("market_type")),
+            prerun_mode=prerun_mode,
+            prerun_offset_seconds=prerun_offset_seconds,
             manual_alert_templates=sanitize_manual_alert_templates(d.get("manual_alert_templates")),
             manual_alert_triggers=sanitize_manual_alert_triggers(d.get("manual_alert_triggers")),
         )
@@ -210,6 +220,8 @@ class SessionSpec:
             history_since=self.history_since, script_name=self.script_name,
             webhook=wh,
             market_type=self.market_type,
+            prerun_mode=self.prerun_mode,
+            prerun_offset_seconds=self.prerun_offset_seconds,
             manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
             manual_alert_triggers=[dict(t) for t in self.manual_alert_triggers],
         )
@@ -221,6 +233,8 @@ class SessionSpec:
             history_since=history_since, script_name=self.script_name,
             webhook=dict(self.webhook),
             market_type=self.market_type,
+            prerun_mode=self.prerun_mode,
+            prerun_offset_seconds=self.prerun_offset_seconds,
             manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
             manual_alert_triggers=[dict(t) for t in self.manual_alert_triggers],
         )
@@ -232,6 +246,8 @@ class SessionSpec:
             history_since=self.history_since, script_name=self.script_name,
             webhook=dict(self.webhook),
             market_type=self.market_type,
+            prerun_mode=self.prerun_mode,
+            prerun_offset_seconds=self.prerun_offset_seconds,
             manual_alert_templates=sanitize_manual_alert_templates(templates),
             manual_alert_triggers=[dict(t) for t in self.manual_alert_triggers],
         )
@@ -243,6 +259,8 @@ class SessionSpec:
             history_since=self.history_since, script_name=self.script_name,
             webhook=dict(self.webhook),
             market_type=self.market_type,
+            prerun_mode=self.prerun_mode,
+            prerun_offset_seconds=self.prerun_offset_seconds,
             manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
             manual_alert_triggers=sanitize_manual_alert_triggers(triggers),
         )
@@ -262,7 +280,32 @@ class SessionSpec:
         }
         if self.market_type:
             data["market_type"] = self.market_type
+        data["prerun_mode"] = self.prerun_mode
+        if self.prerun_offset_seconds is not None:
+            data["prerun_offset_seconds"] = self.prerun_offset_seconds
         return data
+
+    def with_prerun_schedule(self, mode: object, offset_seconds: object = None) -> "SessionSpec":
+        prerun_mode, prerun_offset = validate_prerun_schedule(
+            self.timeframe,
+            mode,
+            offset_seconds,
+        )
+        return SessionSpec(
+            id=self.id,
+            provider=self.provider,
+            exchange=self.exchange,
+            symbol=self.symbol,
+            timeframe=self.timeframe,
+            history_since=self.history_since,
+            script_name=self.script_name,
+            webhook=dict(self.webhook),
+            market_type=self.market_type,
+            prerun_mode=prerun_mode,
+            prerun_offset_seconds=prerun_offset,
+            manual_alert_templates=[dict(t) for t in self.manual_alert_templates],
+            manual_alert_triggers=[dict(t) for t in self.manual_alert_triggers],
+        )
 
     @property
     def feed_id(self) -> str:

--- a/data_service/file_update_loop.py
+++ b/data_service/file_update_loop.py
@@ -31,6 +31,7 @@ from ohlcv_cache import (
     export_to_ohlcv_since,
 )
 from ohlcv_paths import make_cache_path
+from prerun_scheduler import default_offset_seconds
 from state import DataState
 from log_utils import log_with_time
 
@@ -74,6 +75,7 @@ async def file_update_loop(
     toml_path: Path,
     state: DataState,
     emit_event: Callable[[dict], Awaitable[None]],
+    get_prerun_offset_seconds: Callable[[], int] | None = None,
     poll_sec: float = 0.1,
     history_ready_event: asyncio.Event | None = None,
 ) -> None:
@@ -285,8 +287,18 @@ async def file_update_loop(
             if file_path.exists():
                 file_path.unlink()
 
-    timeframe_ms = convert_timeframe(timeframe, to_ms=True)
-    pre_run_script_time = timeframe_ms / 2
+    # Prepare each shared feed at the earliest slot assigned to one of its
+    # sessions. The sessions then dispatch prerun_ready at their own offsets.
+    def resolved_prerun_offset_ms() -> int:
+        try:
+            seconds = (
+                get_prerun_offset_seconds()
+                if get_prerun_offset_seconds is not None
+                else default_offset_seconds(timeframe)
+            )
+            return max(0, int(seconds)) * 1000
+        except (TypeError, ValueError):
+            return default_offset_seconds(timeframe) * 1000
     fixed_open_price: float = 0.0
     open_fix_done = False
 
@@ -377,7 +389,10 @@ async def file_update_loop(
                 len(bars) == 2
                 and ohlcv_path.exists()
                 and (not open_fix_done)
-                and (datetime.now().timestamp() * 1000 >= bars[1][0] + pre_run_script_time)
+                and (
+                    datetime.now().timestamp() * 1000
+                    >= bars[1][0] + resolved_prerun_offset_ms()
+                )
             ):
                 # Wait for history download and fix last open if needed.
                 if not history_download_complete:

--- a/data_service/prerun_scheduler.py
+++ b/data_service/prerun_scheduler.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from bisect import bisect_left
+from collections import Counter
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable, Protocol
+
+
+ONE_MINUTE_SLOTS = (10, 15, 20, 25, 30)
+FIVE_MINUTE_SLOTS = (15, 35, 55, 75, 95, 115, 135, 150)
+STANDARD_SLOT_INTERVAL_SECONDS = 20
+
+
+class SchedulableSession(Protocol):
+    id: str
+    timeframe: str
+    prerun_mode: str
+    prerun_offset_seconds: int | None
+
+
+@dataclass(frozen=True)
+class PrerunAssignment:
+    session_id: str
+    offset_seconds: int
+    duplicate: bool
+
+
+@lru_cache(maxsize=None)
+def timeframe_seconds(timeframe: str) -> int:
+    value = str(timeframe or "").strip()
+    if len(value) < 2 or not value[:-1].isdigit():
+        return 60
+    number = int(value[:-1])
+    unit = value[-1]
+    if unit == "M":
+        return number * 30 * 86400
+    multiplier = {
+        "s": 1,
+        "m": 60,
+        "h": 3600,
+        "d": 86400,
+        "w": 604800,
+    }.get(unit.lower())
+    return number * multiplier if multiplier is not None else 60
+
+
+@lru_cache(maxsize=None)
+def scheduling_window(timeframe: str) -> tuple[int, int, int] | None:
+    value = str(timeframe or "").strip()
+    if value == "1m":
+        return ONE_MINUTE_SLOTS[0], ONE_MINUTE_SLOTS[-1], 5
+    if value == "5m":
+        return FIVE_MINUTE_SLOTS[0], FIVE_MINUTE_SLOTS[-1], STANDARD_SLOT_INTERVAL_SECONDS
+
+    duration = timeframe_seconds(value)
+    if duration > 5 * 60:
+        return 15, duration - 5 * 60, STANDARD_SLOT_INTERVAL_SECONDS
+    return None
+
+
+@lru_cache(maxsize=None)
+def candidate_slots(timeframe: str) -> tuple[int, ...]:
+    value = str(timeframe or "").strip()
+    if value == "1m":
+        return ONE_MINUTE_SLOTS
+    if value == "5m":
+        return FIVE_MINUTE_SLOTS
+
+    window = scheduling_window(value)
+    if window is None:
+        return ()
+    start, end, interval = window
+    slots = list(range(start, end + 1, interval))
+    if slots[-1] != end:
+        slots.append(end)
+    return tuple(slots)
+
+
+def default_offset_seconds(timeframe: str) -> int:
+    slots = candidate_slots(timeframe)
+    if slots:
+        return slots[0]
+    return max(1, timeframe_seconds(timeframe) // 2)
+
+
+def validate_prerun_schedule(
+    timeframe: str,
+    mode: object,
+    offset_seconds: object = None,
+) -> tuple[str, int | None]:
+    normalized_mode = str(mode or "auto").strip().lower()
+    if normalized_mode not in {"auto", "custom"}:
+        raise ValueError("pre-run timing must be auto or custom")
+    if normalized_mode == "auto":
+        return "auto", None
+
+    window = scheduling_window(timeframe)
+    if window is None:
+        raise ValueError(
+            "custom warm-up timing is supported for 1m, 5m, and longer sessions"
+        )
+    try:
+        offset = int(offset_seconds)
+    except (TypeError, ValueError):
+        raise ValueError("custom warm-up time must be expressed in whole seconds")
+    minimum, maximum, _ = window
+    if offset < minimum or offset > maximum:
+        raise ValueError(
+            f"custom warm-up time for {timeframe} must be between "
+            f"{minimum} and {maximum} seconds"
+        )
+    return "custom", offset
+
+
+def _nearest_distance(slot: int, occupied: list[int]) -> int:
+    if not occupied:
+        return 10_000_000
+    index = bisect_left(occupied, slot)
+    distances = []
+    if index < len(occupied):
+        distances.append(abs(occupied[index] - slot))
+    if index > 0:
+        distances.append(abs(slot - occupied[index - 1]))
+    return min(distances)
+
+
+def _shorter_timeframe_starts(
+    duration: int,
+    sessions: list[SchedulableSession],
+    assignments: dict[str, PrerunAssignment],
+) -> list[int]:
+    starts: set[int] = set()
+    for session in sessions:
+        interval = timeframe_seconds(session.timeframe)
+        if interval >= duration:
+            continue
+        offset = assignments[session.id].offset_seconds
+        starts.update(range(offset, duration, interval))
+    return sorted(starts)
+
+
+def assign_prerun_offsets(
+    sessions: Iterable[SchedulableSession],
+) -> dict[str, PrerunAssignment]:
+    ordered = list(sessions)
+    assignments: dict[str, PrerunAssignment] = {}
+    schedulable: dict[int, list[SchedulableSession]] = {}
+
+    for session in ordered:
+        if candidate_slots(session.timeframe):
+            duration = timeframe_seconds(session.timeframe)
+            schedulable.setdefault(duration, []).append(session)
+
+    shorter_sessions: list[SchedulableSession] = []
+    for duration in sorted(schedulable):
+        group = schedulable[duration]
+        slots = candidate_slots(group[0].timeframe)
+        counts: Counter[int] = Counter()
+
+        for session in group:
+            if session.prerun_mode != "custom" or session.prerun_offset_seconds is None:
+                continue
+            offset = int(session.prerun_offset_seconds)
+            counts[offset] += 1
+            assignments[session.id] = PrerunAssignment(
+                session_id=session.id,
+                offset_seconds=offset,
+                duplicate=counts[offset] > 1,
+            )
+
+        occupied = _shorter_timeframe_starts(
+            duration,
+            shorter_sessions,
+            assignments,
+        )
+        occupied_set = set(occupied)
+        for session in group:
+            if session.id in assignments:
+                continue
+            offset = min(
+                slots,
+                key=lambda slot: (
+                    counts[slot],
+                    slot in occupied_set,
+                    -_nearest_distance(slot, occupied),
+                    slot,
+                ),
+            )
+            counts[offset] += 1
+            assignments[session.id] = PrerunAssignment(
+                session_id=session.id,
+                offset_seconds=offset,
+                duplicate=counts[offset] > 1,
+            )
+        shorter_sessions.extend(group)
+
+    for session in ordered:
+        if session.id in assignments:
+            continue
+        offset = default_offset_seconds(session.timeframe)
+        assignments[session.id] = PrerunAssignment(
+            session_id=session.id,
+            offset_seconds=offset,
+            duplicate=False,
+        )
+
+    return assignments

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -10,6 +10,7 @@ from typing import Awaitable, Callable, Dict, List, Optional
 from config import MAX_SESSIONS, FeedSpec, SessionSpec, save_sessions
 from collector_loop import fix_missing_bars_loop, watch_trades_loop
 from file_update_loop import _to_thread_cancel_safe, file_update_loop
+from prerun_scheduler import assign_prerun_offsets
 from runner_supervisor import RunnerSupervisor
 from runtime import Feed, Session
 from tv_logos import TradingViewLogoResolver
@@ -84,6 +85,25 @@ class SessionRegistry:
             out.append(snap)
         return out
 
+    def _rebalance_prerun_schedule(self) -> None:
+        assignments = assign_prerun_offsets(
+            session.spec for session in self.sessions.values()
+        )
+        for session_id, assignment in assignments.items():
+            session = self.sessions.get(session_id)
+            if session is not None:
+                session.set_prerun_assignment(
+                    assignment.offset_seconds,
+                    assignment.duplicate,
+                )
+        for feed in self.feeds.values():
+            offsets = [
+                session.prerun_effective_offset_seconds
+                for session in feed.subscribers.values()
+            ]
+            if offsets:
+                feed.prerun_prepare_offset_seconds = min(offsets)
+
     def retry_missing_symbol_logos(self) -> None:
         """Retry logo resolution when a dashboard reconnects after an earlier miss."""
         for session in list(self.sessions.values()):
@@ -148,6 +168,7 @@ class SessionRegistry:
                     toml_path=feed.paths.toml_path,
                     state=feed.state,
                     emit_event=feed.emit_event,
+                    get_prerun_offset_seconds=lambda: feed.prerun_prepare_offset_seconds,
                     history_ready_event=history_ready_event,
                 )
                 return
@@ -280,6 +301,7 @@ class SessionRegistry:
         session.on_ai_instruction = self.ai_instruction_handler
         feed.subscribers[spec.id] = session
         self.sessions[spec.id] = session
+        self._rebalance_prerun_schedule()
         self._schedule_logo_resolution(session)
         if persist:
             self._persist()
@@ -299,6 +321,7 @@ class SessionRegistry:
         feed = session.feed
         feed.subscribers.pop(session_id, None)
         del self.sessions[session_id]
+        self._rebalance_prerun_schedule()
         await self._teardown_feed_if_idle(feed)
         if cleanup_output:
             # Remove this session's output dir (plot.csv / script_hash.csv / runner.log).
@@ -317,10 +340,12 @@ class SessionRegistry:
 
         previous_sessions = self.sessions
         self.sessions = {session_id: previous_sessions[session_id] for session_id in session_ids}
+        self._rebalance_prerun_schedule()
         try:
             self._persist()
         except Exception:
             self.sessions = previous_sessions
+            self._rebalance_prerun_schedule()
             raise
         await self.notify_hub()
         return self.snapshots()
@@ -375,6 +400,31 @@ class SessionRegistry:
         await session.push_webhook_config()
         await self.notify_hub()
         return dict(session.spec.webhook)
+
+    async def update_prerun_schedule(
+        self,
+        session_id: str,
+        mode: object,
+        offset_seconds: object = None,
+    ) -> SessionSpec:
+        session = self.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFoundError(session_id)
+
+        previous_specs = {key: value.spec for key, value in self.sessions.items()}
+        session.spec = session.spec.with_prerun_schedule(mode, offset_seconds)
+        self._rebalance_prerun_schedule()
+        try:
+            self._persist()
+        except Exception:
+            for key, spec in previous_specs.items():
+                current = self.sessions.get(key)
+                if current is not None:
+                    current.spec = spec
+            self._rebalance_prerun_schedule()
+            raise
+        await self.notify_hub()
+        return session.spec
 
     async def update_history_since(self, session_id: str, history_since: str) -> None:
         session = self.sessions.get(session_id)

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -17,6 +17,7 @@ from pynecore.core.exchange_policy import tradingview_hides_zero_volume
 from log_utils import log_with_time
 from manual_alerts import build_manual_alert_payload, send_manual_alert_payload
 from ohlcv_paths import make_ohlcv_paths, runtime_output_dir
+from prerun_scheduler import default_offset_seconds
 from state import DataState
 from tv_logos import static_logo_info
 from ws_manager import WSManager
@@ -85,6 +86,7 @@ class Feed:
         self._last_raw_trade_price: Optional[float] = None
         self._last_raw_trade_time_ms: Optional[int] = None
         self._raw_trade_stream_started = False
+        self.prerun_prepare_offset_seconds = default_offset_seconds(spec.timeframe)
         self._recent_raw_trade_keys: deque[tuple[Any, ...]] = deque()
         self._recent_raw_trade_key_set: set[tuple[Any, ...]] = set()
         # session_id -> Session
@@ -185,20 +187,7 @@ class Feed:
         for session in list(self.subscribers.values()):
             if session.runner_count <= 0:
                 continue
-            session_payload = dict(payload)
-            if (
-                session.strategy_evaluation_enabled
-                and payload.get("type") in {
-                    "prerun_ready",
-                    "prerun_ready_after_history_download",
-                    "run_ready",
-                }
-            ):
-                generation_id = await session.begin_calculation(session_payload)
-                if generation_id is not None:
-                    session_payload["calculation_generation_id"] = generation_id
-                    session_payload["strategy_evaluation_enabled"] = True
-            await session.send_to_runners(session_payload)
+            await session.handle_feed_event(dict(payload))
 
     def history_ready(self) -> bool:
         return self.history_ready_event.is_set()
@@ -273,6 +262,11 @@ class Session:
         # Drives the dashboard LED: connected-but-prerunning = "starting" (amber),
         # ready = "running" (green).
         self.runner_ready = False
+        self.runner_phase = "stopped"
+        self.next_prerun_at: int | None = None
+        self.prerun_effective_offset_seconds = default_offset_seconds(spec.timeframe)
+        self.prerun_duplicate = False
+        self._prerun_dispatch_task: asyncio.Task | None = None
         self.history_resync_pending = False
         self.calculation_generation_id = uuid.uuid4().hex
         self.calculation_status = "stopped"
@@ -303,6 +297,119 @@ class Session:
         self._manual_alert_trigger_gates: dict[str, dict[str, Any]] = {}
         self.reset_manual_alert_trigger_gate()
 
+    def set_prerun_assignment(self, offset_seconds: int, duplicate: bool) -> None:
+        self.prerun_effective_offset_seconds = max(0, int(offset_seconds))
+        self.prerun_duplicate = bool(duplicate)
+
+    def _runner_phase_payload(self) -> dict[str, Any]:
+        return {
+            "type": "runner_phase",
+            "phase": self.runner_phase,
+            "next_prerun_at": self.next_prerun_at,
+        }
+
+    async def _set_runner_phase(
+        self,
+        phase: str,
+        *,
+        next_prerun_at: int | None = None,
+    ) -> None:
+        changed = phase != self.runner_phase or next_prerun_at != self.next_prerun_at
+        self.runner_phase = phase
+        self.next_prerun_at = next_prerun_at
+        if not changed:
+            return
+        await self.send_to_charts(self._runner_phase_payload())
+        await self._notify_status()
+
+    def _cancel_prerun_dispatch(self) -> None:
+        task = self._prerun_dispatch_task
+        self._prerun_dispatch_task = None
+        if task is not None and not task.done():
+            task.cancel()
+
+    @staticmethod
+    def _event_new_bar_time_ms(event: dict[str, Any]) -> int | None:
+        bars = event.get("confirmed_bar_and_new_bar")
+        if not isinstance(bars, list) or len(bars) < 2:
+            return None
+        new_bar = bars[1]
+        if not isinstance(new_bar, (list, tuple)) or not new_bar:
+            return None
+        try:
+            return int(new_bar[0])
+        except (TypeError, ValueError):
+            return None
+
+    async def _send_runner_event(self, payload: dict[str, Any]) -> None:
+        session_payload = dict(payload)
+        if (
+            self.strategy_evaluation_enabled
+            and session_payload.get("type") in {
+                "prerun_ready",
+                "prerun_ready_after_history_download",
+                "run_ready",
+            }
+        ):
+            generation_id = await self.begin_calculation(session_payload)
+            if generation_id is not None:
+                session_payload["calculation_generation_id"] = generation_id
+                session_payload["strategy_evaluation_enabled"] = True
+        await self.send_to_runners(session_payload)
+
+    async def _schedule_next_prerun(self, run_ready: dict[str, Any]) -> None:
+        new_bar_time_ms = self._event_new_bar_time_ms(run_ready)
+        if new_bar_time_ms is None:
+            await self._set_runner_phase("running")
+            return
+        target_ms = new_bar_time_ms + self.prerun_effective_offset_seconds * 1000
+        await self._set_runner_phase("prerun_scheduled", next_prerun_at=target_ms)
+
+    async def _dispatch_prerun(self, payload: dict[str, Any], target_ms: int) -> None:
+        try:
+            delay = max(0.0, (target_ms - int(time.time() * 1000)) / 1000)
+            if delay > 0:
+                await asyncio.sleep(delay)
+            if self.runner_count <= 0:
+                return
+            await self._set_runner_phase("prerun_active")
+            await self._send_runner_event(payload)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            if self._prerun_dispatch_task is asyncio.current_task():
+                self._prerun_dispatch_task = None
+
+    async def _start_prerun_dispatch(self, payload: dict[str, Any], target_ms: int) -> None:
+        if target_ms > int(time.time() * 1000):
+            await self._set_runner_phase(
+                "prerun_scheduled",
+                next_prerun_at=target_ms,
+            )
+        self._cancel_prerun_dispatch()
+        self._prerun_dispatch_task = asyncio.create_task(
+            self._dispatch_prerun(payload, target_ms),
+            name=f"prerun-dispatch:{self.spec.id}",
+        )
+
+    async def handle_feed_event(self, payload: dict[str, Any]) -> None:
+        event_type = payload.get("type")
+        if event_type == "prerun_ready":
+            new_bar_time_ms = self._event_new_bar_time_ms(payload)
+            if new_bar_time_ms is None:
+                target_ms = int(time.time() * 1000)
+            else:
+                target_ms = new_bar_time_ms + self.prerun_effective_offset_seconds * 1000
+            await self._start_prerun_dispatch(payload, target_ms)
+            return
+
+        if event_type == "run_ready":
+            await self._send_runner_event(payload)
+            await self._schedule_next_prerun(payload)
+            return
+
+        await self._send_runner_event(payload)
+
     def reconfigure_script(self, spec: SessionSpec) -> None:
         """Apply a stopped-session script change without replacing its identity."""
         self.spec = spec
@@ -310,6 +417,9 @@ class Session:
         self.plot_options.clear()
         self.plotchar_history.clear()
         self.runner_ready = False
+        self.runner_phase = "stopped"
+        self.next_prerun_at = None
+        self._cancel_prerun_dispatch()
         self.history_resync_pending = False
         self.calculation_generation_id = uuid.uuid4().hex
         self.calculation_status = "stopped"
@@ -476,6 +586,9 @@ class Session:
             if self.runner_count <= 0:
                 self.runner_count = 0
                 self.runner_ready = False
+                self._cancel_prerun_dispatch()
+                self.runner_phase = "stopped"
+                self.next_prerun_at = None
                 await self.set_calculation_stopped()
                 await self.send_to_charts({"type": "runner_disconnected"})
             await self._notify_status()
@@ -498,6 +611,7 @@ class Session:
         if msg_type == "client_hello":
             role = event.get("role")
             if role == "runner":
+                self.runner_ready = False  # fresh runner: pre_run not done yet (amber)
                 if self.strategy_evaluation_enabled:
                     await self.begin_calculation({"type": "runner_start"})
                 # Replay the feed's pending after-history prerun only after the
@@ -518,9 +632,8 @@ class Session:
 
                 self.client_roles[ws] = role
                 self.runner_count += 1
-                self.runner_ready = False  # fresh runner: pre_run not done yet (amber)
+                await self._set_runner_phase("prerun_active")
                 await self.send_to_charts({"type": "runner_connected"})
-                await self._notify_status()
                 # Push this session's webhook/telegram config to the runner only
                 # (carries url/token — must not reach chart-page browsers).
                 await ws_manager.send(ws, self._webhook_config_payload())
@@ -528,6 +641,7 @@ class Session:
                 self.client_roles[ws] = role
                 if self.runner_count > 0:
                     await ws_manager.send(ws, {"type": "runner_connected"})
+                await ws_manager.send(ws, self._runner_phase_payload())
                 await ws_manager.send(ws, {
                     "type": "manual_alert_trigger",
                     "triggers": self.manual_alert_triggers_payload(),
@@ -539,7 +653,7 @@ class Session:
             # Runner finished its first pre_run -> flip the LED to green.
             self.runner_ready = True
             self.history_resync_pending = False
-            await self._notify_status()
+            await self._set_runner_phase("running")
 
         elif msg_type == "strategy_snapshot":
             if self.client_roles.get(ws) != "runner":
@@ -663,6 +777,10 @@ class Session:
                     print(f"[{self.spec.id}] Failed to broadcast plot data: {e}")
 
         elif msg_type == "script_info":
+            # The runner sends script_info again after each pre_run. Its initial
+            # connection copy arrives before runner_ready and is ignored here.
+            if self.runner_ready and self.runner_phase == "prerun_active":
+                await self._set_runner_phase("running")
             title = event.get("title") or "No title"
             self.chart_info["script_title"] = title
             self.chart_info["script_source_name"] = (
@@ -999,6 +1117,12 @@ class Session:
             "data_since_time": feed.history_start_time(),
             "runner_connected": self.runner_count > 0,
             "runner_ready": self.runner_ready,
+            "runner_phase": self.runner_phase,
+            "next_prerun_at": self.next_prerun_at,
+            "prerun_mode": self.spec.prerun_mode,
+            "prerun_offset_seconds": self.spec.prerun_offset_seconds,
+            "prerun_effective_offset_seconds": self.prerun_effective_offset_seconds,
+            "prerun_duplicate": self.prerun_duplicate,
             "calculation": self.calculation_state_payload(),
             "last_bar_time": feed.last_bar_time(),
             "last_price": feed.last_price(),

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -939,7 +939,76 @@ tr:last-child td { border-bottom: none; }
 .led-stopped { background: #6b7280; }
 .led-starting { background: #e0a300; animation: blink-fast 0.7s infinite; }
 .led-running { background: #28a745; box-shadow: 0 0 6px #28a745; animation: pulse-slow 2s ease-in-out infinite; }
+.led-running.led-warming { animation-duration: 0.65s; }
 .led-crashed { background: var(--danger); box-shadow: 0 0 7px var(--danger); }
+
+.runner-status-anchor {
+  position: relative;
+  display: inline-flex;
+  width: 20px;
+  height: 20px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  color: var(--text);
+  cursor: pointer;
+  vertical-align: middle;
+  touch-action: manipulation;
+}
+.runner-status-anchor:focus-visible {
+  border-radius: 4px;
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.runner-status-tooltip {
+  position: absolute;
+  left: 50%;
+  bottom: calc(100% + 7px);
+  z-index: 48;
+  min-width: max-content;
+  max-width: min(220px, calc(100vw - 24px));
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: #11161d;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.38);
+  color: var(--text);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.25;
+  letter-spacing: 0;
+  white-space: nowrap;
+  opacity: 0;
+  pointer-events: none;
+  transform: translate(-50%, 2px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+.runner-status-anchor.show-runner-status .runner-status-tooltip,
+.runner-status-anchor:focus-visible .runner-status-tooltip {
+  opacity: 1;
+  transform: translate(-50%, 0);
+}
+@media (hover: hover) and (pointer: fine) {
+  .runner-status-anchor:hover .runner-status-tooltip {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+}
+@media (max-width: 720px), (hover: none) and (pointer: coarse) {
+  .runner-status-tooltip {
+    top: calc(100% + 7px);
+    right: 0;
+    bottom: auto;
+    left: auto;
+    transform: translate(0, -2px);
+  }
+  .runner-status-anchor.show-runner-status .runner-status-tooltip,
+  .runner-status-anchor:focus-visible .runner-status-tooltip {
+    transform: translate(0, 0);
+  }
+}
 
 @keyframes pulse-slow { 0%, 100% { opacity: 1; } 50% { opacity: 0.2; } }
 @keyframes blink-fast { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
@@ -4283,6 +4352,88 @@ tr:last-child td { border-bottom: none; }
 }
 .settings-body input:focus { outline: none; border-color: var(--accent); }
 .settings-label { color: var(--muted); font-size: 12px; margin-top: 4px; }
+.settings-section-title {
+  margin-top: 2px;
+  color: var(--text);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+.settings-prerun-title {
+  margin-top: 16px;
+  padding-top: 14px;
+  border-top: 1px solid var(--border);
+}
+.settings-segmented {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  width: 100%;
+  margin-top: 8px;
+  padding: 2px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+}
+.settings-segmented button {
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 0;
+  border-radius: 4px;
+  background: transparent;
+  color: var(--muted);
+  font: inherit;
+  font-size: 12px;
+  letter-spacing: 0;
+  cursor: pointer;
+}
+.settings-segmented button.active {
+  background: #29313c;
+  color: var(--text);
+}
+.settings-segmented button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -1px;
+}
+.settings-segmented button:disabled { opacity: 0.55; cursor: wait; }
+.settings-prerun-assigned {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-top: 8px;
+  color: var(--muted);
+  font-size: 12px;
+}
+.settings-prerun-assigned strong {
+  color: var(--text);
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-variant-numeric: tabular-nums;
+}
+.settings-prerun-assigned span {
+  color: #d29922;
+  font-size: 10px;
+}
+.settings-prerun-custom {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 86px;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  color: var(--muted);
+  font-size: 12px;
+}
+.settings-prerun-custom[hidden] { display: none; }
+.settings-prerun-custom input {
+  width: 86px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+.settings-prerun-custom small {
+  grid-column: 2;
+  color: var(--muted);
+  font-size: 10px;
+  text-align: center;
+}
 .settings-body input:disabled { opacity: 0.55; cursor: not-allowed; }
 .settings-loading {
   display: flex;
@@ -5543,6 +5694,7 @@ tr:last-child td { border-bottom: none; }
     left: auto;
     right: 0;
     text-align: left;
+    white-space: normal;
   }
   /* bigger touch targets on mobile */
   .btn { padding: 8px 12px; }

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -4334,6 +4334,12 @@ tr:last-child td { border-bottom: none; }
   width: 13px;
   height: 13px;
 }
+/* webhook/telegram gear icons: match the 13px data-column icons */
+[data-act="webhook-settings"] .icon,
+[data-act="telegram-settings"] .icon {
+  width: 13px;
+  height: 13px;
+}
 #script-refresh.btn-icon {
   display: inline-flex;
   align-items: center;

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=141" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=142" />
 </head>
 <body>
   <header class="topbar">
@@ -1039,6 +1039,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=154"></script>
+  <script src="/static/dashboard.js?v=156"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=137" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=141" />
 </head>
 <body>
   <header class="topbar">
@@ -1039,6 +1039,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=148"></script>
+  <script src="/static/dashboard.js?v=154"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -7030,6 +7030,69 @@
     });
   }
 
+  function positionDataSincePopover(wrap) {
+    const popover = wrap && wrap.querySelector(".data-since-popover");
+    if (!popover) return;
+    const carousel = wrap.closest("#sessions > tbody");
+    const carouselRect = carousel ? carousel.getBoundingClientRect() : null;
+    const viewportPadding = 12;
+    const leftBoundary = Math.max(
+      viewportPadding,
+      carouselRect ? carouselRect.left + 2 : viewportPadding,
+    );
+    const rightBoundary = Math.min(
+      window.innerWidth - viewportPadding,
+      carouselRect ? carouselRect.right - 2 : window.innerWidth - viewportPadding,
+    );
+    popover.style.right = "auto";
+    popover.style.left = "0px";
+    popover.style.maxWidth = `${Math.max(120, rightBoundary - leftBoundary)}px`;
+    const rect = popover.getBoundingClientRect();
+    const minOffset = leftBoundary - rect.left;
+    const maxOffset = rightBoundary - rect.right;
+    const offset = Math.min(maxOffset, Math.max(minOffset, 0));
+    popover.style.left = `${Math.round(offset)}px`;
+  }
+
+  function runnerStatusText(session, now = Date.now()) {
+    const runner = String((session && session.runner) || "stopped");
+    const phase = String((session && session.runner_phase) || "");
+    if (runner === "stopped" || runner === "crashed") return runner;
+    if (phase === "prerun_active") return "warming up";
+    if (phase === "prerun_scheduled") {
+      const target = Number(session && session.next_prerun_at);
+      if (Number.isFinite(target) && target > 0) {
+        const remaining = Math.ceil((target - now) / 1000);
+        if (remaining <= 0) return "warming up";
+        if (remaining <= 5) return `warming up in ${remaining}s`;
+      }
+      return "running";
+    }
+    if (runner === "starting") return "warming up";
+    return "running";
+  }
+
+  function closeRunnerStatusTooltips(exceptAnchor = null) {
+    document.querySelectorAll(".runner-status-anchor.show-runner-status").forEach((anchor) => {
+      if (anchor !== exceptAnchor) anchor.classList.remove("show-runner-status");
+    });
+  }
+
+  function updateRunnerStatusTooltips() {
+    const now = Date.now();
+    document.querySelectorAll("#sessions tbody tr[data-session-id]").forEach((tr) => {
+      const session = sessions.find((item) => sessionId(item) === tr.dataset.sessionId);
+      if (!session) return;
+      const anchor = tr.querySelector('[data-act="runner-status"]');
+      const tooltip = tr.querySelector('[data-field="runner-status-tooltip"]');
+      const text = runnerStatusText(session, now);
+      setText(tooltip, text);
+      const led = tr.querySelector('[data-field="runner-led"]');
+      if (led) led.classList.toggle("led-warming", session.runner_phase === "prerun_active");
+      if (anchor) anchor.setAttribute("aria-label", `Runner status: ${text}`);
+    });
+  }
+
   function scriptSelectNodes() {
     return {
       control: el("script-select-control"),
@@ -7292,6 +7355,7 @@
     if (!wrap) return;
     const show = !wrap.classList.contains("show-since");
     closeDataSinceTooltips(wrap);
+    if (show) positionDataSincePopover(wrap);
     wrap.classList.toggle("show-since", show);
   }
 
@@ -7312,7 +7376,11 @@
               `<circle cx="15" cy="19" r="1.5"></circle>` +
             `</svg>` +
           `</button>` +
-          `<span data-field="runner-led" class="led"></span>` +
+          `<button type="button" class="runner-status-anchor" data-act="runner-status" ` +
+          `aria-label="Runner status">` +
+            `<span data-field="runner-led" class="led" aria-hidden="true"></span>` +
+            `<span data-field="runner-status-tooltip" class="runner-status-tooltip" role="status"></span>` +
+          `</button>` +
         `</span></td>` +
       `<td data-label="Symbol" class="mono"><span data-field="symbol-cell" class="symbol-cell"></span></td>` +
       `<td data-label="TF" data-field="timeframe"></td>` +
@@ -7332,7 +7400,7 @@
           `data-act="data-since"></span>` +
           `<span data-field="data-since-popover" class="data-since-popover"></span></span>` +
         `<button class="btn btn-icon data-edit-btn" data-act="data-edit" ` +
-        `title="Edit data start" aria-label="Edit data start">` +
+        `title="Data settings" aria-label="Data settings">` +
           `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">` +
             `<path d="M12 20h9"></path>` +
             `<path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"></path>` +
@@ -7389,6 +7457,14 @@
         }
       } else if (act === "data-edit") openSettings(id, "data-since");
       else if (act === "data-integrity") openSettings(id, "data-integrity");
+      else if (act === "runner-status") {
+        e.preventDefault();
+        e.stopPropagation();
+        const anchor = target.closest(".runner-status-anchor");
+        const show = anchor && !anchor.classList.contains("show-runner-status");
+        closeRunnerStatusTooltips(anchor);
+        if (anchor) anchor.classList.toggle("show-runner-status", Boolean(show));
+      }
       else if (act === "script-edit") openScriptChange(id);
       else if (act === "delete") openRemoveConfirm(id);
       else if (act === "logs") openLogs(id);
@@ -7408,7 +7484,11 @@
 
     const led = tr.querySelector('[data-field="runner-led"]');
     setClass(led, `led led-${runner}`);
-    if (led && led.title !== runner) led.title = runner;
+    const statusText = runnerStatusText(s);
+    if (led) led.classList.toggle("led-warming", s.runner_phase === "prerun_active");
+    setText(tr.querySelector('[data-field="runner-status-tooltip"]'), statusText);
+    const statusAnchor = tr.querySelector('[data-act="runner-status"]');
+    if (statusAnchor) statusAnchor.setAttribute("aria-label", `Runner status: ${statusText}`);
 
     const symbolKey = JSON.stringify([s.symbol || "", s.tv_symbol || "", s.symbol_logo_url || ""]);
     if (tr.dataset.symbolKey !== symbolKey) {
@@ -9321,6 +9401,8 @@
   let settingsSession = null;
   let settingsMode = null; // "webhook" | "telegram" | "data-since" | "data-integrity"
   let settingsOriginalHistorySince = null;
+  let settingsOriginalPrerunMode = "auto";
+  let settingsOriginalPrerunOffset = null;
   let settingsIntegrityAction = null;
   let settingsIntegrityReport = null;
   let settingsIntegrityRunning = null; // "check" | "repair"
@@ -9353,6 +9435,50 @@
     const value = Number(match[1]);
     const multiplier = match[2] === "m" ? 60 : match[2] === "h" ? 3600 : 86400;
     return value * multiplier;
+  }
+
+  function formatPrerunOffset(value) {
+    const total = Math.max(0, Number(value) || 0);
+    const minutes = Math.floor(total / 60);
+    const seconds = Math.floor(total % 60);
+    return `${String(minutes).padStart(2, "0")}:${String(seconds).padStart(2, "0")}`;
+  }
+
+  function parsePrerunOffset(value) {
+    const match = /^(\d+):([0-5]\d)$/.exec(String(value || "").trim());
+    if (!match) return null;
+    return Number(match[1]) * 60 + Number(match[2]);
+  }
+
+  function prerunScheduleRange(timeframe) {
+    const value = String(timeframe || "").trim();
+    if (value === "1m") return { min: 10, max: 30 };
+    if (value === "5m") return { min: 15, max: 150 };
+    const match = /^(\d+)([smhdwM])$/.exec(value);
+    if (!match) return null;
+    const amount = Number(match[1]);
+    const unit = match[2];
+    const multiplier = unit === "s" ? 1
+      : unit === "m" ? 60
+        : unit === "h" ? 3600
+          : unit === "d" ? 86400
+            : unit === "w" ? 604800
+              : 30 * 86400;
+    const duration = amount * multiplier;
+    return duration > 300 ? { min: 15, max: duration - 300 } : null;
+  }
+
+  function setPrerunSettingsMode(mode) {
+    const normalized = mode === "custom" ? "custom" : "auto";
+    const modeInput = el("settings-prerun-mode");
+    if (modeInput) modeInput.value = normalized;
+    document.querySelectorAll("[data-prerun-mode]").forEach((button) => {
+      const selected = button.dataset.prerunMode === normalized;
+      button.classList.toggle("active", selected);
+      button.setAttribute("aria-pressed", String(selected));
+    });
+    const customRow = el("settings-prerun-custom-row");
+    if (customRow) customRow.hidden = normalized !== "custom";
   }
 
   function renderDataIntegrityIntro(id) {
@@ -9482,6 +9608,8 @@
     settingsSession = id;
     settingsMode = mode;
     settingsOriginalHistorySince = null;
+    settingsOriginalPrerunMode = "auto";
+    settingsOriginalPrerunOffset = null;
     settingsIntegrityAction = null;
     settingsIntegrityReport = null;
     settingsIntegrityRunning = null;
@@ -9497,7 +9625,7 @@
       (mode === "webhook" ? "Webhook URL — "
         : mode === "telegram" ? "Telegram bot — "
         : mode === "data-integrity" ? "Data integrity — "
-        : "Data since — ") + id;
+        : "Data settings — ") + id;
     el("settings-fields").innerHTML = "loading…";
     el("settings-modal").classList.remove("hidden");
     lockBodyScroll();
@@ -9520,8 +9648,19 @@
         initial = String(s.history_since);
       }
       settingsOriginalHistorySince = initial;
+      settingsOriginalPrerunMode = s.prerun_mode === "custom" ? "custom" : "auto";
+      settingsOriginalPrerunOffset = s.prerun_offset_seconds == null
+        ? null
+        : Number(s.prerun_offset_seconds);
+      const effectiveOffset = Number(s.prerun_effective_offset_seconds) || 0;
+      const prerunRange = prerunScheduleRange(s.timeframe);
+      const supportsCustom = Boolean(prerunRange);
+      const customInitial = settingsOriginalPrerunOffset == null
+        ? effectiveOffset
+        : settingsOriginalPrerunOffset;
       el("settings-fields").innerHTML =
-        `<label class="settings-label">Data start (UTC)</label>` +
+        `<div class="settings-section-title">Data start</div>` +
+        `<label class="settings-label" for="settings-history-since">UTC date and time</label>` +
         `<input id="settings-history-since" type="text" ` +
         `placeholder="YYYY-MM-DD or YYYY-MM-DD HH:MM" value="${esc(initial)}">` +
         `<div class="muted">UTC date or datetime, e.g. 2026-05-01 or 2026-06-01 07:30.</div>` +
@@ -9530,10 +9669,35 @@
           ? `<div class="muted">Shares this market's data, so it changes too: ` +
             `<span class="mono">${esc(shared.join(", "))}</span></div>`
           : "") +
+        `<div class="settings-section-title settings-prerun-title">Warm-up schedule</div>` +
+        `<div class="muted">Warm-up recalculates the strategy over historical candles before processing the next confirmed candle.</div>` +
+        (supportsCustom
+          ? `<input id="settings-prerun-mode" type="hidden" value="${esc(settingsOriginalPrerunMode)}">` +
+            `<div class="settings-segmented" role="group" aria-label="Warm-up schedule mode">` +
+              `<button type="button" data-prerun-mode="auto">Auto</button>` +
+              `<button type="button" data-prerun-mode="custom">Custom</button>` +
+            `</div>` +
+            `<div class="settings-prerun-assigned">Assigned time ` +
+              `<strong>${esc(formatPrerunOffset(effectiveOffset))}</strong>` +
+              (s.prerun_duplicate ? `<span>shared slot</span>` : "") +
+            `</div>` +
+            `<label id="settings-prerun-custom-row" class="settings-prerun-custom" hidden>` +
+              `<span>Start after candle open</span>` +
+              `<input id="settings-prerun-offset" type="text" inputmode="numeric" ` +
+              `value="${esc(formatPrerunOffset(customInitial))}" placeholder="MM:SS">` +
+              `<small>${formatPrerunOffset(prerunRange.min)} - ${formatPrerunOffset(prerunRange.max)}</small>` +
+            `</label>`
+          : `<div class="muted">This timeframe uses the default midpoint schedule.</div>`) +
         `<div id="settings-loading" class="settings-loading" hidden>` +
           `<span class="settings-spinner" aria-hidden="true"></span>` +
           `<span class="settings-loading-text">Re-syncing data…</span>` +
         `</div>`;
+      if (supportsCustom) {
+        document.querySelectorAll("[data-prerun-mode]").forEach((button) => {
+          button.addEventListener("click", () => setPrerunSettingsMode(button.dataset.prerunMode));
+        });
+        setPrerunSettingsMode(settingsOriginalPrerunMode);
+      }
       return;
     }
     try {
@@ -9568,13 +9732,15 @@
     settingsSession = null;
     settingsMode = null;
     settingsOriginalHistorySince = null;
+    settingsOriginalPrerunMode = "auto";
+    settingsOriginalPrerunOffset = null;
     settingsIntegrityAction = null;
     settingsIntegrityReport = null;
     settingsIntegrityRunning = null;
     settingsIntegrityCancelRequested = false;
   }
 
-  function setDataSinceLoading(on) {
+  function setDataSettingsLoading(on, reSyncing = false) {
     const saveBtn = el("settings-save");
     const inputEl = el("settings-history-since");
     const status = el("settings-loading");
@@ -9583,6 +9749,13 @@
       saveBtn.textContent = on ? "Applying…" : "Save";
     }
     if (inputEl) inputEl.disabled = on;
+    const offsetInput = el("settings-prerun-offset");
+    if (offsetInput) offsetInput.disabled = on;
+    document.querySelectorAll("[data-prerun-mode]").forEach((button) => {
+      button.disabled = on;
+    });
+    const loadingText = status && status.querySelector(".settings-loading-text");
+    if (loadingText) loadingText.textContent = reSyncing ? "Re-syncing data…" : "Applying settings…";
     if (status) status.hidden = !on;
   }
 
@@ -9633,25 +9806,52 @@
       const inputEl = el("settings-history-since");
       const value = (inputEl ? inputEl.value : "").trim();
       const sid = settingsSession;
-      if (isSameUtcDateInput(value, settingsOriginalHistorySince)) {
+      const session = sessions.find((item) => sessionId(item) === sid) || {};
+      const historyChanged = !isSameUtcDateInput(value, settingsOriginalHistorySince);
+      const modeInput = el("settings-prerun-mode");
+      const prerunMode = modeInput && modeInput.value === "custom" ? "custom" : "auto";
+      let prerunOffset = null;
+      if (prerunMode === "custom") {
+        prerunOffset = parsePrerunOffset(el("settings-prerun-offset")?.value);
+        const range = prerunScheduleRange(session.timeframe);
+        if (!range || prerunOffset == null || prerunOffset < range.min || prerunOffset > range.max) {
+          el("settings-error").textContent =
+            range
+              ? `Warm-up time must be between ${formatPrerunOffset(range.min)} and ${formatPrerunOffset(range.max)}.`
+              : "Custom warm-up timing is not available for this timeframe.";
+          return;
+        }
+      }
+      const scheduleChanged = prerunMode !== settingsOriginalPrerunMode ||
+        (prerunMode === "custom" && prerunOffset !== settingsOriginalPrerunOffset);
+      if (!historyChanged && !scheduleChanged) {
         closeSettings();
         return;
       }
       el("settings-error").textContent = "";
-      setDataSinceLoading(true); // feed + runner restart takes a moment; no double-submit
+      setDataSettingsLoading(true, historyChanged);
       try {
-        await api(`/api/sessions/${encodeURIComponent(sid)}/history-since`, {
-          method: "PATCH",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ history_since: value }),
-        });
+        if (scheduleChanged) {
+          await api(`/api/sessions/${encodeURIComponent(sid)}/prerun-schedule`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ mode: prerunMode, offset_seconds: prerunOffset }),
+          });
+        }
+        if (historyChanged) {
+          await api(`/api/sessions/${encodeURIComponent(sid)}/history-since`, {
+            method: "PATCH",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ history_since: value }),
+          });
+        }
       } catch (e) {
         el("settings-error").textContent = e.message;
-        setDataSinceLoading(false);
+        setDataSettingsLoading(false);
         return;
       }
       if (settingsSession === sid && settingsMode === "data-since") {
-        setDataSinceLoading(false);
+        setDataSettingsLoading(false);
         closeSettings();
       }
       return;
@@ -9780,10 +9980,15 @@
     if (scriptControl && e.target && !scriptControl.contains(e.target)) {
       closeScriptDropdown();
     }
+    if (!e.target || !e.target.closest || !e.target.closest(".runner-status-anchor")) {
+      closeRunnerStatusTooltips();
+    }
     if (!isTouchTooltipMode()) return;
     if (!e.target || !e.target.closest || e.target.closest(".data-badge-wrap")) return;
     closeDataSinceTooltips();
   });
+
+  setInterval(updateRunnerStatusTooltips, 1000);
 
   // ---- collapsible "Add session" card (collapsed by default) ---------------
   let addCardAnimation = null;

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -7359,6 +7359,13 @@
     wrap.classList.toggle("show-since", show);
   }
 
+  // gear/cog line icon (matches the pencil/magnifier .icon line-icon style)
+  const settingsGearIcon =
+    `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">`
+    + `<circle cx="12" cy="12" r="3"></circle>`
+    + `<path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"></path>`
+    + `</svg>`;
+
   function createSessionRow(id) {
     const tr = document.createElement("tr");
     tr.dataset.sessionId = id;
@@ -7401,10 +7408,7 @@
           `<span data-field="data-since-popover" class="data-since-popover"></span></span>` +
         `<button class="btn btn-icon data-edit-btn" data-act="data-edit" ` +
         `title="Data settings" aria-label="Data settings">` +
-          `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">` +
-            `<path d="M12 20h9"></path>` +
-            `<path d="M16.5 3.5a2.1 2.1 0 0 1 3 3L7 19l-4 1 1-4z"></path>` +
-          `</svg>` +
+          settingsGearIcon +
         `</button>` +
         `<button class="btn btn-icon data-integrity-btn" data-act="data-integrity" ` +
         `title="Verify OHLCV data" aria-label="Verify OHLCV data">` +
@@ -7418,10 +7422,10 @@
       `<td data-label="Last bar" class="muted">${lastBarCell({})}</td>` +
       `<td data-label="Webhook"><span class="cell-inline">` +
         `<input type="checkbox" data-act="webhook">` +
-        `<button class="btn btn-icon" data-act="webhook-settings" title="Webhook URL">&#9881;</button></span></td>` +
+        `<button class="btn btn-icon" data-act="webhook-settings" title="Webhook URL">` + settingsGearIcon + `</button></span></td>` +
       `<td data-label="Telegram"><span class="cell-inline">` +
         `<input type="checkbox" data-act="telegram">` +
-        `<button class="btn btn-icon" data-act="telegram-settings" title="Telegram bot">&#9881;</button></span></td>` +
+        `<button class="btn btn-icon" data-act="telegram-settings" title="Telegram bot">` + settingsGearIcon + `</button></span></td>` +
       `<td data-label="Runner" class="runner-cell" data-field="runner-cell"></td>` +
       `<td data-label="Chart"><a data-field="chart-link" class="btn btn-chart" target="_blank">Open</a></td>` +
       `<td data-label="Remove"><button class="btn btn-danger btn-icon" data-act="delete" title="Delete session">&times;</button></td>`;

--- a/data_service/templates/data.js
+++ b/data_service/templates/data.js
@@ -334,14 +334,24 @@ App.data = {
     const collections = App.collections;
     const chart = App.chart;
     if (!state.runnerConnected || generation !== state.loadGeneration) return;
-    for (let i = 0; i < 30; i++) {
+    const warmupDeadline = Date.now() + 5 * 60 * 1000;
+    let attempts = 0;
+    while (attempts < 30 && Date.now() < warmupDeadline) {
       if (generation !== state.loadGeneration) return;
       try {
         const resp = await fetch(`${App.config.apiBase}/plot?limit=100000`);
+        if (resp.status === 409) {
+          await App.util.sleep(1000);
+          continue;
+        }
         const plots = await resp.json();
+        attempts += 1;
         if (generation !== state.loadGeneration) return;
 
-        if (Array.isArray(plots) && plots.length > 0) {
+        const hasHistoricalData = Array.isArray(plots) && plots.some(
+          plot => Array.isArray(plot && plot.data) && plot.data.length > 0
+        );
+        if (hasHistoricalData) {
           const pendingSeriesData = [];
           plots.forEach(plot => {
             const seriesData = [];
@@ -370,6 +380,7 @@ App.data = {
           return;
         }
       } catch (e) {
+        attempts += 1;
         // Ignore and retry
       }
       await App.util.sleep(1000);
@@ -510,12 +521,17 @@ App.data = {
       if (info.script_source_name != null) {
         state.scriptSourceName = info.script_source_name || "";
       }
-      state.baseInfoTop = `<span class="info-main">${symbol} | ${timeframe} | ${exchange}</span>`;
-      state.baseInfoText = state.baseInfoTop;
+      state.runnerConnected = Boolean(info.runner_connected);
+      state.runnerPhase = info.runner_phase || (state.runnerConnected ? "running" : "stopped");
+      state.nextPrerunAt = Number.isFinite(Number(info.next_prerun_at))
+        ? Number(info.next_prerun_at)
+        : null;
+      state.baseInfoTop = `${symbol} | ${timeframe} | ${exchange}`;
+      state.baseInfoText = "";
       App.ui.setChartInfo();
     } catch (e) {
-      state.baseInfoTop = "<span class=\"info-main\">Unknown | Unknown | Unknown</span>";
-      state.baseInfoText = state.baseInfoTop;
+      state.baseInfoTop = "Unknown | Unknown | Unknown";
+      state.baseInfoText = "";
       App.ui.setChartInfo();
     }
   },

--- a/data_service/templates/index.html
+++ b/data_service/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Chart</title>
-  <link rel="stylesheet" href="/static/styles.css?v=6" />
+  <link rel="stylesheet" href="/static/styles.css?v=13" />
   <script src="https://cdn.jsdelivr.net/npm/lightweight-charts@5.0.9/dist/lightweight-charts.standalone.production.js"></script>
 </head>
 <body>
@@ -32,7 +32,20 @@
   <button id="nav-to-start" class="nav-btn nav-btn-left" title="처음으로">&laquo;</button>
   <button id="nav-to-end" class="nav-btn nav-btn-right" title="최신으로">&raquo;</button>
   <div id="chart-info">
-    <div id="chart-info-line">Loading...</div>
+    <div id="chart-info-line">
+      <span id="chart-info-base" class="info-main">Loading...</span>
+      <span id="chart-info-separator" class="chart-info-separator hidden" aria-hidden="true">|</span>
+      <button id="chart-runner-status" class="chart-runner-status hidden" type="button"
+              aria-label="Strategy status" aria-expanded="false">
+        <span class="chart-runner-led" aria-hidden="true"></span>
+        <span id="chart-runner-popover" class="chart-runner-popover" role="status">
+          <strong id="chart-runner-status-text">running</strong>
+          <span>Strategy calculation step:<br>Warm-up &rarr; Confirmed bar calculation</span>
+          <span>Warm-up recalculates the strategy over historical candles before the next confirmed bar is processed.</span>
+        </span>
+      </button>
+      <span id="chart-info-ohlcv" class="info-ohlcv"></span>
+    </div>
     <div id="chart-info-title-row" class="hidden">
       <span id="chart-info-title"></span>
       <div id="toolbar">
@@ -163,13 +176,13 @@
     </div>
   </section>
   <!--RUNTIME_CONFIG-->
-  <script src="/static/state.js?v=2"></script>
-  <script src="/static/ui.js?v=5"></script>
+  <script src="/static/state.js?v=3"></script>
+  <script src="/static/ui.js?v=10"></script>
   <script src="/static/bgcolor.js?v=2"></script>
   <script src="/static/chart.js?v=3"></script>
   <script src="/static/measure.js"></script>
-  <script src="/static/data.js?v=5"></script>
-  <script src="/static/ws.js?v=3"></script>
+  <script src="/static/data.js?v=7"></script>
+  <script src="/static/ws.js?v=4"></script>
   <script src="/static/main.js"></script>
 </body>
 </html>

--- a/data_service/templates/index.html
+++ b/data_service/templates/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Chart</title>
-  <link rel="stylesheet" href="/static/styles.css?v=13" />
+  <link rel="stylesheet" href="/static/styles.css?v=21" />
   <script src="https://cdn.jsdelivr.net/npm/lightweight-charts@5.0.9/dist/lightweight-charts.standalone.production.js"></script>
 </head>
 <body>
@@ -33,9 +33,9 @@
   <button id="nav-to-end" class="nav-btn nav-btn-right" title="최신으로">&raquo;</button>
   <div id="chart-info">
     <div id="chart-info-line">
-      <span id="chart-info-base" class="info-main">Loading...</span>
-      <span id="chart-info-separator" class="chart-info-separator hidden" aria-hidden="true">|</span>
-      <button id="chart-runner-status" class="chart-runner-status hidden" type="button"
+      <span id="chart-info-base" class="info-main">Loading...</span><!--
+      --><span id="chart-info-separator" class="chart-info-separator chart-info-sep hidden" aria-hidden="true"></span><!--
+      --><button id="chart-runner-status" class="chart-runner-status hidden" type="button"
               aria-label="Strategy status" aria-expanded="false">
         <span class="chart-runner-led" aria-hidden="true"></span>
         <span id="chart-runner-popover" class="chart-runner-popover" role="status">
@@ -43,8 +43,8 @@
           <span>Strategy calculation step:<br>Warm-up &rarr; Confirmed bar calculation</span>
           <span>Warm-up recalculates the strategy over historical candles before the next confirmed bar is processed.</span>
         </span>
-      </button>
-      <span id="chart-info-ohlcv" class="info-ohlcv"></span>
+      </button><!--
+      --><span id="chart-info-ohlcv" class="info-ohlcv"></span>
     </div>
     <div id="chart-info-title-row" class="hidden">
       <span id="chart-info-title"></span>
@@ -177,7 +177,7 @@
   </section>
   <!--RUNTIME_CONFIG-->
   <script src="/static/state.js?v=3"></script>
-  <script src="/static/ui.js?v=10"></script>
+  <script src="/static/ui.js?v=12"></script>
   <script src="/static/bgcolor.js?v=2"></script>
   <script src="/static/chart.js?v=3"></script>
   <script src="/static/measure.js"></script>

--- a/data_service/templates/state.js
+++ b/data_service/templates/state.js
@@ -17,6 +17,8 @@ window.App.config = {
 window.App.state = {
   ws: null,
   runnerConnected: false,
+  runnerPhase: "stopped",
+  nextPrerunAt: null,
   initialLoadInProgress: false,
   initialLoadDone: false,
   // bumped by resetChartState so an in-flight loadInitialWithRetry started

--- a/data_service/templates/styles.css
+++ b/data_service/templates/styles.css
@@ -53,6 +53,7 @@ body.source-open #chart {
 #chart-info-line {
   display: block;
   min-height: 20px;
+  line-height: 20px;
   white-space: normal;
 }
 .chart-info-separator.hidden,
@@ -62,13 +63,43 @@ body.source-open #chart {
 .chart-info-separator {
   color: rgba(0, 0, 0, 0.42);
 }
+#chart-info .info-main,
+#chart-info .info-ohlcv,
+.chart-info-separator {
+  line-height: inherit;
+  vertical-align: middle;
+}
+/* thin vertical rule between coin | tf | exchange | ohlcv — centered on the text
+   optical middle (a text "|" glyph sits slightly low) */
+.chart-info-sep {
+  display: inline-block;
+  width: 1px;
+  height: 0.82em;
+  margin: 0 7px;
+  background: rgba(0, 0, 0, 0.32);
+  vertical-align: middle;
+  transform: translateY(-0.06em);
+}
+/* coin | tf | exchange dividers are bolder, matching the old bold "|" glyph */
+.chart-info-sep-strong {
+  width: 2px;
+  height: 0.75em;   /* 16px context → ~12px, matches the cap height */
+  background: rgba(0, 0, 0, 0.5);
+}
+/* the ohlcv divider is in the smaller 14px line context — grow it to the same
+   ~12px so it also matches the letter height, and nudge it down so its vertical
+   center lines up with the 16px base dividers */
+#chart-info-separator.chart-info-sep {
+  height: 0.86em;
+  transform: translateY(0.02em);
+}
 .chart-runner-status {
   position: relative;
   display: inline-grid;
   place-items: center;
   width: 16px;
   height: 20px;
-  margin: 0 1px;
+  margin: 0 6px 0 1px;
   padding: 0;
   border: 0;
   border-radius: 0;
@@ -77,6 +108,11 @@ body.source-open #chart {
   cursor: pointer;
   touch-action: manipulation;
   vertical-align: middle;
+}
+/* when the ohlcv divider is hidden, the LED sits right after the exchange —
+   give it a left gap (the divider's margin normally provides this) */
+#chart-info-separator.hidden + #chart-runner-status {
+  margin-left: 7px;
 }
 .chart-runner-status:focus-visible {
   outline: 2px solid rgba(0, 122, 255, 0.72);
@@ -90,9 +126,10 @@ body.source-open #chart {
   background: #22a06b;
   box-shadow: 0 0 0 3px rgba(34, 160, 107, 0.14);
   animation: chart-runner-pulse 1.8s ease-in-out infinite;
-  transform: translateY(-1px);
 }
 .chart-runner-status.warming .chart-runner-led {
+  background: #e0a300;
+  box-shadow: 0 0 0 3px rgba(224, 163, 0, 0.18);
   animation-duration: 0.65s;
 }
 @keyframes chart-runner-pulse {
@@ -1367,6 +1404,7 @@ body.source-open .source-panel {
   }
 
   #chart-info-line {
+    line-height: 18px;
     overflow: visible;
   }
 

--- a/data_service/templates/styles.css
+++ b/data_service/templates/styles.css
@@ -52,6 +52,86 @@ body.source-open #chart {
 }
 #chart-info-line {
   display: block;
+  min-height: 20px;
+  white-space: normal;
+}
+.chart-info-separator.hidden,
+.chart-runner-status.hidden {
+  display: none;
+}
+.chart-info-separator {
+  color: rgba(0, 0, 0, 0.42);
+}
+.chart-runner-status {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+  width: 16px;
+  height: 20px;
+  margin: 0 1px;
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  touch-action: manipulation;
+  vertical-align: middle;
+}
+.chart-runner-status:focus-visible {
+  outline: 2px solid rgba(0, 122, 255, 0.72);
+  outline-offset: 2px;
+}
+.chart-runner-led {
+  display: block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #22a06b;
+  box-shadow: 0 0 0 3px rgba(34, 160, 107, 0.14);
+  animation: chart-runner-pulse 1.8s ease-in-out infinite;
+  transform: translateY(-1px);
+}
+.chart-runner-status.warming .chart-runner-led {
+  animation-duration: 0.65s;
+}
+@keyframes chart-runner-pulse {
+  0%, 100% { opacity: 0.72; }
+  50% { opacity: 1; }
+}
+.chart-runner-popover {
+  position: absolute;
+  top: calc(100% + 8px);
+  left: 0;
+  z-index: 30;
+  display: grid;
+  gap: 4px;
+  width: min(250px, calc(100vw - 32px));
+  padding: 9px 10px;
+  border: 1px solid rgba(17, 24, 39, 0.18);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.98);
+  color: #111827;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.24);
+  font-size: 11px;
+  line-height: 1.35;
+  letter-spacing: 0;
+  text-align: left;
+  white-space: normal;
+  pointer-events: none;
+  opacity: 0;
+  transform: translateY(-4px);
+  visibility: hidden;
+  transition: opacity 140ms ease, transform 140ms ease, visibility 140ms ease;
+}
+.chart-runner-popover strong {
+  font-size: 12px;
+  font-weight: 700;
+}
+.chart-runner-status.open .chart-runner-popover {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
 }
 #chart-info-title-row {
   display: flex;
@@ -1284,6 +1364,24 @@ body.source-open .source-panel {
 
   #chart-info .info-ohlcv {
     font-size: 12px;
+  }
+
+  #chart-info-line {
+    overflow: visible;
+  }
+
+  .chart-runner-status {
+    width: 14px;
+    height: 18px;
+  }
+
+  .chart-runner-popover {
+    width: min(232px, calc(100vw - 32px));
+    transform: translateY(-4px);
+  }
+
+  .chart-runner-status.open .chart-runner-popover {
+    transform: translateY(0);
   }
 
   .toolbar-btn {

--- a/data_service/templates/ui.js
+++ b/data_service/templates/ui.js
@@ -73,7 +73,10 @@ App.ui = {
     if (ohlcvText !== null) {
       state.baseInfoText = ohlcvText || "";
     }
-    this.elements.chartInfoBase.textContent = state.baseInfoTop;
+    this.elements.chartInfoBase.innerHTML = String(state.baseInfoTop || "")
+      .split(" | ")
+      .map((part) => this.escapeHtml(part))
+      .join('<span class="chart-info-sep chart-info-sep-strong" aria-hidden="true"></span>');
     this.elements.chartInfoOhlcv.innerHTML = state.baseInfoText || "";
     this.elements.chartInfoSeparator.classList.toggle("hidden", !state.baseInfoText);
     this.updateRunnerStatus();

--- a/data_service/templates/ui.js
+++ b/data_service/templates/ui.js
@@ -4,6 +4,12 @@ App.ui = {
   elements: {
     chartInfo: document.getElementById("chart-info"),
     chartInfoLine: document.getElementById("chart-info-line"),
+    chartInfoBase: document.getElementById("chart-info-base"),
+    chartInfoSeparator: document.getElementById("chart-info-separator"),
+    chartInfoOhlcv: document.getElementById("chart-info-ohlcv"),
+    chartRunnerStatus: document.getElementById("chart-runner-status"),
+    chartRunnerPopover: document.getElementById("chart-runner-popover"),
+    chartRunnerStatusText: document.getElementById("chart-runner-status-text"),
     chartInfoTitleRow: document.getElementById("chart-info-title-row"),
     chartInfoTitle: document.getElementById("chart-info-title"),
     alertsToggle: document.getElementById("alerts-toggle"),
@@ -64,11 +70,13 @@ App.ui = {
   sourceComposing: false,
   setChartInfo(ohlcvText = null) {
     const state = App.state;
-    const baseLine = ohlcvText
-      ? `${state.baseInfoTop} | <span class="info-ohlcv">${ohlcvText}</span>`
-      : state.baseInfoTop;
-    state.baseInfoText = baseLine;
-    this.elements.chartInfoLine.innerHTML = baseLine;
+    if (ohlcvText !== null) {
+      state.baseInfoText = ohlcvText || "";
+    }
+    this.elements.chartInfoBase.textContent = state.baseInfoTop;
+    this.elements.chartInfoOhlcv.innerHTML = state.baseInfoText || "";
+    this.elements.chartInfoSeparator.classList.toggle("hidden", !state.baseInfoText);
+    this.updateRunnerStatus();
     if (state.scriptTitleVisible) {
       this.elements.chartInfoTitle.textContent = state.scriptTitle;
       this.elements.chartInfoTitleRow.classList.remove("hidden");
@@ -76,6 +84,63 @@ App.ui = {
       this.elements.chartInfoTitle.textContent = "";
       this.elements.chartInfoTitleRow.classList.add("hidden");
     }
+  },
+  runnerStatusText(now = Date.now()) {
+    const state = App.state;
+    if (!state.runnerConnected || state.runnerPhase === "stopped") return "stopped";
+    if (state.runnerPhase === "prerun_active") return "warming up";
+    if (state.runnerPhase === "prerun_scheduled" && Number.isFinite(state.nextPrerunAt)) {
+      const remaining = Math.ceil((state.nextPrerunAt - now) / 1000);
+      if (remaining >= 1 && remaining <= 5) return `warming up in ${remaining}s`;
+      if (remaining <= 0) return "warming up";
+    }
+    return "running";
+  },
+  updateRunnerStatus() {
+    const { chartRunnerStatus, chartRunnerStatusText } = this.elements;
+    const state = App.state;
+    const visible = Boolean(state.runnerConnected);
+    chartRunnerStatus.classList.toggle("hidden", !visible);
+    if (!visible) {
+      chartRunnerStatus.classList.remove("open");
+      chartRunnerStatus.setAttribute("aria-expanded", "false");
+      return;
+    }
+    const text = this.runnerStatusText();
+    chartRunnerStatusText.textContent = text;
+    chartRunnerStatus.setAttribute("aria-label", `Strategy status: ${text}`);
+    chartRunnerStatus.classList.toggle("warming", state.runnerPhase === "prerun_active");
+  },
+  positionRunnerStatusPopover() {
+    const { chartRunnerStatus: button, chartRunnerPopover: popover } = this.elements;
+    if (!button || !popover) return;
+    popover.style.left = "0px";
+    const rect = popover.getBoundingClientRect();
+    const viewportPadding = 12;
+    const minOffset = viewportPadding - rect.left;
+    const maxOffset = window.innerWidth - viewportPadding - rect.right;
+    const offset = Math.min(maxOffset, Math.max(minOffset, 0));
+    popover.style.left = `${Math.round(offset)}px`;
+  },
+  initRunnerStatus() {
+    const button = this.elements.chartRunnerStatus;
+    button.addEventListener("click", (event) => {
+      event.stopPropagation();
+      const open = !button.classList.contains("open");
+      if (open) this.positionRunnerStatusPopover();
+      button.classList.toggle("open", open);
+      button.setAttribute("aria-expanded", open ? "true" : "false");
+    });
+    document.addEventListener("pointerdown", (event) => {
+      if (button.contains(event.target)) return;
+      button.classList.remove("open");
+      button.setAttribute("aria-expanded", "false");
+    }, true);
+    window.addEventListener("resize", () => {
+      if (button.classList.contains("open")) this.positionRunnerStatusPopover();
+    });
+    window.setInterval(() => this.updateRunnerStatus(), 1000);
+    this.updateRunnerStatus();
   },
   toggleAlertsMenu(forceOpen = null) {
     const menu = this.elements.alertsMenu;
@@ -1819,6 +1884,8 @@ App.ui = {
 
     document.addEventListener("keydown", (e) => {
       if (e.key === "Escape") {
+        this.elements.chartRunnerStatus.classList.remove("open");
+        this.elements.chartRunnerStatus.setAttribute("aria-expanded", "false");
         this.closeManualAlertConfirm();
         this.closeManualAlertMenu();
         this.closeAlertTemplateModal();
@@ -1883,6 +1950,7 @@ App.ui = {
     });
 
     this.attachSourceResize();
+    this.initRunnerStatus();
   }
 };
 

--- a/data_service/templates/ws.js
+++ b/data_service/templates/ws.js
@@ -32,11 +32,21 @@ App.ws = {
           App.data.loadInitialWithRetry();
         } else if (msg.type === "runner_disconnected") {
           state.runnerConnected = false;
+          state.runnerPhase = "stopped";
+          state.nextPrerunAt = null;
           chart.resetChartState(false);
           App.ui.setChartInfo();
         } else if (msg.type === "runner_connected") {
           state.runnerConnected = true;
+          if (state.runnerPhase === "stopped") state.runnerPhase = "running";
+          App.ui.updateRunnerStatus();
           App.data.loadInitialWithRetry();
+        } else if (msg.type === "runner_phase") {
+          state.runnerPhase = msg.phase || (state.runnerConnected ? "running" : "stopped");
+          state.nextPrerunAt = Number.isFinite(Number(msg.next_prerun_at))
+            ? Number(msg.next_prerun_at)
+            : null;
+          App.ui.updateRunnerStatus();
         } else if (msg.type === "script_info") {
           state.scriptTitle = msg.title || "No title";
           state.scriptTitleVisible = true;

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -937,6 +937,8 @@ async def main():
                 )
             finally:
                 SUPPRESS_EXTERNAL_NOTIFICATIONS = False
+            if runner.plot_writer:
+                runner.plot_writer.flush()
             pending_full_reemit = False
 
             # The re-sync plot.csv and historical markers are complete. Reload chart


### PR DESCRIPTION
## 요약

- 동일 시점에 집중되던 세션별 전체 pre_run 계산을 타임프레임별 안전 구간에 분산합니다.
- Data settings에서 세션별 Auto/Custom warm-up 시각을 확인하고 변경할 수 있습니다.
- 대시보드와 개별 차트에서 예정, 실행, 완료 상태를 표시하고 차트 warm-up 상태를 노란색 빠른 점멸로 구분합니다.
- pre_run 도중 차트가 비어 있거나 일부 plot만 읽는 문제를 방지합니다.

## 스케줄링 규칙

- 1분봉: 봉 시작 후 10~30초, 5초 간격
- 5분봉: 봉 시작 후 15초~2분 30초, 20초 간격
- 5분 초과: 봉 시작 후 15초~봉 종료 5분 전, 20초 간격
- 짧은 타임프레임을 먼저 배정하고 상위 타임프레임은 이미 예약된 반복 실행 시각을 가능한 한 피합니다.
- 후보보다 세션이 많으면 사용 횟수가 적은 슬롯부터 균형 있게 재사용합니다.
- Custom 설정은 유지하고 Auto 세션만 전체 세션 구성에 따라 재배정합니다.

## 런타임 동작

- 공유 feed는 구독 세션 중 가장 이른 배정 시각에 데이터를 준비합니다.
- 각 세션은 자신의 배정 시각에 기존 prerun_ready 이벤트를 Runner로 전달합니다.
- run_ready와 전략 계산, 주문 회계, 알림 전송 규칙은 변경하지 않습니다.
- 업데이트나 Runner 시작 직후 최초 초기 pre_run은 기존처럼 즉시 실행되고, 이후 반복 pre_run부터 분산 시각이 적용됩니다.
- 스케줄 변경만 저장하면 OHLCV 재동기화나 Runner 재시작을 수행하지 않습니다.

## 차트 및 대시보드

- warm-up 5초 전부터 상태 카운트다운을 표시합니다.
- 대시보드는 기존 녹색 상태등의 빠른 점멸을 사용하고, 개별 차트는 노란색 빠른 점멸을 사용합니다.
- 차트 헤더의 종목 정보, 구분선, 상태등, OHLCV 중심 정렬을 통일합니다.
- 설정 버튼은 공통 SVG 톱니 아이콘을 사용합니다.
- pre_run 실행 중 plot API가 미완성 데이터를 반환하지 않으며, 계산 완료 후 writer flush와 재조회로 완성된 차트를 표시합니다.