### PR TITLE
확정봉 검증 러너 및 누락 신호 보완 전송 추가

### DIFF
--- a/data_service/api.py
+++ b/data_service/api.py
@@ -39,6 +39,7 @@ from registry import (
     SessionNotFoundError,
     SessionOrderError,
     SessionRegistry,
+    VerificationRunnerUnavailableError,
 )
 from runtime import Session
 from schedule_utils import seconds_until_bar_boundary_guard_end
@@ -550,6 +551,7 @@ def build_session_api_router(registry: SessionRegistry) -> APIRouter:
             "runner_connected": rt.runner_count > 0,
             "runner_phase": rt.runner_phase,
             "next_prerun_at": rt.next_prerun_at,
+            "verification": registry.verification_status(rt),
         })
 
     @r.get("/api/{session_id}/script-source")
@@ -1884,6 +1886,21 @@ def build_control_router(
             return JSONResponse({"error": "session not found"}, status_code=404)
         except HistoryNotReadyError:
             return JSONResponse({"error": "market data is still preparing"}, status_code=409)
+        return JSONResponse({"ok": True})
+
+    @r.post("/api/sessions/{session_id}/verification/restart")
+    async def verification_runner_restart(session_id: str) -> JSONResponse:
+        try:
+            await registry.restart_verification_runner(session_id)
+        except SessionNotFoundError:
+            return JSONResponse({"error": "session not found"}, status_code=404)
+        except HistoryNotReadyError:
+            return JSONResponse(
+                {"error": "market data is still preparing"},
+                status_code=409,
+            )
+        except VerificationRunnerUnavailableError as exc:
+            return JSONResponse({"error": str(exc)}, status_code=409)
         return JSONResponse({"ok": True})
 
     @r.get("/api/sessions/{session_id}/runner/logs")

--- a/data_service/file_update_loop.py
+++ b/data_service/file_update_loop.py
@@ -9,6 +9,7 @@ from typing import Any, Awaitable, Callable, Optional, TypeVar
 from config import FeedSpec
 from pynecore.cli.commands.data import parse_date_or_days
 from pynecore.core.ohlcv_file import OHLCVReader
+from pynecore.core.exchange_policy import previous_close_is_next_open
 from pynecore.cli.app import app_state
 from ohlcv_io import (
     convert_timeframe,
@@ -37,6 +38,14 @@ from log_utils import log_with_time
 
 
 T = TypeVar("T")
+
+
+def _apply_open_target(bar: list, target_open_price: float) -> None:
+    if target_open_price <= 0.0 or len(bar) < 4:
+        return
+    bar[1] = target_open_price
+    bar[2] = max(float(bar[2]), target_open_price)
+    bar[3] = min(float(bar[3]), target_open_price)
 
 
 async def _to_thread_cancel_safe(func: Callable[..., T], /, *args: Any, **kwargs: Any) -> T:
@@ -399,7 +408,8 @@ async def file_update_loop(
                     continue
 
                 # Fetch candles via fetch_ohlcv at the first pre_run after history download
-                if not first_fetch_after_download_done:
+                initial_refresh = not first_fetch_after_download_done
+                if initial_refresh:
                     res = await _retry_ohlcv_update(
                         "pre_run initial OHLCV refresh",
                         lambda: fetch_and_update_ohlcv_data(
@@ -443,8 +453,13 @@ async def file_update_loop(
                             for bar in res
                         ]
                         upsert_bars(cache_path, provider, exchange, symbol, timeframe, cache_rows)
-                    # Current candle open price fix if needed
-                    fixed_open_price = await _to_thread_cancel_safe(
+
+                # Fetch-based exchanges already received their authoritative open
+                # during the initial full refresh. Continuity exchanges still need
+                # to retain previous_close so a later live bar cannot replace it.
+                retain_open_target = previous_close_is_next_open(exchange)
+                if (not initial_refresh) or retain_open_target:
+                    resolved_open_price, open_fix_changed = await _to_thread_cancel_safe(
                         fix_last_open_if_needed,
                         str(ohlcv_path),
                         exchange=exchange,
@@ -452,7 +467,15 @@ async def file_update_loop(
                         timeframe=timeframe,
                         market_type=market_type,
                     )
-                    if fixed_open_price > 0.0:
+                    # Bitget/Bybit must retain previous-close continuity even when
+                    # the fake bar already had the target open. Other exchanges
+                    # only reapply an open that actually corrected the file.
+                    fixed_open_price = (
+                        resolved_open_price
+                        if open_fix_changed or retain_open_target
+                        else 0.0
+                    )
+                    if open_fix_changed:
                         # Fix the last bar stored in the ohlcv cache
                         cache_rows = []
                         with OHLCVReader(ohlcv_path) as reader:
@@ -465,8 +488,7 @@ async def file_update_loop(
 
                 # Send pre-run ready signal (confirmed bar and new bar)
                 confirmed_bar_and_new_bar = [bars[0], bars[1]]
-                if fixed_open_price > 0.0:
-                    confirmed_bar_and_new_bar[1][1] = fixed_open_price
+                _apply_open_target(confirmed_bar_and_new_bar[1], fixed_open_price)
 
                 bar_ts = int(confirmed_bar_and_new_bar[1][0])  # new bar timestamp in ms
                 if prerun_sent_for_bar_ts != bar_ts:
@@ -489,8 +511,7 @@ async def file_update_loop(
                 if not history_download_complete:
                     continue
 
-                if fixed_open_price > 0.0:
-                    confirmed_bar_and_new_bar[0][1] = fixed_open_price
+                _apply_open_target(confirmed_bar_and_new_bar[0], fixed_open_price)
 
                 incremented_size = update_ohlcv_data(str(ohlcv_path), confirmed_bar_and_new_bar)
                 if incremented_size > 0:

--- a/data_service/main.py
+++ b/data_service/main.py
@@ -203,7 +203,16 @@ async def main() -> None:
     ensure_provider_config()
     cfg = load_hub_config()
     specs = load_initial_sessions()
-    registry = SessionRegistry(port=cfg.port)
+    registry = SessionRegistry(
+        port=cfg.port,
+        verification_delivery_path=(
+            _PROJECT_ROOT
+            / "workdir"
+            / "data"
+            / "cache"
+            / "verification_delivery.sqlite"
+        ),
+    )
     calendar_store = CalendarEventStore(
         _PROJECT_ROOT / "workdir" / "config" / "calendar_events.json"
     )

--- a/data_service/market_data_diagnostics.py
+++ b/data_service/market_data_diagnostics.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+import atexit
+import json
+import math
+import os
+import queue
+import threading
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DIAGNOSTIC_LOG_NAME = "market_data_diagnostics.jsonl"
+_MAX_LOG_BYTES = 20 * 1024 * 1024
+_BACKUP_COUNT = 3
+_QUEUE_SIZE = 10_000
+
+
+def utc_now_iso() -> str:
+    return datetime.now(UTC).isoformat(timespec="milliseconds")
+
+
+def _json_safe(value: Any) -> Any:
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple, set)):
+        return [_json_safe(item) for item in value]
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return str(value)
+    return number if math.isfinite(number) else str(number)
+
+
+def ohlcv_bar_data(bar: Any) -> dict[str, int | float] | None:
+    try:
+        if bar is None:
+            return None
+        if isinstance(bar, (list, tuple)) and len(bar) >= 6:
+            timestamp = int(bar[0])
+            if timestamp < 10_000_000_000:
+                timestamp *= 1000
+            values = bar[1:6]
+        else:
+            timestamp = int(getattr(bar, "timestamp")) * 1000
+            values = (
+                getattr(bar, "open"),
+                getattr(bar, "high"),
+                getattr(bar, "low"),
+                getattr(bar, "close"),
+                getattr(bar, "volume"),
+            )
+        return {
+            "timestamp_ms": timestamp,
+            "time_utc": datetime.fromtimestamp(timestamp / 1000, UTC).isoformat(),
+            "open": float(values[0]),
+            "high": float(values[1]),
+            "low": float(values[2]),
+            "close": float(values[3]),
+            "volume": float(values[4]),
+        }
+    except (AttributeError, IndexError, TypeError, ValueError, OverflowError):
+        return None
+
+
+class _DiagnosticWriter:
+    def __init__(self) -> None:
+        self._queue: queue.Queue[tuple[Path, dict[str, Any]] | None] = queue.Queue(
+            maxsize=_QUEUE_SIZE
+        )
+        self._thread: threading.Thread | None = None
+        self._thread_lock = threading.Lock()
+        self._dropped = 0
+
+    def enqueue(self, path: Path, record: dict[str, Any]) -> None:
+        self._ensure_started()
+        try:
+            self._queue.put_nowait((path, record))
+        except queue.Full:
+            self._dropped += 1
+
+    def _ensure_started(self) -> None:
+        if self._thread is not None and self._thread.is_alive():
+            return
+        with self._thread_lock:
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._thread = threading.Thread(
+                target=self._run,
+                name="market-data-diagnostics",
+                daemon=True,
+            )
+            self._thread.start()
+
+    def _run(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is None:
+                self._queue.task_done()
+                return
+            path, record = item
+            try:
+                if self._dropped:
+                    record["writer_dropped_events"] = self._dropped
+                    self._dropped = 0
+                self._write(path, record)
+            except Exception:
+                # Diagnostics must never interrupt market-data or strategy execution.
+                pass
+            finally:
+                self._queue.task_done()
+
+    @staticmethod
+    def _rotate(path: Path) -> None:
+        if not path.exists() or path.stat().st_size < _MAX_LOG_BYTES:
+            return
+        oldest = path.with_name(f"{path.name}.{_BACKUP_COUNT}")
+        oldest.unlink(missing_ok=True)
+        for index in range(_BACKUP_COUNT - 1, 0, -1):
+            source = path.with_name(f"{path.name}.{index}")
+            if source.exists():
+                os.replace(source, path.with_name(f"{path.name}.{index + 1}"))
+        os.replace(path, path.with_name(f"{path.name}.1"))
+
+    def _write(self, path: Path, record: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._rotate(path)
+        line = json.dumps(_json_safe(record), ensure_ascii=False, separators=(",", ":"))
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(line)
+            handle.write("\n")
+
+    def close(self) -> None:
+        thread = self._thread
+        if thread is None or not thread.is_alive():
+            return
+        try:
+            self._queue.put(None, timeout=1.0)
+            thread.join(timeout=2.0)
+        except Exception:
+            pass
+
+
+_WRITER = _DiagnosticWriter()
+atexit.register(_WRITER.close)
+
+
+def log_session_diagnostic(
+    output_dir: Path | str,
+    session_id: str,
+    event: dict[str, Any],
+    *,
+    feed: dict[str, Any] | None = None,
+) -> None:
+    try:
+        event_type = str(event.get("event") or event.get("type") or "unknown")
+        payload = dict(event)
+        payload.pop("type", None)
+        payload["event"] = event_type
+        record = {
+            "schema_version": 1,
+            "observed_at": utc_now_iso(),
+            "monotonic_ns": time.monotonic_ns(),
+            "session_id": session_id,
+            "feed": feed or {},
+            **payload,
+        }
+        # Freeze mutable bar/event lists before the background writer sees them.
+        _WRITER.enqueue(Path(output_dir) / DIAGNOSTIC_LOG_NAME, _json_safe(record))
+    except Exception:
+        pass

--- a/data_service/ohlcv_io.py
+++ b/data_service/ohlcv_io.py
@@ -143,6 +143,39 @@ def _ohlcv_float(value: float) -> float:
     return struct.unpack("f", struct.pack("f", value))[0]
 
 
+def _preserve_latest_closed_bar(
+    rest_bars: list,
+    local_closed_bar: OHLCV | None,
+) -> list:
+    """Protect only the latest closed local candle from a stale REST value."""
+    if not rest_bars or local_closed_bar is None:
+        return rest_bars
+
+    local_timestamp = int(local_closed_bar.timestamp)
+    local_volume = _ohlcv_float(float(local_closed_bar.volume))
+    merged: list = []
+    for rest in rest_bars:
+        preserve_local = (
+            isinstance(rest, (list, tuple))
+            and len(rest) >= 6
+            and int(rest[0] / 1000) == local_timestamp
+            and _ohlcv_float(float(rest[5])) < local_volume
+        )
+        if preserve_local:
+            merged.append([
+                local_timestamp * 1000,
+                float(local_closed_bar.open),
+                float(local_closed_bar.high),
+                float(local_closed_bar.low),
+                float(local_closed_bar.close),
+                float(local_closed_bar.volume),
+            ])
+        else:
+            merged.append(rest)
+
+    return merged
+
+
 def _filter_invalid_ccxt_markets(markets: list) -> list:
     """Drop ccxt-normalized markets that have no id/symbol.
 
@@ -251,10 +284,15 @@ def fix_last_open_if_needed(
     symbol: str = "",
     timeframe: str = "",
     market_type: str = "",
-) -> float:
+) -> tuple[float, bool]:
+    """Resolve and persist the forming candle's authoritative open.
+
+    The returned target remains valid even when the file already had that open.
+    A fake candle can be replaced by a later live candle after this function
+    returns, so the caller must retain and reapply the target until run_ready.
+    """
     retry_delays = (1.0, 2.0)
     max_attempts = len(retry_delays) + 1
-    fixed_candle_open_price = 0.0
     open_price, high_price, low_price, close_price, vol, prev_close_price = 0.0, 0.0, 0.0, 0.0, 0.0, 0.0
     last_timestamp, interval = 0, 0
     with OHLCVReader(ohlcv_path) as reader:
@@ -291,7 +329,7 @@ def fix_last_open_if_needed(
                         f"[fix_last_open_if_needed] Error fetching current open: {e}; "
                         f"failed after {attempt}/{max_attempts}"
                     )
-                    return fixed_candle_open_price
+                    return 0.0, False
                 delay = retry_delays[attempt - 1]
                 log_with_time(
                     f"[fix_last_open_if_needed] Error fetching current open: {e}; "
@@ -309,7 +347,7 @@ def fix_last_open_if_needed(
                 break
 
             if attempt >= max_attempts:
-                return fixed_candle_open_price
+                return 0.0, False
             delay = retry_delays[attempt - 1]
             log_with_time(
                 "[fix_last_open_if_needed] current open not found in fetched OHLCV; "
@@ -318,23 +356,29 @@ def fix_last_open_if_needed(
             time.sleep(delay)
 
         if target_open_price is None:
-            return fixed_candle_open_price
+            return 0.0, False
     else:
-        # BITGET-style continuity: the live-built current candle can start from the
-        # first trade, while the chart expects the previous close as the next open.
+        # Bitget and Bybit use previous-close continuity. Keep the legacy fallback
+        # for any provider not covered by the fetch-current-open policy.
         target_open_price = prev_close_price
 
-    if open_price != target_open_price:
+    corrected_high_price = max(high_price, target_open_price)
+    corrected_low_price = min(low_price, target_open_price)
+    changed = (
+        open_price != target_open_price
+        or high_price != corrected_high_price
+        or low_price != corrected_low_price
+    )
+    if changed:
         with OHLCVWriter(ohlcv_path) as writer:
             writer.overwrite(timestamp=writer.end_timestamp,
                              candle=OHLCV(timestamp=writer.end_timestamp, open=target_open_price,
-                                          high=high_price,
-                                          low=low_price, close=close_price, volume=vol))
-            fixed_candle_open_price = target_open_price
+                                          high=corrected_high_price,
+                                          low=corrected_low_price, close=close_price, volume=vol))
             # print("Candle open price fixing done")
             writer.close()
 
-    return fixed_candle_open_price
+    return target_open_price, changed
 
 
 def update_ohlcv_data(ohlcv_path: str, candle_datas: list) -> int:
@@ -397,6 +441,7 @@ def fetch_and_update_ohlcv_data(
     with OHLCVReader(ohlcv_path) as reader:
         size = reader.size
         last_candle = reader.read(size - 1)
+        previous_candle = reader.read(size - 2) if size >= 2 else None
         last_timestamp_sec = last_candle.timestamp
         interval = reader.interval
         reader.close()
@@ -416,8 +461,9 @@ def fetch_and_update_ohlcv_data(
             print(f"[fetch_and_update_ohlcv_data] No data received from exchange")
             return None
 
-        update_ohlcv_data(ohlcv_path, res)
-        return res
+        merged = _preserve_latest_closed_bar(res, previous_candle)
+        update_ohlcv_data(ohlcv_path, merged)
+        return merged
 
     except Exception as e:
         log_with_time(f"[fetch_and_update_ohlcv_data] Error fetching OHLCV: {e}")
@@ -442,6 +488,7 @@ def fetch_and_update_recent_ohlcv_data(
     with OHLCVReader(ohlcv_path) as reader:
         interval = reader.interval
         last_bar = reader.read(reader.size - 1)
+        previous_bar = reader.read(reader.size - 2) if reader.size >= 2 else None
         reader.close()
 
     if interval is None:
@@ -486,9 +533,10 @@ def fetch_and_update_recent_ohlcv_data(
         if not closed_bars:
             return None
 
-        update_ohlcv_data(ohlcv_path, closed_bars + [current_bar])
+        merged_closed_bars = _preserve_latest_closed_bar(closed_bars, previous_bar)
+        update_ohlcv_data(ohlcv_path, merged_closed_bars + [current_bar])
         # print(f"[fetch_and_update_recent_closed_ohlcv_data] Updated bars:\n{closed_bars}")
-        return closed_bars
+        return merged_closed_bars
 
     except Exception as e:
         log_with_time(f"[fetch_and_update_recent_closed_ohlcv_data] Error fetching OHLCV: {e}")

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -5,12 +5,13 @@ import sqlite3
 import shutil
 import traceback
 from dataclasses import replace
+from pathlib import Path
 from typing import Awaitable, Callable, Dict, List, Optional
 
 from config import MAX_SESSIONS, FeedSpec, SessionSpec, save_sessions
 from collector_loop import fix_missing_bars_loop, watch_trades_loop
 from file_update_loop import _to_thread_cancel_safe, file_update_loop
-from verification import FinalizedCandleProbe
+from verification import FinalizedCandleProbe, VerificationDeliveryService
 from prerun_scheduler import assign_prerun_offsets
 from runner_supervisor import RunnerSupervisor
 from runtime import Feed, Session
@@ -53,7 +54,12 @@ class SessionRegistry:
     Multiple Sessions on the same (provider, exchange, symbol, timeframe) share a
     single Feed, so the same market is only collected/downloaded once."""
 
-    def __init__(self, port: int) -> None:
+    def __init__(
+        self,
+        port: int,
+        *,
+        verification_delivery_path: Path | None = None,
+    ) -> None:
         self.feeds: Dict[str, Feed] = {}
         self.sessions: Dict[str, Session] = {}
         self.hub_ws = WSManager()  # dashboard clients on /ws/hub
@@ -64,6 +70,11 @@ class SessionRegistry:
             Callable[[Session, dict], Awaitable[None]]
         ] = None
         self.strategy_evaluation_enabled = False
+        self.verification_delivery = (
+            VerificationDeliveryService(verification_delivery_path)
+            if verification_delivery_path is not None
+            else None
+        )
 
     # ------------------------------------------------------------------
     # Queries
@@ -406,6 +417,7 @@ class SessionRegistry:
             feed,
             strategy_evaluation_enabled=self.strategy_evaluation_enabled,
             verification_enabled=self.supervisor.verification_enabled,
+            verification_delivery=self.verification_delivery,
         )
         session.on_status_change = self.notify_hub
         session.on_spec_change = self._persist_and_notify
@@ -822,6 +834,8 @@ class SessionRegistry:
 
     async def shutdown(self) -> None:
         await self.supervisor.shutdown()
+        if self.verification_delivery is not None:
+            await self.verification_delivery.close()
         logo_tasks = list(self.logo_tasks.values())
         self.logo_tasks.clear()
         for t in logo_tasks:

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -10,6 +10,7 @@ from typing import Awaitable, Callable, Dict, List, Optional
 from config import MAX_SESSIONS, FeedSpec, SessionSpec, save_sessions
 from collector_loop import fix_missing_bars_loop, watch_trades_loop
 from file_update_loop import _to_thread_cancel_safe, file_update_loop
+from verification import FinalizedCandleProbe
 from prerun_scheduler import assign_prerun_offsets
 from runner_supervisor import RunnerSupervisor
 from runtime import Feed, Session
@@ -38,6 +39,10 @@ class SessionOrderError(Exception):
 
 
 class RunnerActiveError(Exception):
+    pass
+
+
+class VerificationRunnerUnavailableError(Exception):
     pass
 
 
@@ -77,11 +82,52 @@ class SessionRegistry:
             return "starting"
         return sup
 
+    def verification_status(self, session: Session) -> dict:
+        enabled = self.supervisor.verification_enabled
+        verification = session.verification
+        if not enabled:
+            return {"enabled": False, "status": "disabled"}
+
+        primary_status = self.runner_status(session.spec.id)
+        process_status = self.supervisor.verification_process_status(session.spec.id)
+        recovery = self.supervisor.verification_recovery_info(session.spec.id)
+        if primary_status in {"stopped", "crashed"}:
+            status = "stopped"
+        elif process_status == "recovering":
+            status = "recovering"
+        elif verification.runner_count > 0 and verification.runner_ready:
+            status = "running"
+        elif verification.runner_count > 0:
+            status = "warming_up"
+        elif verification.connection_lost and process_status == "starting":
+            status = "reconnecting"
+        elif process_status == "crashed":
+            status = "crashed"
+        elif process_status == "starting":
+            status = "starting"
+        else:
+            status = process_status
+
+        next_retry_at = recovery.get("next_retry_at")
+        return {
+            "enabled": True,
+            "status": status,
+            "connected": verification.runner_count > 0,
+            "ready": verification.runner_ready,
+            "reason": recovery.get("reason") or verification.last_error,
+            "attempt": recovery.get("attempt", 0),
+            "next_retry_at": (
+                int(float(next_retry_at) * 1000) if next_retry_at is not None else None
+            ),
+            "updated_at": verification.state_updated_at,
+        }
+
     def snapshots(self) -> List[dict]:
         out = []
         for s in self.sessions.values():
             snap = s.snapshot()
             snap["runner"] = self.runner_status(s.spec.id)
+            snap["verification"] = self.verification_status(s)
             out.append(snap)
         return out
 
@@ -219,6 +265,70 @@ class SessionRegistry:
         }
         self._start_file_update_task(feed)
 
+    @staticmethod
+    def _has_verification_probe_consumer(feed: Feed) -> bool:
+        return any(
+            session.verification.enabled and session.verification.runner_count > 0
+            for session in feed.subscribers.values()
+        )
+
+    def _start_verification_probe(self, feed: Feed) -> None:
+        current = feed.finalized_candle_probe
+        if current is not None:
+            task = feed.tasks.get(current.task_name)
+            if task is not None and not task.done():
+                return
+            feed.tasks.pop(current.task_name, None)
+
+        spec = feed.spec
+        probe = FinalizedCandleProbe(
+            exchange_name=spec.exchange,
+            symbol=spec.symbol,
+            timeframe=spec.timeframe,
+            market_type=spec.market_type,
+            on_event=feed.log_market_data_diagnostic,
+            on_authoritative=feed.queue_verification_candle,
+        )
+        feed.seed_verification_primary_results(probe)
+        feed.finalized_candle_probe = probe
+        probe_name = probe.task_name
+        feed.tasks[probe_name] = asyncio.create_task(
+            self._guard_probe(feed, probe_name, probe.run())
+        )
+
+    async def _stop_verification_probe(self, feed: Feed) -> None:
+        probe = feed.finalized_candle_probe
+        feed.finalized_candle_probe = None
+        feed.clear_verification_primary_results()
+        if probe is None:
+            return
+        task = feed.tasks.pop(probe.task_name, None)
+        if task is None:
+            return
+        task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    async def _sync_verification_probe(self, feed: Feed) -> None:
+        async with feed._verification_probe_lock:
+            if self._has_verification_probe_consumer(feed):
+                self._start_verification_probe(feed)
+            else:
+                await self._stop_verification_probe(feed)
+
+    async def _guard_probe(self, feed: Feed, name: str, coro) -> None:
+        try:
+            await coro
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            feed.log_market_data_diagnostic({
+                "event": "finalized_candle_probe_crashed",
+                "source": name,
+                "error_type": type(e).__name__,
+                "error_message": str(e)[:500],
+            })
+            print(f"[feed {feed.spec.id}] {name} crashed: {e}")
+
     async def _guard_feed(self, feed: Feed, name: str, coro) -> None:
         try:
             await coro
@@ -295,10 +405,15 @@ class SessionRegistry:
             spec,
             feed,
             strategy_evaluation_enabled=self.strategy_evaluation_enabled,
+            verification_enabled=self.supervisor.verification_enabled,
         )
         session.on_status_change = self.notify_hub
         session.on_spec_change = self._persist_and_notify
         session.on_ai_instruction = self.ai_instruction_handler
+        session.verification.on_recovery = self._request_verification_recovery
+        session.verification.on_connected = self._mark_verification_connected
+        session.verification.on_disconnected = self._mark_verification_disconnected
+        session.verification.on_ready = self._mark_verification_ready
         feed.subscribers[spec.id] = session
         self.sessions[spec.id] = session
         self._rebalance_prerun_schedule()
@@ -320,6 +435,7 @@ class SessionRegistry:
         await self.supervisor.stop(session_id)
         feed = session.feed
         feed.subscribers.pop(session_id, None)
+        await self._sync_verification_probe(feed)
         del self.sessions[session_id]
         self._rebalance_prerun_schedule()
         await self._teardown_feed_if_idle(feed)
@@ -634,6 +750,7 @@ class SessionRegistry:
         if session is None:
             raise SessionNotFoundError(session_id)
         await self.supervisor.stop(session_id)
+        await self._sync_verification_probe(session.feed)
         await self.notify_hub()
 
     async def restart_runner(self, session_id: str) -> None:
@@ -643,6 +760,50 @@ class SessionRegistry:
         if not session.feed.history_ready():
             raise HistoryNotReadyError(session_id)
         await self.supervisor.restart(session.spec, session.paths)
+
+    async def restart_verification_runner(self, session_id: str) -> None:
+        session = self.sessions.get(session_id)
+        if session is None:
+            raise SessionNotFoundError(session_id)
+        if not self.supervisor.verification_enabled:
+            raise VerificationRunnerUnavailableError(
+                "verification runner is disabled"
+            )
+        if not self.supervisor.is_active(session_id):
+            raise VerificationRunnerUnavailableError(
+                "start the strategy runner before restarting verification"
+            )
+        if not session.feed.history_ready():
+            raise HistoryNotReadyError(session_id)
+        await session.verification.prepare_recovery("manual restart")
+        await self.supervisor.restart_verification(
+            session.spec,
+            session.paths,
+            reason="manual restart",
+        )
+        await self.notify_hub()
+
+    async def _request_verification_recovery(
+        self,
+        session: Session,
+        reason: str,
+    ) -> None:
+        self.supervisor.request_verification_recovery(
+            session.spec.id,
+            reason=reason,
+        )
+        await self.notify_hub()
+
+    async def _mark_verification_connected(self, session: Session) -> None:
+        self.supervisor.mark_verification_connected(session.spec.id)
+        await self._sync_verification_probe(session.feed)
+
+    async def _mark_verification_disconnected(self, session: Session) -> None:
+        self.supervisor.mark_verification_disconnected(session.spec.id)
+        await self._sync_verification_probe(session.feed)
+
+    async def _mark_verification_ready(self, session: Session) -> None:
+        self.supervisor.mark_verification_ready(session.spec.id)
 
     # ------------------------------------------------------------------
     # Boot / shutdown

--- a/data_service/registry.py
+++ b/data_service/registry.py
@@ -130,6 +130,11 @@ class SessionRegistry:
             "next_retry_at": (
                 int(float(next_retry_at) * 1000) if next_retry_at is not None else None
             ),
+            "latest_finding": (
+                dict(verification.latest_finding)
+                if verification.latest_finding is not None
+                else None
+            ),
             "updated_at": verification.state_updated_at,
         }
 

--- a/data_service/runner_supervisor.py
+++ b/data_service/runner_supervisor.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import os
 import sys
+import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Awaitable, Callable, Dict, Optional
@@ -11,11 +13,13 @@ from runtime import SessionPaths
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 RUNNER_MAIN = REPO_ROOT / "runner_service" / "main.py"
+VERIFICATION_CONNECT_TIMEOUT_SECONDS = 30.0
 
 
 @dataclass
 class RunnerProcessHandle:
     session_id: str
+    role: str
     process: asyncio.subprocess.Process
     status: str          # starting | stopped | crashed  (process-level)
     user_stopped: bool   # True when stop/restart asked for it (crash vs intentional)
@@ -35,6 +39,20 @@ class RunnerSupervisor:
         self.port = port
         self._on_change = on_change
         self.handles: Dict[str, RunnerProcessHandle] = {}
+        self.verification_handles: Dict[str, RunnerProcessHandle] = {}
+        self._verification_targets: Dict[str, tuple[SessionSpec, SessionPaths]] = {}
+        self._verification_desired: set[str] = set()
+        self._verification_recovery_tasks: Dict[str, asyncio.Task] = {}
+        self._verification_recovery_attempts: Dict[str, int] = {}
+        self._verification_recovery_reasons: Dict[str, str] = {}
+        self._verification_recovery_at: Dict[str, float] = {}
+        self._verification_recovery_spawning: set[str] = set()
+        self._verification_connect_timeout_tasks: Dict[str, asyncio.Task] = {}
+        self._shutting_down = False
+        self.verification_enabled = (
+            os.environ.get("PYNEREAL_VERIFICATION_RUNNER", "1").strip().lower()
+            not in {"0", "false", "no", "off"}
+        )
 
     async def _changed(self) -> None:
         try:
@@ -57,12 +75,61 @@ class RunnerSupervisor:
             return "starting"  # process up; registry upgrades to "running" if connected
         return h.status
 
-    async def start(self, spec: SessionSpec, paths: SessionPaths) -> None:
-        if self.is_active(spec.id):
-            return  # already running
+    def verification_process_status(self, session_id: str) -> str:
+        if not self.verification_enabled:
+            return "disabled"
+        recovery = self._verification_recovery_tasks.get(session_id)
+        if recovery is not None and not recovery.done():
+            return "recovering"
+        handle = self.verification_handles.get(session_id)
+        if handle is None:
+            return "stopped"
+        if handle.process.returncode is None:
+            return "starting"
+        return handle.status
 
-        # Reap any finished handle / log file before re-spawning.
-        await self._cleanup_handle(spec.id)
+    def verification_recovery_info(self, session_id: str) -> dict:
+        return {
+            "attempt": int(self._verification_recovery_attempts.get(session_id, 0)),
+            "reason": self._verification_recovery_reasons.get(session_id),
+            "next_retry_at": self._verification_recovery_at.get(session_id),
+        }
+
+    async def start(self, spec: SessionSpec, paths: SessionPaths) -> None:
+        if not self.is_active(spec.id):
+            # Reap any finished handle / log file before re-spawning.
+            await self._cleanup_handle(spec.id, role="primary")
+            await self._spawn(spec, paths, role="primary")
+
+        if self.verification_enabled:
+            self._verification_targets[spec.id] = (spec, paths)
+            self._verification_desired.add(spec.id)
+        if self.verification_enabled and not self._is_verification_active(spec.id):
+            try:
+                await self._cleanup_handle(spec.id, role="verification")
+                await self._spawn(
+                    spec,
+                    self._verification_paths(paths),
+                    role="verification",
+                )
+            except Exception as error:
+                print(
+                    f"[supervisor] verification runner {spec.id} failed to start: "
+                    f"{type(error).__name__}: {error}"
+                )
+                self.request_verification_recovery(
+                    spec.id,
+                    reason=f"initial start failed: {type(error).__name__}: {error}",
+                )
+
+    async def _spawn(
+        self,
+        spec: SessionSpec,
+        paths: SessionPaths,
+        *,
+        role: str,
+    ) -> None:
+        handles = self.handles if role == "primary" else self.verification_handles
 
         paths.log_path.parent.mkdir(parents=True, exist_ok=True)
         log_fh = open(paths.log_path, "ab", buffering=0)
@@ -70,6 +137,7 @@ class RunnerSupervisor:
         args = [
             sys.executable, "-u", str(RUNNER_MAIN),
             "--session-id", spec.id,
+            "--role", role,
             "--data-service-ws", self._ws_url(spec.id),
             "--provider", spec.provider,
             "--exchange", spec.exchange,
@@ -82,33 +150,270 @@ class RunnerSupervisor:
             "--telegram-enabled", _bool_arg(spec.webhook.get("telegram_notification")),
         ]
 
-        proc = await asyncio.create_subprocess_exec(
-            *args, stdout=log_fh, stderr=log_fh, cwd=str(REPO_ROOT),
-        )
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *args, stdout=log_fh, stderr=log_fh, cwd=str(REPO_ROOT),
+            )
+        except Exception:
+            log_fh.close()
+            raise
         handle = RunnerProcessHandle(
-            session_id=spec.id, process=proc, status="starting",
+            session_id=spec.id, role=role, process=proc, status="starting",
             user_stopped=False, log_path=paths.log_path, log_fh=log_fh,
         )
-        self.handles[spec.id] = handle
+        handles[spec.id] = handle
         handle.monitor_task = asyncio.create_task(self._monitor(handle))
-        print(f"[supervisor] started runner for {spec.id} (pid={proc.pid})")
+        if role == "verification":
+            self._start_verification_connect_timeout(handle)
+        print(
+            f"[supervisor] started {role} runner for {spec.id} "
+            f"(pid={proc.pid})"
+        )
         await self._changed()
+
+    @staticmethod
+    def _verification_paths(paths: SessionPaths) -> SessionPaths:
+        return SessionPaths(
+            plot_path=paths.plot_path.with_name("verification_plot.csv"),
+            hash_path=paths.hash_path.with_name("verification_script_hash.csv"),
+            log_path=paths.log_path.with_name("verification_runner.log"),
+        )
+
+    def _is_verification_active(self, session_id: str) -> bool:
+        handle = self.verification_handles.get(session_id)
+        return bool(handle and handle.process.returncode is None)
 
     async def _monitor(self, handle: RunnerProcessHandle) -> None:
         rc = await handle.process.wait()
-        if handle.user_stopped or rc == 0:
+        if (
+            handle.role == "verification"
+            and self.verification_handles.get(handle.session_id) is handle
+        ):
+            self._cancel_verification_connect_timeout(handle.session_id)
+        unexpected_exit = (
+            not handle.user_stopped
+            and (handle.role == "verification" or rc != 0)
+        )
+        if not unexpected_exit:
             handle.status = "stopped"
         else:
             handle.status = "crashed"
-            print(f"[supervisor] runner {handle.session_id} crashed (exit={rc})")
+            print(
+                f"[supervisor] {handle.role} runner {handle.session_id} "
+                f"crashed (exit={rc})"
+            )
         try:
             handle.log_fh.close()
         except Exception:
             pass
+        if (
+            unexpected_exit
+            and handle.role == "verification"
+            and handle.session_id in self._verification_desired
+            and not self._shutting_down
+        ):
+            scheduled = self.request_verification_recovery(
+                handle.session_id,
+                reason=f"process exited with code {rc}",
+            )
+            if not scheduled:
+                recovery = self._verification_recovery_tasks.get(handle.session_id)
+                if recovery is not None and not recovery.done():
+                    def retry_after_current(_task: asyncio.Task) -> None:
+                        current = self.verification_handles.get(handle.session_id)
+                        if current is handle and current.process.returncode is not None:
+                            self.request_verification_recovery(
+                                handle.session_id,
+                                reason=f"process exited with code {rc}",
+                            )
+
+                    recovery.add_done_callback(retry_after_current)
         await self._changed()
 
+    def _start_verification_connect_timeout(
+        self,
+        handle: RunnerProcessHandle,
+    ) -> None:
+        self._cancel_verification_connect_timeout(handle.session_id)
+        self._verification_connect_timeout_tasks[handle.session_id] = asyncio.create_task(
+            self._verification_connect_timeout(handle),
+            name=f"verification-connect-timeout:{handle.session_id}",
+        )
+
+    def _cancel_verification_connect_timeout(self, session_id: str) -> None:
+        task = self._verification_connect_timeout_tasks.pop(session_id, None)
+        if task is not None and not task.done() and task is not asyncio.current_task():
+            task.cancel()
+
+    async def _verification_connect_timeout(
+        self,
+        handle: RunnerProcessHandle,
+    ) -> None:
+        try:
+            await asyncio.sleep(VERIFICATION_CONNECT_TIMEOUT_SECONDS)
+            if (
+                self.verification_handles.get(handle.session_id) is handle
+                and handle.process.returncode is None
+                and handle.session_id in self._verification_desired
+            ):
+                self.request_verification_recovery(
+                    handle.session_id,
+                    reason="verification runner connection timed out",
+                )
+        except asyncio.CancelledError:
+            raise
+        finally:
+            if (
+                self._verification_connect_timeout_tasks.get(handle.session_id)
+                is asyncio.current_task()
+            ):
+                self._verification_connect_timeout_tasks.pop(handle.session_id, None)
+
+    @staticmethod
+    def _verification_recovery_delay(attempt: int) -> float:
+        return float((2, 5, 10, 20, 30, 60)[min(max(attempt - 1, 0), 5)])
+
+    def request_verification_recovery(
+        self,
+        session_id: str,
+        *,
+        reason: str,
+        immediate: bool = False,
+    ) -> bool:
+        if (
+            not self.verification_enabled
+            or self._shutting_down
+            or session_id not in self._verification_desired
+            or session_id not in self._verification_targets
+        ):
+            return False
+        current = self._verification_recovery_tasks.get(session_id)
+        if current is not None and not current.done():
+            if not immediate:
+                return False
+            current.cancel()
+
+        attempt = self._verification_recovery_attempts.get(session_id, 0) + 1
+        delay = 0.0 if immediate else self._verification_recovery_delay(attempt)
+        self._verification_recovery_attempts[session_id] = attempt
+        self._verification_recovery_reasons[session_id] = reason
+        self._verification_recovery_at[session_id] = time.time() + delay
+        task = asyncio.create_task(
+            self._recover_verification(session_id, delay),
+            name=f"verification-recovery:{session_id}",
+        )
+        self._verification_recovery_tasks[session_id] = task
+        asyncio.create_task(self._changed())
+        return True
+
+    async def _recover_verification(self, session_id: str, delay: float) -> None:
+        current_task = asyncio.current_task()
+        try:
+            if delay > 0:
+                await asyncio.sleep(delay)
+            if (
+                self._shutting_down
+                or session_id not in self._verification_desired
+                or not self.is_active(session_id)
+            ):
+                return
+            spec, paths = self._verification_targets[session_id]
+            self._verification_recovery_spawning.add(session_id)
+            await self._stop_handle(session_id, role="verification")
+            await self._cleanup_handle(session_id, role="verification")
+            await self._spawn(
+                spec,
+                self._verification_paths(paths),
+                role="verification",
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as error:
+            print(
+                f"[supervisor] verification runner {session_id} recovery failed: "
+                f"{type(error).__name__}: {error}"
+            )
+            if session_id in self._verification_desired and not self._shutting_down:
+                self._verification_recovery_tasks.pop(session_id, None)
+                self.request_verification_recovery(
+                    session_id,
+                    reason=f"restart failed: {type(error).__name__}: {error}",
+                )
+        finally:
+            self._verification_recovery_spawning.discard(session_id)
+            if self._verification_recovery_tasks.get(session_id) is current_task:
+                self._verification_recovery_tasks.pop(session_id, None)
+                self._verification_recovery_at.pop(session_id, None)
+            await self._changed()
+
+    def mark_verification_connected(self, session_id: str) -> None:
+        self._cancel_verification_connect_timeout(session_id)
+        task = self._verification_recovery_tasks.get(session_id)
+        if (
+            task is not None
+            and not task.done()
+            and session_id not in self._verification_recovery_spawning
+        ):
+            task.cancel()
+            self._verification_recovery_tasks.pop(session_id, None)
+            self._verification_recovery_at.pop(session_id, None)
+
+    def mark_verification_disconnected(self, session_id: str) -> None:
+        handle = self.verification_handles.get(session_id)
+        if (
+            handle is None
+            or handle.process.returncode is not None
+            or session_id not in self._verification_desired
+        ):
+            return
+        # The runner's reconnect loop keeps its in-memory strategy state. Only
+        # replace the process if it cannot restore the local websocket channel.
+        self._start_verification_connect_timeout(handle)
+
+    def mark_verification_ready(self, session_id: str) -> None:
+        self.mark_verification_connected(session_id)
+        self._verification_recovery_attempts.pop(session_id, None)
+        self._verification_recovery_reasons.pop(session_id, None)
+
+    async def restart_verification(
+        self,
+        spec: SessionSpec,
+        paths: SessionPaths,
+        *,
+        reason: str = "manual restart",
+    ) -> None:
+        if not self.verification_enabled:
+            raise RuntimeError("verification runner is disabled")
+        if not self.is_active(spec.id):
+            raise RuntimeError("primary runner is not running")
+        self._verification_targets[spec.id] = (spec, paths)
+        self._verification_desired.add(spec.id)
+        self.request_verification_recovery(
+            spec.id,
+            reason=reason,
+            immediate=True,
+        )
+
     async def stop(self, session_id: str) -> None:
-        handle = self.handles.get(session_id)
+        self._verification_desired.discard(session_id)
+        recovery = self._verification_recovery_tasks.pop(session_id, None)
+        if recovery is not None and not recovery.done():
+            recovery.cancel()
+            await asyncio.gather(recovery, return_exceptions=True)
+        self._verification_recovery_at.pop(session_id, None)
+        self._verification_recovery_attempts.pop(session_id, None)
+        self._verification_recovery_reasons.pop(session_id, None)
+        self._verification_recovery_spawning.discard(session_id)
+        self._cancel_verification_connect_timeout(session_id)
+        self._verification_targets.pop(session_id, None)
+        await asyncio.gather(
+            self._stop_handle(session_id, role="verification"),
+            self._stop_handle(session_id, role="primary"),
+        )
+
+    async def _stop_handle(self, session_id: str, *, role: str) -> None:
+        handles = self.handles if role == "primary" else self.verification_handles
+        handle = handles.get(session_id)
         if handle is None:
             return
         handle.user_stopped = True
@@ -135,14 +440,15 @@ class RunnerSupervisor:
                 await handle.monitor_task
             except Exception:
                 pass
-        print(f"[supervisor] stopped runner for {session_id}")
+        print(f"[supervisor] stopped {role} runner for {session_id}")
 
     async def restart(self, spec: SessionSpec, paths: SessionPaths) -> None:
         await self.stop(spec.id)
         await self.start(spec, paths)
 
-    async def _cleanup_handle(self, session_id: str) -> None:
-        handle = self.handles.pop(session_id, None)
+    async def _cleanup_handle(self, session_id: str, *, role: str) -> None:
+        handles = self.handles if role == "primary" else self.verification_handles
+        handle = handles.pop(session_id, None)
         if handle is None:
             return
         if handle.monitor_task is not None and not handle.monitor_task.done():
@@ -153,8 +459,22 @@ class RunnerSupervisor:
             pass
 
     async def shutdown(self) -> None:
-        for sid in list(self.handles.keys()):
+        self._shutting_down = True
+        session_ids = set(self.handles) | set(self.verification_handles)
+        for sid in list(session_ids):
             await self.stop(sid)
+        recovery_tasks = list(self._verification_recovery_tasks.values())
+        self._verification_recovery_tasks.clear()
+        for task in recovery_tasks:
+            task.cancel()
+        if recovery_tasks:
+            await asyncio.gather(*recovery_tasks, return_exceptions=True)
+        connect_tasks = list(self._verification_connect_timeout_tasks.values())
+        self._verification_connect_timeout_tasks.clear()
+        for task in connect_tasks:
+            task.cancel()
+        if connect_tasks:
+            await asyncio.gather(*connect_tasks, return_exceptions=True)
 
 
 def _bool_arg(v) -> str:

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -21,7 +21,7 @@ from prerun_scheduler import default_offset_seconds
 from market_data_diagnostics import log_session_diagnostic
 from state import DataState
 from tv_logos import static_logo_info
-from verification import VerificationCoordinator
+from verification import VerificationCoordinator, VerificationDeliveryService
 from ws_manager import WSManager
 
 
@@ -323,6 +323,7 @@ class Session:
         *,
         strategy_evaluation_enabled: bool = False,
         verification_enabled: bool = False,
+        verification_delivery: VerificationDeliveryService | None = None,
     ) -> None:
         self.spec = spec
         self.feed = feed
@@ -338,6 +339,7 @@ class Session:
         self.verification = VerificationCoordinator(
             self,
             enabled=verification_enabled,
+            delivery=verification_delivery,
         )
         # True only after the runner finishes its first pre_run (chart plots ready).
         # Drives the dashboard LED: connected-but-prerunning = "starting" (amber),

--- a/data_service/runtime.py
+++ b/data_service/runtime.py
@@ -18,16 +18,16 @@ from log_utils import log_with_time
 from manual_alerts import build_manual_alert_payload, send_manual_alert_payload
 from ohlcv_paths import make_ohlcv_paths, runtime_output_dir
 from prerun_scheduler import default_offset_seconds
+from market_data_diagnostics import log_session_diagnostic
 from state import DataState
 from tv_logos import static_logo_info
+from verification import VerificationCoordinator
 from ws_manager import WSManager
 
 
 _MAX_AI_INSTRUCTION_CHARS = 4_000
 _MAX_PROCESSED_AI_INSTRUCTION_EVENTS = 500
 _MAX_RECENT_RAW_TRADE_KEYS = 10_000
-
-
 def _plot_wire_value(value: Any, kind: str) -> float | int | None:
     if value is None or str(value) == "":
         return None
@@ -77,6 +77,7 @@ class Feed:
         self.paths = FeedPaths.build(spec)
         self.state = DataState()
         self.tasks: Dict[str, Any] = {}
+        self.finalized_candle_probe: Any | None = None
         self.history_ready_event = asyncio.Event()
         self.data_integrity_lock = asyncio.Lock()
         self.collector_error: Optional[str] = None
@@ -89,6 +90,9 @@ class Feed:
         self.prerun_prepare_offset_seconds = default_offset_seconds(spec.timeframe)
         self._recent_raw_trade_keys: deque[tuple[Any, ...]] = deque()
         self._recent_raw_trade_key_set: set[tuple[Any, ...]] = set()
+        self._verification_dispatch_sequence = 0
+        self._verification_primary_results: dict[int, dict[str, Any]] = {}
+        self._verification_probe_lock = asyncio.Lock()
         # session_id -> Session
         self.subscribers: Dict[str, "Session"] = {}
 
@@ -189,6 +193,78 @@ class Feed:
                 continue
             await session.handle_feed_event(dict(payload))
 
+    def queue_verification_candle(self, payload: dict[str, Any]) -> None:
+        self._verification_dispatch_sequence += 1
+        key = f"verification_dispatch:{self._verification_dispatch_sequence}"
+        task = asyncio.create_task(self._dispatch_verification_candle(payload))
+        self.tasks[key] = task
+
+        def discard(_task: asyncio.Task) -> None:
+            self.tasks.pop(key, None)
+
+        task.add_done_callback(discard)
+
+    async def _dispatch_verification_candle(self, payload: dict[str, Any]) -> None:
+        for session in list(self.subscribers.values()):
+            if session.runner_count <= 0 or not session.verification.enabled:
+                continue
+            await session.verification.handle_candle(dict(payload))
+
+    def record_verification_primary_result(self, payload: dict[str, Any]) -> None:
+        try:
+            timestamp_ms = int(payload["candle_timestamp_ms"])
+        except (KeyError, TypeError, ValueError):
+            return
+        existing = self._verification_primary_results.get(timestamp_ms)
+        confirmed_bar = payload.get("confirmed_bar")
+        has_bar = (
+            isinstance(confirmed_bar, (list, tuple))
+            and len(confirmed_bar) >= 6
+        )
+        existing_bar = existing.get("confirmed_bar") if existing else None
+        existing_has_bar = (
+            isinstance(existing_bar, (list, tuple)) and len(existing_bar) >= 6
+        )
+        replace = existing is None or (has_bar and not existing_has_bar)
+        if has_bar and existing_has_bar:
+            try:
+                replace = float(confirmed_bar[5]) >= float(existing_bar[5])
+            except (TypeError, ValueError, OverflowError):
+                replace = False
+        if replace:
+            self._verification_primary_results[timestamp_ms] = dict(payload)
+        while len(self._verification_primary_results) > 128:
+            self._verification_primary_results.pop(
+                min(self._verification_primary_results)
+            )
+        probe = self.finalized_candle_probe
+        if probe is not None:
+            probe.record_primary_result(payload)
+
+    def seed_verification_primary_results(self, probe: Any) -> None:
+        for payload in self._verification_primary_results.values():
+            probe.record_primary_result(payload)
+
+    def clear_verification_primary_results(self) -> None:
+        self._verification_primary_results.clear()
+
+    def log_market_data_diagnostic(self, event: dict[str, Any]) -> None:
+        feed_data = {
+            "id": self.spec.id,
+            "provider": self.spec.provider,
+            "exchange": self.spec.exchange,
+            "symbol": self.spec.symbol,
+            "timeframe": self.spec.timeframe,
+            "market_type": self.spec.market_type,
+        }
+        for session in list(self.subscribers.values()):
+            log_session_diagnostic(
+                session.paths.plot_path.parent,
+                session.spec.id,
+                event,
+                feed=feed_data,
+            )
+
     def history_ready(self) -> bool:
         return self.history_ready_event.is_set()
 
@@ -246,6 +322,7 @@ class Session:
         feed: Feed,
         *,
         strategy_evaluation_enabled: bool = False,
+        verification_enabled: bool = False,
     ) -> None:
         self.spec = spec
         self.feed = feed
@@ -258,6 +335,10 @@ class Session:
         self.plotchar_history: List[Dict[str, Any]] = []
         self.client_roles: Dict[WebSocket, Optional[str]] = {}
         self.runner_count = 0
+        self.verification = VerificationCoordinator(
+            self,
+            enabled=verification_enabled,
+        )
         # True only after the runner finishes its first pre_run (chart plots ready).
         # Drives the dashboard LED: connected-but-prerunning = "starting" (amber),
         # ready = "running" (green).
@@ -343,6 +424,13 @@ class Session:
 
     async def _send_runner_event(self, payload: dict[str, Any]) -> None:
         session_payload = dict(payload)
+        if (
+            session_payload.get("type") == "run_ready"
+            and self.verification.enabled
+        ):
+            session_payload["verification_generation_id"] = (
+                self.verification.generation_id
+            )
         if (
             self.strategy_evaluation_enabled
             and session_payload.get("type") in {
@@ -433,6 +521,7 @@ class Session:
         self.chart_info["script_source"] = ""
         self._processed_ai_instruction_ids.clear()
         self._processed_ai_instruction_order.clear()
+        self.verification.reset_for_reconfigure()
 
     @property
     def ohlcv_path(self) -> Path:
@@ -592,6 +681,8 @@ class Session:
                 await self.set_calculation_stopped()
                 await self.send_to_charts({"type": "runner_disconnected"})
             await self._notify_status()
+        elif role == "verification_runner":
+            await self.verification.handle_disconnect()
 
     async def handle_text(self, ws: WebSocket, msg_text: str) -> None:
         try:
@@ -608,9 +699,14 @@ class Session:
         ohlcv_path = self.feed.paths.ohlcv_path
         plot_path = self.paths.plot_path
 
+        if await self.verification.handle_message(ws, event):
+            return
+
         if msg_type == "client_hello":
             role = event.get("role")
             if role == "runner":
+                if self.runner_count <= 0:
+                    self.verification.reset_generation()
                 self.runner_ready = False  # fresh runner: pre_run not done yet (amber)
                 if self.strategy_evaluation_enabled:
                     await self.begin_calculation({"type": "runner_start"})
@@ -650,10 +746,13 @@ class Session:
                 self.client_roles[ws] = None
 
         elif msg_type == "runner_ready":
+            if self.client_roles.get(ws) != "runner":
+                return
             # Runner finished its first pre_run -> flip the LED to green.
             self.runner_ready = True
             self.history_resync_pending = False
             await self._set_runner_phase("running")
+            await self.verification.on_primary_ready()
 
         elif msg_type == "strategy_snapshot":
             if self.client_roles.get(ws) != "runner":
@@ -794,8 +893,12 @@ class Session:
                 "source_name": self.chart_info.get("script_source_name"),
                 "source": self.chart_info.get("script_source") or "",
             })
+            if self.client_roles.get(ws) == "runner":
+                await self.verification.on_script_info()
 
         elif (msg_type == "reset_history") or (msg_type == "script_modified"):
+            if self.client_roles.get(ws) == "runner":
+                self.verification.on_primary_reset()
             self.trades_history.clear()
             self.plot_options.clear()
             self.plotchar_history.clear()

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -807,6 +807,51 @@ tr:last-child td { border-bottom: none; }
   gap: 6px;
   white-space: nowrap;
 }
+.runner-actions > .btn[data-tooltip],
+.runner-actions > .verification-status-wrap > .btn[data-tooltip],
+.data-controls > .btn[data-tooltip] {
+  position: relative;
+}
+@media (hover: hover) and (pointer: fine) {
+  .runner-actions > .btn[data-tooltip]::after,
+  .runner-actions > .verification-status-wrap > .btn[data-tooltip]::after,
+  .data-controls > .btn[data-tooltip]::after {
+    content: attr(data-tooltip);
+    position: absolute;
+    left: 50%;
+    bottom: calc(100% + 7px);
+    z-index: 48;
+    width: max-content;
+    max-width: min(220px, calc(100vw - 24px));
+    padding: 6px 8px;
+    border: 1px solid var(--border);
+    border-radius: 5px;
+    background: #11161d;
+    box-shadow: 0 6px 18px rgba(0, 0, 0, 0.38);
+    color: var(--text);
+    font-size: 11px;
+    font-weight: 500;
+    line-height: 1.25;
+    letter-spacing: 0;
+    white-space: nowrap;
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, 2px);
+    transition: opacity 120ms ease, transform 120ms ease;
+  }
+  .runner-actions > .btn[data-tooltip]:hover::after,
+  .runner-actions > .btn[data-tooltip]:focus-visible::after,
+  .runner-actions > .verification-status-wrap > .btn[data-tooltip]:hover::after,
+  .runner-actions > .verification-status-wrap > .btn[data-tooltip]:focus-visible::after,
+  .data-controls > .btn[data-tooltip]:hover::after,
+  .data-controls > .btn[data-tooltip]:focus-visible::after {
+    opacity: 1;
+    transform: translate(-50%, 0);
+  }
+  .runner-actions > .verification-status-wrap.show-verification-status > .btn[data-tooltip]::after {
+    display: none;
+  }
+}
 
 @media (min-width: 721px) {
   #sessions th:nth-child(10) { width: 1%; }
@@ -814,7 +859,8 @@ tr:last-child td { border-bottom: none; }
     width: 1%;
     padding-right: 36px;
   }
-  .runner-actions { min-width: 190px; }
+  /* Reserve the widest running state: Stop + Restart + Logs + Verification. */
+  .runner-actions { min-width: 130px; }
 }
 
 .symbol-cell,
@@ -990,6 +1036,143 @@ tr:last-child td { border-bottom: none; }
   opacity: 1;
   transform: translate(-50%, 0);
 }
+
+.verification-status-wrap {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  vertical-align: middle;
+}
+.verification-status-wrap[hidden] { display: none; }
+.verification-inspect-button {
+  touch-action: manipulation;
+}
+.verification-inspect-button:hover,
+.verification-inspect-button:focus-visible,
+.verification-status-wrap.show-verification-status .verification-inspect-button {
+  border-color: var(--accent);
+  color: var(--text);
+}
+.verification-led {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 50%;
+  background: #6b7280;
+}
+.verification-led-running {
+  border-color: #42d77d;
+  background: #28a745;
+  box-shadow: 0 0 5px rgba(40, 167, 69, 0.75);
+}
+.verification-led-starting,
+.verification-led-warming_up {
+  border-color: #ffd45e;
+  background: #e0a300;
+  animation: blink-fast 0.7s infinite;
+}
+.verification-led-recovering {
+  border-color: #76a7ff;
+  background: var(--accent);
+  animation: pulse-slow 1s ease-in-out infinite;
+}
+
+.verification-led-reconnecting {
+  background: #f3b33d;
+  box-shadow: 0 0 0 2px rgb(243 179 61 / 18%);
+  animation: pulse-slow 0.8s ease-in-out infinite;
+}
+.verification-led-crashed {
+  border-color: #ff8c96;
+  background: var(--danger);
+  box-shadow: 0 0 5px rgba(220, 53, 69, 0.7);
+}
+.verification-status-popover {
+  position: absolute;
+  right: 0;
+  bottom: calc(100% + 7px);
+  z-index: 49;
+  display: grid;
+  width: min(280px, calc(100vw - 24px));
+  gap: 7px;
+  padding: 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: #11161d;
+  box-shadow: 0 6px 18px rgba(0, 0, 0, 0.38);
+  color: var(--text);
+  font-size: 10px;
+  font-weight: 400;
+  line-height: 1.4;
+  letter-spacing: 0;
+  text-align: left;
+  white-space: normal;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateY(2px);
+  transition: opacity 120ms ease, transform 120ms ease;
+}
+.verification-status-wrap.show-verification-status .verification-status-popover {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+.verification-popover-title {
+  color: #f2f5f8;
+  font-size: 11px;
+  font-weight: 600;
+}
+.verification-popover-header {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.verification-popover-heading {
+  display: inline-flex;
+  min-width: 0;
+  align-items: center;
+  gap: 7px;
+}
+.verification-status-description {
+  color: var(--muted);
+}
+.verification-restart-button {
+  display: inline-flex;
+  width: 24px;
+  height: 24px;
+  flex: 0 0 24px;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: #1b222c;
+  color: var(--text);
+  cursor: pointer;
+  touch-action: manipulation;
+}
+.verification-restart-button:hover,
+.verification-restart-button:focus-visible {
+  border-color: var(--accent);
+  outline: none;
+}
+.verification-restart-button:disabled {
+  cursor: default;
+  opacity: 0.42;
+}
+.verification-restart-button svg {
+  width: 14px;
+  height: 14px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
 @media (hover: hover) and (pointer: fine) {
   .runner-status-anchor:hover .runner-status-tooltip {
     opacity: 1;
@@ -1007,6 +1190,10 @@ tr:last-child td { border-bottom: none; }
   .runner-status-anchor.show-runner-status .runner-status-tooltip,
   .runner-status-anchor:focus-visible .runner-status-tooltip {
     transform: translate(0, 0);
+  }
+  .verification-status-popover {
+    right: 0;
+    left: auto;
   }
 }
 
@@ -4330,7 +4517,8 @@ tr:last-child td { border-bottom: none; }
   width: 13px;
   height: 13px;
 }
-.data-integrity-btn .icon {
+.data-integrity-btn .icon,
+.verification-inspect-button .icon {
   width: 13px;
   height: 13px;
 }
@@ -5707,15 +5895,6 @@ tr:last-child td { border-bottom: none; }
   /* re-assert the square (this block's .btn padding would otherwise distort the
      icon buttons) and enlarge them to a comfortable touch size */
   .btn-icon { width: 34px; height: 34px; padding: 0; }
-  /* uniform width for the Chart "Open" link and runner Start/Stop/Restart/Logs
-     buttons — mobile only. On desktop the runner column is a fixed 190px and a
-     forced per-button min-width would overflow it in the running state and
-     shake the column, so this stays scoped to the mobile card layout. */
-  .btn-chart,
-  .runner-actions .btn {
-    min-width: 72px;
-    text-align: center;
-  }
   input[type="checkbox"] { width: 18px; height: 18px; }
 
   @media (hover: hover) and (pointer: fine) {

--- a/data_service/templates/dashboard.css
+++ b/data_service/templates/dashboard.css
@@ -1140,6 +1140,46 @@ tr:last-child td { border-bottom: none; }
 .verification-status-description {
   color: var(--muted);
 }
+.verification-latest-finding {
+  display: grid;
+  min-width: 0;
+  gap: 3px;
+  padding-top: 7px;
+  border-top: 1px solid var(--border);
+}
+.verification-finding-heading {
+  color: #f2f5f8;
+  font-weight: 600;
+}
+.verification-finding-empty,
+.verification-finding-meta {
+  color: var(--muted);
+}
+.verification-finding-details {
+  display: grid;
+  min-width: 0;
+  gap: 2px;
+}
+.verification-finding-details[hidden] {
+  display: none;
+}
+.verification-finding-kind {
+  font-weight: 600;
+}
+.verification-finding-kind-missing {
+  color: #ff8c96;
+}
+.verification-finding-kind-primary_only {
+  color: #ffd45e;
+}
+.verification-finding-order,
+.verification-finding-meta {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+.verification-finding-order {
+  color: var(--text);
+}
 .verification-restart-button {
   display: inline-flex;
   width: 24px;

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=148" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=149" />
 </head>
 <body>
   <header class="topbar">
@@ -1039,6 +1039,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=162"></script>
+  <script src="/static/dashboard.js?v=163"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.html
+++ b/data_service/templates/dashboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no" />
   <title>PyneReal Hub</title>
-  <link rel="stylesheet" href="/static/dashboard.css?v=142" />
+  <link rel="stylesheet" href="/static/dashboard.css?v=148" />
 </head>
 <body>
   <header class="topbar">
@@ -1039,6 +1039,6 @@
     </form>
   </div>
 
-  <script src="/static/dashboard.js?v=156"></script>
+  <script src="/static/dashboard.js?v=162"></script>
 </body>
 </html>

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -6978,16 +6978,82 @@
     if (isCalendarOpen() && calendarSelectedDate) renderCalendarAddControls();
   }
 
+  // Lucide line-art icons for the runner/chart action buttons (viewBox 0 0 24 24,
+  // stroke-width 2 via .btn-icon .icon). Defined before runnerButtons so they are
+  // initialized before any render-time call.
+  const runnerPlayIcon =
+    `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">`
+    + `<polygon points="6 3 20 12 6 21 6 3"></polygon>`
+    + `</svg>`;
+  const runnerStopIcon =
+    `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">`
+    + `<rect x="3" y="3" width="18" height="18" rx="2"></rect>`
+    + `</svg>`;
+  const runnerRestartIcon =
+    `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">`
+    + `<path d="M21 12a9 9 0 1 1-9-9c2.52 0 4.93 1 6.74 2.74L21 8"></path>`
+    + `<path d="M21 3v5h-5"></path>`
+    + `</svg>`;
+  const runnerLogsIcon =
+    `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">`
+    + `<polyline points="4 17 10 11 4 5"></polyline>`
+    + `<line x1="12" y1="19" x2="20" y2="19"></line>`
+    + `</svg>`;
+  const magnifierIcon =
+    `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">`
+    + `<circle cx="11" cy="11" r="8"></circle>`
+    + `<path d="m21 21-4.3-4.3"></path>`
+    + `</svg>`;
+  const runnerOpenIcon =
+    `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">`
+    + `<path d="M15 3h6v6"></path>`
+    + `<path d="M10 14 21 3"></path>`
+    + `<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h6"></path>`
+    + `</svg>`;
+
   function runnerButtons(s) {
     const r = s.runner || "stopped";
     const dataReady = !!s.history_ready;
     if (r === "running" || r === "starting") {
-      return `<button class="btn" data-runner="stop">Stop</button>` +
-             `<button class="btn" data-runner="restart"${dataReady ? "" : " disabled"}>Restart</button>`;
+      return `<button class="btn btn-icon" data-runner="stop" data-tooltip="Stop" aria-label="Stop">${runnerStopIcon}</button>` +
+             `<button class="btn btn-icon" data-runner="restart" data-tooltip="Restart"${dataReady ? "" : " disabled"} aria-label="Restart">${runnerRestartIcon}</button>`;
     }
     const canStart = dataReady && Boolean(s.script_name);
-    const title = s.script_name ? "" : ' title="Select a script first"';
-    return `<button class="btn btn-primary" data-runner="start"${canStart ? "" : " disabled"}${title}>Start</button>`;
+    return `<button class="btn btn-icon" data-runner="start" data-tooltip="Start"${canStart ? "" : " disabled"} aria-label="Start">${runnerPlayIcon}</button>`;
+  }
+
+  function verificationControls(s) {
+    const verification = s && s.verification && typeof s.verification === "object"
+      ? s.verification
+      : {};
+    const runner = String((s && s.runner) || "stopped");
+    if (!verification.enabled || (runner !== "running" && runner !== "starting")) return "";
+    return (
+        `<span data-field="verification-status-wrap" class="verification-status-wrap">` +
+        `<button type="button" class="btn btn-icon verification-inspect-button" ` +
+        `data-act="verification-status" data-tooltip="Verification runner" ` +
+        `aria-label="Verification runner" aria-expanded="false">` +
+          magnifierIcon +
+        `</button>` +
+        `<span class="verification-status-popover" role="dialog" ` +
+        `aria-label="Verification runner status">` +
+          `<span class="verification-popover-header">` +
+            `<span class="verification-popover-heading">` +
+              `<span data-field="verification-led" class="verification-led" aria-hidden="true"></span>` +
+              `<span class="verification-popover-title">Verification runner</span>` +
+            `</span>` +
+            `<button type="button" class="verification-restart-button" ` +
+            `data-act="verification-restart" title="Restart verification runner" ` +
+            `aria-label="Restart verification runner">` +
+              runnerRestartIcon +
+            `</button>` +
+          `</span>` +
+          `<span class="verification-status-description">` +
+            `Independently recalculates finalized candles to detect missed or false signals.` +
+          `</span>` +
+        `</span>` +
+      `</span>`
+    );
   }
 
   function esc(s) {
@@ -7072,9 +7138,40 @@
     return "running";
   }
 
+  function verificationStatusText(session, now = Date.now()) {
+    const verification = session && session.verification && typeof session.verification === "object"
+      ? session.verification
+      : {};
+    const status = String(verification.status || "stopped");
+    if (status === "recovering") {
+      const retryAt = Number(verification.next_retry_at);
+      const attempt = Number(verification.attempt || 0);
+      if (Number.isFinite(retryAt) && retryAt > now) {
+        const remaining = Math.max(1, Math.ceil((retryAt - now) / 1000));
+        return `Verification: recovering in ${remaining}s${attempt > 0 ? ` (attempt ${attempt})` : ""}`;
+      }
+      return `Verification: recovering${attempt > 0 ? ` (attempt ${attempt})` : ""}`;
+    }
+    if (status === "reconnecting") return "Verification: reconnecting";
+    if (status === "warming_up") return "Verification: warming up";
+    if (status === "starting") return "Verification: starting";
+    if (status === "running") return "Verification: running";
+    if (status === "crashed") return "Verification: crashed";
+    return "Verification: stopped";
+  }
+
   function closeRunnerStatusTooltips(exceptAnchor = null) {
     document.querySelectorAll(".runner-status-anchor.show-runner-status").forEach((anchor) => {
       if (anchor !== exceptAnchor) anchor.classList.remove("show-runner-status");
+    });
+  }
+
+  function closeVerificationStatusPopovers(exceptWrap = null) {
+    document.querySelectorAll(".verification-status-wrap.show-verification-status").forEach((wrap) => {
+      if (wrap === exceptWrap) return;
+      wrap.classList.remove("show-verification-status");
+      const button = wrap.querySelector('[data-act="verification-status"]');
+      if (button) button.setAttribute("aria-expanded", "false");
     });
   }
 
@@ -7090,6 +7187,12 @@
       const led = tr.querySelector('[data-field="runner-led"]');
       if (led) led.classList.toggle("led-warming", session.runner_phase === "prerun_active");
       if (anchor) anchor.setAttribute("aria-label", `Runner status: ${text}`);
+      const verification = session.verification || {};
+      const verificationWrap = tr.querySelector('[data-field="verification-status-wrap"]');
+      const verificationText = verificationStatusText(session, now);
+      if (verificationWrap) verificationWrap.hidden = !verification.enabled;
+      const verificationAnchor = tr.querySelector('[data-act="verification-status"]');
+      if (verificationAnchor) verificationAnchor.setAttribute("aria-label", verificationText);
     });
   }
 
@@ -7407,15 +7510,12 @@
           `data-act="data-since"></span>` +
           `<span data-field="data-since-popover" class="data-since-popover"></span></span>` +
         `<button class="btn btn-icon data-edit-btn" data-act="data-edit" ` +
-        `title="Data settings" aria-label="Data settings">` +
+        `data-tooltip="Data settings" aria-label="Data settings">` +
           settingsGearIcon +
         `</button>` +
         `<button class="btn btn-icon data-integrity-btn" data-act="data-integrity" ` +
-        `title="Verify OHLCV data" aria-label="Verify OHLCV data">` +
-          `<svg class="icon" viewBox="0 0 24 24" aria-hidden="true">` +
-            `<circle cx="11" cy="11" r="8"></circle>` +
-            `<path d="m21 21-4.3-4.3"></path>` +
-          `</svg>` +
+        `data-tooltip="Verify OHLCV data" aria-label="Verify OHLCV data">` +
+          magnifierIcon +
         `</button>` +
         `<span data-field="history-loading" class="muted">loading</span>` +
         `</span></td>` +
@@ -7427,7 +7527,7 @@
         `<input type="checkbox" data-act="telegram">` +
         `<button class="btn btn-icon" data-act="telegram-settings" title="Telegram bot">` + settingsGearIcon + `</button></span></td>` +
       `<td data-label="Runner" class="runner-cell" data-field="runner-cell"></td>` +
-      `<td data-label="Chart"><a data-field="chart-link" class="btn btn-chart" target="_blank">Open</a></td>` +
+      `<td data-label="Chart"><a data-field="chart-link" class="btn btn-chart btn-icon" target="_blank" title="Open chart" aria-label="Open chart">${runnerOpenIcon}</a></td>` +
       `<td data-label="Remove"><button class="btn btn-danger btn-icon" data-act="delete" title="Delete session">&times;</button></td>`;
 
     tr.addEventListener("change", (e) => {
@@ -7467,7 +7567,24 @@
         const anchor = target.closest(".runner-status-anchor");
         const show = anchor && !anchor.classList.contains("show-runner-status");
         closeRunnerStatusTooltips(anchor);
+        closeVerificationStatusPopovers();
         if (anchor) anchor.classList.toggle("show-runner-status", Boolean(show));
+      }
+      else if (act === "verification-status") {
+        e.preventDefault();
+        e.stopPropagation();
+        const wrap = target.closest(".verification-status-wrap");
+        const show = wrap && !wrap.classList.contains("show-verification-status");
+        closeRunnerStatusTooltips();
+        closeVerificationStatusPopovers(wrap);
+        if (wrap) wrap.classList.toggle("show-verification-status", Boolean(show));
+        target.setAttribute("aria-expanded", String(Boolean(show)));
+      }
+      else if (act === "verification-restart") {
+        e.preventDefault();
+        e.stopPropagation();
+        closeVerificationStatusPopovers();
+        restartVerificationRunner(id);
       }
       else if (act === "script-edit") openScriptChange(id);
       else if (act === "delete") openRemoveConfirm(id);
@@ -7481,7 +7598,8 @@
   function patchSessionRow(tr, s) {
     const id = sessionId(s);
     const runner = s.runner || "stopped";
-    const runnerControlsKey = `${runner}:${s.history_ready ? "ready" : "preparing"}:${s.script_name ? "script" : "no-script"}`;
+    const verificationEnabled = Boolean(s.verification && s.verification.enabled);
+    const runnerControlsKey = `${runner}:${s.history_ready ? "ready" : "preparing"}:${s.script_name ? "script" : "no-script"}:${verificationEnabled ? "verification" : "no-verification"}`;
     const collector = s.collector || "stopped";
     const wh = s.webhook || {};
     const exchange = (s.exchange || "").toUpperCase();
@@ -7493,6 +7611,34 @@
     setText(tr.querySelector('[data-field="runner-status-tooltip"]'), statusText);
     const statusAnchor = tr.querySelector('[data-act="runner-status"]');
     if (statusAnchor) statusAnchor.setAttribute("aria-label", `Runner status: ${statusText}`);
+
+    if (tr.dataset.runnerControlsKey !== runnerControlsKey) {
+      setHTML(
+        tr.querySelector('[data-field="runner-cell"]'),
+        `<span class="runner-actions">${runnerButtons(s)}` +
+          `<button class="btn btn-icon" data-act="logs" data-tooltip="Logs" aria-label="Logs">${runnerLogsIcon}</button>` +
+          `${verificationControls(s)}</span>`,
+      );
+      tr.dataset.runnerControlsKey = runnerControlsKey;
+    }
+
+    const verification = s.verification && typeof s.verification === "object"
+      ? s.verification
+      : {};
+    const verificationStatus = String(verification.status || "stopped");
+    const verificationWrap = tr.querySelector('[data-field="verification-status-wrap"]');
+    if (verificationWrap) verificationWrap.hidden = !verification.enabled;
+    setClass(
+      tr.querySelector('[data-field="verification-led"]'),
+      `verification-led verification-led-${verificationStatus}`,
+    );
+    const verificationText = verificationStatusText(s);
+    const verificationAnchor = tr.querySelector('[data-act="verification-status"]');
+    if (verificationAnchor) verificationAnchor.setAttribute("aria-label", `Verification runner: ${verificationText}`);
+    const verificationRestart = tr.querySelector('[data-act="verification-restart"]');
+    if (verificationRestart) {
+      verificationRestart.disabled = !(runner === "running" || runner === "starting");
+    }
 
     const symbolKey = JSON.stringify([s.symbol || "", s.tv_symbol || "", s.symbol_logo_url || ""]);
     if (tr.dataset.symbolKey !== symbolKey) {
@@ -7547,14 +7693,6 @@
 
     setChecked(tr.querySelector('[data-act="webhook"]'), !!wh.enabled);
     setChecked(tr.querySelector('[data-act="telegram"]'), !!wh.telegram_notification);
-
-    if (tr.dataset.runnerControlsKey !== runnerControlsKey) {
-      setHTML(
-        tr.querySelector('[data-field="runner-cell"]'),
-        `<span class="runner-actions">${runnerButtons(s)}<button class="btn" data-act="logs">Logs</button></span>`,
-      );
-      tr.dataset.runnerControlsKey = runnerControlsKey;
-    }
 
     const chart = tr.querySelector('[data-field="chart-link"]');
     const href = `/s/${encodeURIComponent(id)}`;
@@ -9104,6 +9242,27 @@
     }
   }
 
+  async function restartVerificationRunner(id) {
+    const session = sessions.find((item) => sessionId(item) === id);
+    if (session && session.verification) {
+      session.verification = {
+        ...session.verification,
+        status: "recovering",
+        reason: "manual restart",
+        next_retry_at: Date.now(),
+      };
+      render();
+    }
+    try {
+      await api(`/api/sessions/${encodeURIComponent(id)}/verification/restart`, {
+        method: "POST",
+      });
+    } catch (e) {
+      alert(`verification restart failed: ${e.message}`);
+      await refresh();
+    }
+  }
+
   async function toggleWebhook(id, payload) {
     try {
       await api(`/api/${encodeURIComponent(id)}/webhook-config`, {
@@ -9986,6 +10145,9 @@
     }
     if (!e.target || !e.target.closest || !e.target.closest(".runner-status-anchor")) {
       closeRunnerStatusTooltips();
+    }
+    if (!e.target || !e.target.closest || !e.target.closest(".verification-status-wrap")) {
+      closeVerificationStatusPopovers();
     }
     if (!isTouchTooltipMode()) return;
     if (!e.target || !e.target.closest || e.target.closest(".data-badge-wrap")) return;

--- a/data_service/templates/dashboard.js
+++ b/data_service/templates/dashboard.js
@@ -7051,6 +7051,16 @@
           `<span class="verification-status-description">` +
             `Independently recalculates finalized candles to detect missed or false signals.` +
           `</span>` +
+          `<span class="verification-latest-finding">` +
+            `<span class="verification-finding-heading">Latest finding</span>` +
+            `<span data-field="verification-finding-empty" class="verification-finding-empty">None detected</span>` +
+            `<span data-field="verification-finding-details" class="verification-finding-details" hidden>` +
+              `<span data-field="verification-finding-kind" class="verification-finding-kind"></span>` +
+              `<span data-field="verification-finding-order" class="verification-finding-order"></span>` +
+              `<span data-field="verification-finding-candle" class="verification-finding-meta"></span>` +
+              `<span data-field="verification-finding-detected" class="verification-finding-meta"></span>` +
+            `</span>` +
+          `</span>` +
         `</span>` +
       `</span>`
     );
@@ -7158,6 +7168,54 @@
     if (status === "running") return "Verification: running";
     if (status === "crashed") return "Verification: crashed";
     return "Verification: stopped";
+  }
+
+  function verificationFindingTime(value) {
+    const timestamp = typeof value === "number" ? value : Date.parse(String(value || ""));
+    const date = new Date(timestamp);
+    if (!Number.isFinite(timestamp) || Number.isNaN(date.getTime())) return "Unknown";
+    return date.toLocaleString("en-US", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+      hourCycle: "h23",
+    });
+  }
+
+  function updateVerificationFinding(tr, finding) {
+    const empty = tr.querySelector('[data-field="verification-finding-empty"]');
+    const details = tr.querySelector('[data-field="verification-finding-details"]');
+    const available = finding && typeof finding === "object";
+    if (empty) empty.hidden = Boolean(available);
+    if (details) details.hidden = !available;
+    if (!available) return;
+
+    const discrepancy = String(finding.discrepancy || "");
+    const kind = discrepancy === "missing" ? "Missed signal" : "Possible false signal";
+    const kindNode = tr.querySelector('[data-field="verification-finding-kind"]');
+    setText(kindNode, kind);
+    if (kindNode) {
+      setClass(kindNode, `verification-finding-kind verification-finding-kind-${discrepancy || "unknown"}`);
+    }
+
+    const action = String(finding.action || "signal").toUpperCase();
+    const orderId = String(finding.exit_id || finding.order_id || "-");
+    const occurrence = Number(finding.occurrence_index || 0);
+    setText(
+      tr.querySelector('[data-field="verification-finding-order"]'),
+      `${action} · ${orderId}${occurrence > 0 ? ` · #${occurrence + 1}` : ""}`,
+    );
+    setText(
+      tr.querySelector('[data-field="verification-finding-candle"]'),
+      `Candle ${verificationFindingTime(Number(finding.candle_timestamp_ms))}`,
+    );
+    setText(
+      tr.querySelector('[data-field="verification-finding-detected"]'),
+      `Detected ${verificationFindingTime(finding.detected_at)}`,
+    );
   }
 
   function closeRunnerStatusTooltips(exceptAnchor = null) {
@@ -7635,6 +7693,7 @@
     const verificationText = verificationStatusText(s);
     const verificationAnchor = tr.querySelector('[data-act="verification-status"]');
     if (verificationAnchor) verificationAnchor.setAttribute("aria-label", `Verification runner: ${verificationText}`);
+    updateVerificationFinding(tr, verification.latest_finding);
     const verificationRestart = tr.querySelector('[data-act="verification-restart"]');
     if (verificationRestart) {
       verificationRestart.disabled = !(runner === "running" || runner === "starting");

--- a/data_service/verification/__init__.py
+++ b/data_service/verification/__init__.py
@@ -1,0 +1,16 @@
+"""Finalized-candle verification for realtime strategy sessions.
+
+The package keeps the verification subsystem separate from the primary runner:
+
+* ``source`` selects exchange-confirmed candles.
+* ``coordinator`` owns session warm-up, replay, and result comparison.
+* ``protocol`` normalizes comparison identities shared by those paths.
+
+Process creation remains in ``runner_supervisor`` and the isolated strategy
+calculation remains in ``runner_service`` because those are process boundaries.
+"""
+
+from .coordinator import VerificationCoordinator
+from .source import FinalizedCandleProbe
+
+__all__ = ["FinalizedCandleProbe", "VerificationCoordinator"]

--- a/data_service/verification/__init__.py
+++ b/data_service/verification/__init__.py
@@ -5,12 +5,18 @@ The package keeps the verification subsystem separate from the primary runner:
 * ``source`` selects exchange-confirmed candles.
 * ``coordinator`` owns session warm-up, replay, and result comparison.
 * ``protocol`` normalizes comparison identities shared by those paths.
+* ``delivery`` handles asynchronous corrective notifications and deduplication.
 
 Process creation remains in ``runner_supervisor`` and the isolated strategy
 calculation remains in ``runner_service`` because those are process boundaries.
 """
 
 from .coordinator import VerificationCoordinator
+from .delivery import VerificationDeliveryService
 from .source import FinalizedCandleProbe
 
-__all__ = ["FinalizedCandleProbe", "VerificationCoordinator"]
+__all__ = [
+    "FinalizedCandleProbe",
+    "VerificationCoordinator",
+    "VerificationDeliveryService",
+]

--- a/data_service/verification/coordinator.py
+++ b/data_service/verification/coordinator.py
@@ -9,6 +9,7 @@ from fastapi import WebSocket
 
 from market_data_diagnostics import log_session_diagnostic
 
+from .delivery import VerificationDeliveryRequest, VerificationDeliveryService
 from .protocol import compare_results
 
 if TYPE_CHECKING:
@@ -23,9 +24,16 @@ _MAX_RESULTS = 128
 class VerificationCoordinator:
     """Own one session's verification protocol and comparison state."""
 
-    def __init__(self, session: Session, *, enabled: bool) -> None:
+    def __init__(
+        self,
+        session: Session,
+        *,
+        enabled: bool,
+        delivery: VerificationDeliveryService | None = None,
+    ) -> None:
         self.session = session
         self.enabled = enabled
+        self.delivery = delivery
         self.runner_count = 0
         self.runner_ready = False
         self.generation_id = uuid.uuid4().hex
@@ -37,6 +45,7 @@ class VerificationCoordinator:
 
         self._primary_results: dict[int, dict[str, Any]] = {}
         self._finalized_results: dict[int, dict[str, Any]] = {}
+        self._primary_delivery_context: dict[int, dict[str, Any]] = {}
         self._comparison_fingerprints: set[tuple[Any, ...]] = set()
         self._candle_backlog: dict[int, dict[str, Any]] = {}
         self._protocol_lock = asyncio.Lock()
@@ -69,6 +78,7 @@ class VerificationCoordinator:
         self._candle_backlog.clear()
         self._primary_results.clear()
         self._finalized_results.clear()
+        self._primary_delivery_context.clear()
         self._comparison_fingerprints.clear()
 
     def reset_for_reconfigure(self) -> None:
@@ -78,6 +88,7 @@ class VerificationCoordinator:
         self.runner_ready = False
         self._primary_results.clear()
         self._finalized_results.clear()
+        self._primary_delivery_context.clear()
         self._comparison_fingerprints.clear()
         self._candle_backlog.clear()
         self._last_dispatched_timestamp_ms = None
@@ -541,8 +552,17 @@ class VerificationCoordinator:
         )
         target[timestamp_ms] = dict(event)
         while len(target) > _MAX_RESULTS:
-            target.pop(next(iter(target)))
+            expired_timestamp = next(iter(target))
+            target.pop(expired_timestamp)
+            if target is self._primary_results:
+                self._primary_delivery_context.pop(expired_timestamp, None)
         if event.get("type") == "primary_result":
+            self._primary_delivery_context[timestamp_ms] = {
+                "webhook_config": dict(self.session.spec.webhook),
+                "script_title": str(
+                    self.session.chart_info.get("script_title") or ""
+                ),
+            }
             self.session.feed.record_verification_primary_result(event)
         self._log({
             "event": event.get("type"),
@@ -554,6 +574,7 @@ class VerificationCoordinator:
             "source_hashes": event.get("source_hashes") or {},
             "result_status": event.get("result_status"),
             "reason": event.get("reason"),
+            "authoritative_source": event.get("authoritative_source"),
         })
 
     def _compare_timestamp(self, timestamp_ms: int, generation_id: str) -> None:
@@ -570,7 +591,79 @@ class VerificationCoordinator:
         if fingerprint in self._comparison_fingerprints:
             return
         self._comparison_fingerprints.add(fingerprint)
+        comparison["supplemental_delivery_enabled"] = self.delivery is not None
         self._log(comparison)
+        self._enqueue_supplemental_delivery(
+            primary,
+            finalized,
+            comparison,
+            timestamp_ms,
+        )
+
+    def _enqueue_supplemental_delivery(
+        self,
+        primary: dict[str, Any],
+        finalized: dict[str, Any],
+        comparison: dict[str, Any],
+        timestamp_ms: int,
+    ) -> None:
+        if (
+            self.delivery is None
+            or not comparison.get("primary_result_available")
+            or not comparison.get("source_hashes_matched")
+            or self._rewarm_pending
+            or self.connection_lost
+            or not self.initialized
+            or not self.runner_ready
+        ):
+            return
+        authoritative_source = str(
+            finalized.get("authoritative_source") or ""
+        ).strip()
+        if not authoritative_source:
+            return
+
+        context = self._primary_delivery_context.get(timestamp_ms) or {}
+        toggles = primary.get("notification_toggles") or {}
+        common = {
+            "session_id": self.session.spec.id,
+            "script_title": str(context.get("script_title") or ""),
+            "exchange": self.session.spec.exchange,
+            "symbol": self.session.spec.symbol,
+            "timeframe": self.session.spec.timeframe,
+            "candle_timestamp_ms": timestamp_ms,
+            "primary_bar": comparison.get("primary_confirmed_bar"),
+            "finalized_bar": comparison.get("finalized_confirmed_bar"),
+            "bar_difference": dict(
+                comparison.get("confirmed_bar_difference") or {}
+            ),
+            "authoritative_source": authoritative_source,
+            "notification_toggles": {
+                "webhook": bool(toggles.get("webhook")),
+                "telegram": bool(toggles.get("telegram")),
+            },
+            "webhook_config": dict(context.get("webhook_config") or {}),
+            "on_result": self._log,
+        }
+        for discrepancy, key in (
+            ("missing", "missing_order_signals"),
+            ("primary_only", "primary_only_order_signals"),
+        ):
+            if discrepancy == "missing":
+                enabled = bool(
+                    common["notification_toggles"]["webhook"]
+                    or common["notification_toggles"]["telegram"]
+                )
+            else:
+                enabled = bool(common["notification_toggles"]["telegram"])
+            if not enabled:
+                continue
+            for signal in comparison.get(key) or []:
+                self.delivery.enqueue(VerificationDeliveryRequest(
+                    discrepancy=discrepancy,
+                    order_signal=dict(signal),
+                    **common,
+                ))
 
     def _resolve_initial_primary_pending(
         self,

--- a/data_service/verification/coordinator.py
+++ b/data_service/verification/coordinator.py
@@ -41,6 +41,7 @@ class VerificationCoordinator:
         self.connection_lost = False
         self.source_hashes: dict[str, str] = {}
         self.last_error: str | None = None
+        self.latest_finding: dict[str, Any] | None = None
         self.state_updated_at = datetime.now(UTC).isoformat()
 
         self._primary_results: dict[int, dict[str, Any]] = {}
@@ -98,6 +99,7 @@ class VerificationCoordinator:
         self.source_hashes.clear()
         self._rewarm_pending = False
         self.last_error = None
+        self.latest_finding = None
         self.state_updated_at = datetime.now(UTC).isoformat()
 
     def _cancel_warmup_timeout(self) -> None:
@@ -593,12 +595,73 @@ class VerificationCoordinator:
         self._comparison_fingerprints.add(fingerprint)
         comparison["supplemental_delivery_enabled"] = self.delivery is not None
         self._log(comparison)
+        self._record_latest_finding(
+            finalized,
+            comparison,
+            timestamp_ms,
+        )
         self._enqueue_supplemental_delivery(
             primary,
             finalized,
             comparison,
             timestamp_ms,
         )
+
+    def _comparison_is_reliable(
+        self,
+        finalized: dict[str, Any],
+        comparison: dict[str, Any],
+    ) -> bool:
+        return bool(
+            comparison.get("primary_result_available")
+            and comparison.get("source_hashes_matched")
+            and not self._rewarm_pending
+            and not self.connection_lost
+            and self.initialized
+            and self.runner_ready
+            and str(finalized.get("authoritative_source") or "").strip()
+        )
+
+    def _record_latest_finding(
+        self,
+        finalized: dict[str, Any],
+        comparison: dict[str, Any],
+        timestamp_ms: int,
+    ) -> None:
+        if not self._comparison_is_reliable(finalized, comparison):
+            return
+
+        discrepancy = ""
+        signal: dict[str, Any] | None = None
+        missing = comparison.get("missing_order_signals") or []
+        primary_only = comparison.get("primary_only_order_signals") or []
+        if missing:
+            discrepancy = "missing"
+            signal = dict(missing[-1])
+        elif primary_only:
+            discrepancy = "primary_only"
+            signal = dict(primary_only[-1])
+        if signal is None:
+            return
+
+        now = datetime.now(UTC).isoformat()
+        self.latest_finding = {
+            "discrepancy": discrepancy,
+            "candle_timestamp_ms": timestamp_ms,
+            "detected_at": now,
+            "action": str(signal.get("action") or ""),
+            "order_id": str(signal.get("order_id") or ""),
+            "exit_id": str(signal.get("exit_id") or ""),
+            "occurrence_index": int(signal.get("occurrence_index") or 0),
+        }
+        self.state_updated_at = now
+        self._notify_status_soon()
+
+    def _notify_status_soon(self) -> None:
+        try:
+            asyncio.get_running_loop().create_task(self.session._notify_status())
+        except RuntimeError:
+            pass
 
     def _enqueue_supplemental_delivery(
         self,

--- a/data_service/verification/coordinator.py
+++ b/data_service/verification/coordinator.py
@@ -1,0 +1,633 @@
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any, Awaitable, Callable
+
+from fastapi import WebSocket
+
+from market_data_diagnostics import log_session_diagnostic
+
+from .protocol import compare_results
+
+if TYPE_CHECKING:
+    from runtime import Session
+
+
+_WARMUP_TIMEOUT_SECONDS = 300.0
+_MAX_CANDLE_BACKLOG = 128
+_MAX_RESULTS = 128
+
+
+class VerificationCoordinator:
+    """Own one session's verification protocol and comparison state."""
+
+    def __init__(self, session: Session, *, enabled: bool) -> None:
+        self.session = session
+        self.enabled = enabled
+        self.runner_count = 0
+        self.runner_ready = False
+        self.generation_id = uuid.uuid4().hex
+        self.initialized = False
+        self.connection_lost = False
+        self.source_hashes: dict[str, str] = {}
+        self.last_error: str | None = None
+        self.state_updated_at = datetime.now(UTC).isoformat()
+
+        self._primary_results: dict[int, dict[str, Any]] = {}
+        self._finalized_results: dict[int, dict[str, Any]] = {}
+        self._comparison_fingerprints: set[tuple[Any, ...]] = set()
+        self._candle_backlog: dict[int, dict[str, Any]] = {}
+        self._protocol_lock = asyncio.Lock()
+        self._last_dispatched_timestamp_ms: int | None = None
+        self._latest_authoritative_timestamp_ms: int | None = None
+        self._rewarm_pending = False
+        self._warmup_timeout_task: asyncio.Task | None = None
+        self._initial_pending_timestamp_ms: int | None = None
+        self._initial_primary_pending_resolved = False
+
+        self.on_recovery: Callable[[Session, str], Awaitable[None]] | None = None
+        self.on_connected: Callable[[Session], Awaitable[None]] | None = None
+        self.on_disconnected: Callable[[Session], Awaitable[None]] | None = None
+        self.on_ready: Callable[[Session], Awaitable[None]] | None = None
+
+    @property
+    def rewarm_pending(self) -> bool:
+        return self._rewarm_pending
+
+    def reset_generation(self) -> None:
+        self._cancel_warmup_timeout()
+        self._initial_pending_timestamp_ms = None
+        self._initial_primary_pending_resolved = False
+        self.generation_id = uuid.uuid4().hex
+        self.runner_ready = False
+        self.initialized = False
+        self.source_hashes.clear()
+        self._last_dispatched_timestamp_ms = None
+        self._latest_authoritative_timestamp_ms = None
+        self._candle_backlog.clear()
+        self._primary_results.clear()
+        self._finalized_results.clear()
+        self._comparison_fingerprints.clear()
+
+    def reset_for_reconfigure(self) -> None:
+        self._cancel_warmup_timeout()
+        self._initial_pending_timestamp_ms = None
+        self._initial_primary_pending_resolved = False
+        self.runner_ready = False
+        self._primary_results.clear()
+        self._finalized_results.clear()
+        self._comparison_fingerprints.clear()
+        self._candle_backlog.clear()
+        self._last_dispatched_timestamp_ms = None
+        self._latest_authoritative_timestamp_ms = None
+        self.initialized = False
+        self.connection_lost = False
+        self.source_hashes.clear()
+        self._rewarm_pending = False
+        self.last_error = None
+        self.state_updated_at = datetime.now(UTC).isoformat()
+
+    def _cancel_warmup_timeout(self) -> None:
+        task = self._warmup_timeout_task
+        self._warmup_timeout_task = None
+        if task is not None and not task.done() and task is not asyncio.current_task():
+            task.cancel()
+
+    async def _warmup_timeout(self, generation_id: str) -> None:
+        try:
+            await asyncio.sleep(_WARMUP_TIMEOUT_SECONDS)
+            if (
+                generation_id == self.generation_id
+                and self.runner_count > 0
+                and not self.runner_ready
+            ):
+                await self.request_recovery("verification warm-up timed out")
+        except asyncio.CancelledError:
+            raise
+        finally:
+            if self._warmup_timeout_task is asyncio.current_task():
+                self._warmup_timeout_task = None
+
+    async def prepare_recovery(self, reason: str) -> None:
+        self.reset_generation()
+        self.connection_lost = False
+        self._rewarm_pending = True
+        self.last_error = reason
+        self.state_updated_at = datetime.now(UTC).isoformat()
+        self._log({
+            "event": "verification_recovery_requested",
+            "generation_id": self.generation_id,
+            "reason": reason,
+        })
+        await self.session._notify_status()
+
+    async def request_recovery(self, reason: str) -> None:
+        await self.prepare_recovery(reason)
+        if self.on_recovery is not None:
+            await self.on_recovery(self.session, reason)
+
+    def _resume_plan(
+        self,
+        resume: Any,
+    ) -> tuple[bool, str, int | None, list[dict[str, Any]]]:
+        if not self.initialized:
+            return False, "verification state is not initialized", None, []
+        if not isinstance(resume, dict):
+            return False, "verification resume state is missing", None, []
+        if str(resume.get("generation_id") or "") != self.generation_id:
+            return False, "verification generation changed", None, []
+        if not bool(resume.get("complete", False)):
+            return False, "verification pending-result history overflowed", None, []
+        source_hashes = resume.get("source_hashes") or {}
+        if source_hashes != self.source_hashes:
+            return False, "verification script source changed", None, []
+        try:
+            last_processed_ms = int(resume["last_processed_timestamp_ms"])
+            expected_timestamp_ms = int(resume["pending_bar_timestamp_ms"])
+        except (KeyError, TypeError, ValueError):
+            return False, "verification resume cursor is missing", None, []
+        if (
+            self._last_dispatched_timestamp_ms is not None
+            and last_processed_ms > self._last_dispatched_timestamp_ms
+        ):
+            return False, "verification resume cursor is ahead of dispatch", None, []
+
+        pending = [
+            payload
+            for timestamp_ms, payload in sorted(self._candle_backlog.items())
+            if timestamp_ms > last_processed_ms
+        ]
+        if (
+            self._latest_authoritative_timestamp_ms is not None
+            and self._latest_authoritative_timestamp_ms > last_processed_ms
+            and not pending
+        ):
+            return False, "verification candle backlog is incomplete", None, []
+        for payload in pending:
+            try:
+                timestamp_ms = int(payload["candle_timestamp_ms"])
+                next_timestamp_ms = int(payload["confirmed_bar_and_new_bar"][1][0])
+            except (KeyError, IndexError, TypeError, ValueError):
+                return False, "verification candle backlog is invalid", None, []
+            if timestamp_ms != expected_timestamp_ms:
+                return False, "verification candle backlog has a gap", None, []
+            expected_timestamp_ms = next_timestamp_ms
+        return True, "", last_processed_ms, pending
+
+    async def _ack_result(self, ws: WebSocket, event: dict[str, Any]) -> None:
+        try:
+            timestamp_ms = int(event["candle_timestamp_ms"])
+        except (KeyError, TypeError, ValueError):
+            return
+        await self.session.ws_manager.send(ws, {
+            "type": "verification_result_ack",
+            "generation_id": self.generation_id,
+            "candle_timestamp_ms": timestamp_ms,
+        })
+
+    async def _resume_runner(self, ws: WebSocket, resume: Any) -> tuple[bool, str]:
+        valid, reason, last_processed_ms, pending = self._resume_plan(resume)
+        if not valid or last_processed_ms is None:
+            return False, reason
+
+        async with self._protocol_lock:
+            for result in resume.get("pending_results") or []:
+                if not isinstance(result, dict):
+                    continue
+                if result.get("type") != "verification_result":
+                    continue
+                if str(result.get("generation_id") or "") != self.generation_id:
+                    continue
+                await self.record_result(result)
+                await self._ack_result(ws, result)
+
+            self._last_dispatched_timestamp_ms = last_processed_ms
+            self.runner_ready = True
+            self.connection_lost = False
+            self.last_error = None
+            self.state_updated_at = datetime.now(UTC).isoformat()
+            await self.session.ws_manager.send(ws, {
+                "type": "verification_resume_accepted",
+                "generation_id": self.generation_id,
+                "replay_count": len(pending),
+            })
+            for payload in pending:
+                await self._dispatch_payload_locked(ws, payload)
+
+        self._log({
+            "event": "verification_runner_resumed",
+            "generation_id": self.generation_id,
+            "calculated_through_ms": last_processed_ms,
+            "replayed_candles": len(pending),
+            "pending_results": len(resume.get("pending_results") or []),
+        })
+        return True, ""
+
+    async def handle_disconnect(self) -> None:
+        self.runner_count -= 1
+        if self.runner_count <= 0:
+            self.runner_count = 0
+            self.runner_ready = False
+            self.connection_lost = True
+            self.last_error = "verification runner connection lost"
+            self.state_updated_at = datetime.now(UTC).isoformat()
+            self._cancel_warmup_timeout()
+        self._log({
+            "event": "verification_runner_disconnected",
+            "generation_id": self.generation_id,
+        })
+        if self.runner_count == 0:
+            if self.on_disconnected is not None:
+                await self.on_disconnected(self.session)
+            await self.session._notify_status()
+
+    async def handle_client_hello(
+        self,
+        ws: WebSocket,
+        event: dict[str, Any],
+    ) -> None:
+        self.session.client_roles[ws] = "verification_runner"
+        self.runner_count += 1
+        self.runner_ready = False
+        self.state_updated_at = datetime.now(UTC).isoformat()
+        self._log({
+            "event": "verification_runner_connected",
+            "generation_id": self.generation_id,
+        })
+        if self.on_connected is not None:
+            await self.on_connected(self.session)
+
+        resume = event.get("verification_resume")
+        resumed = False
+        resume_reason = ""
+        if self.session.runner_ready and resume is not None:
+            resumed, resume_reason = await self._resume_runner(ws, resume)
+        if resumed:
+            if self.on_ready is not None:
+                await self.on_ready(self.session)
+            await self.session._notify_status()
+            return
+
+        reconnecting = self.connection_lost or self.initialized or resume is not None
+        if reconnecting:
+            resume_reason = resume_reason or "verification resume state is unavailable"
+            self._log({
+                "event": "verification_runner_resume_rejected",
+                "generation_id": self.generation_id,
+                "reason": resume_reason,
+            })
+            if not self._rewarm_pending:
+                self.reset_generation()
+                self._rewarm_pending = True
+            self.last_error = resume_reason
+        self.connection_lost = False
+        await self.session._notify_status()
+        if not self.session.runner_ready:
+            return
+        if (
+            self._rewarm_pending
+            and self.session.runner_phase in {"prerun_scheduled", "prerun_active"}
+        ):
+            self._log({
+                "event": "verification_warmup_deferred",
+                "generation_id": self.generation_id,
+                "runner_phase": self.session.runner_phase,
+                "next_prerun_at": self.session.next_prerun_at,
+            })
+            return
+        self._rewarm_pending = False
+        await self.send_warmup(ws)
+
+    async def handle_message(self, ws: WebSocket, event: dict[str, Any]) -> bool:
+        msg_type = event.get("type")
+        if msg_type == "client_hello" and event.get("role") == "verification_runner":
+            await self.handle_client_hello(ws, event)
+            return True
+        if msg_type == "verification_runner_ready":
+            await self._handle_runner_ready(ws, event)
+            return True
+        if msg_type in {"primary_result", "verification_result"}:
+            expected_role = (
+                "runner" if msg_type == "primary_result" else "verification_runner"
+            )
+            if self.session.client_roles.get(ws) == expected_role:
+                await self.record_result(event)
+                if msg_type == "verification_result":
+                    await self._ack_result(ws, event)
+            return True
+        if msg_type in {
+            "verification_continuity_error",
+            "verification_calculation_error",
+        }:
+            if self.session.client_roles.get(ws) != "verification_runner":
+                return True
+            reason = str(
+                event.get("error_message") or event.get("error_type") or msg_type
+            )
+            self._log({
+                "event": msg_type,
+                "generation_id": event.get("generation_id"),
+                "candle_timestamp_ms": event.get("candle_timestamp_ms"),
+                "expected_timestamp_ms": event.get("expected_timestamp_ms"),
+                "received_timestamp_ms": event.get("received_timestamp_ms"),
+                "error_type": event.get("error_type"),
+                "error_message": event.get("error_message"),
+            })
+            await self.request_recovery(reason)
+            return True
+        return False
+
+    async def _handle_runner_ready(
+        self,
+        ws: WebSocket,
+        event: dict[str, Any],
+    ) -> None:
+        if self.session.client_roles.get(ws) != "verification_runner":
+            return
+        if event.get("generation_id") != self.generation_id:
+            return
+        self.runner_ready = True
+        self.initialized = True
+        self.connection_lost = False
+        self.source_hashes = dict(event.get("source_hashes") or {})
+        self._cancel_warmup_timeout()
+        self.last_error = None
+        self.state_updated_at = datetime.now(UTC).isoformat()
+        self._log({
+            "event": "verification_runner_ready",
+            "generation_id": self.generation_id,
+            "calculated_through": event.get("calculated_through"),
+            "pending_bar_timestamp_ms": event.get("pending_bar_timestamp_ms"),
+            "source_hashes": event.get("source_hashes") or {},
+        })
+        try:
+            calculated_through_ms = int(event["calculated_through"]) * 1000
+            pending_bar_timestamp_ms = int(event["pending_bar_timestamp_ms"])
+        except (KeyError, TypeError, ValueError):
+            calculated_through_ms = None
+            pending_bar_timestamp_ms = None
+        replayed, replay_reason = await self._replay_backlog(
+            ws,
+            calculated_through_ms=calculated_through_ms,
+            pending_bar_timestamp_ms=pending_bar_timestamp_ms,
+        )
+        if not replayed:
+            self._log({
+                "event": "verification_warmup_replay_failed",
+                "generation_id": self.generation_id,
+                "reason": replay_reason,
+            })
+            self.reset_generation()
+            self.last_error = replay_reason
+            await self.send_warmup(ws)
+            return
+        if self.on_ready is not None:
+            await self.on_ready(self.session)
+        await self.session._notify_status()
+
+    async def on_primary_ready(self) -> None:
+        self._rewarm_pending = False
+        await self.send_warmup()
+
+    async def on_script_info(self) -> None:
+        if not self._rewarm_pending:
+            return
+        self._rewarm_pending = False
+        await self.send_warmup()
+
+    def on_primary_reset(self) -> None:
+        self.reset_generation()
+        self._rewarm_pending = True
+
+    async def send_warmup(self, ws: WebSocket | None = None) -> None:
+        if self.runner_count <= 0 or not self.session.runner_ready:
+            return
+        async with self.session.feed.state.lock:
+            live_bars = [list(bar) for bar in self.session.feed.state.live_bars[-2:]]
+        if len(live_bars) == 2:
+            self._initial_pending_timestamp_ms = int(live_bars[-1][0])
+            self._initial_primary_pending_resolved = False
+        else:
+            self._initial_pending_timestamp_ms = None
+            self._initial_primary_pending_resolved = True
+        payload = {
+            "type": "verification_warmup",
+            "ohlcv_path": str(self.session.feed.paths.ohlcv_path),
+            "toml_path": str(self.session.feed.paths.toml_path),
+            "confirmed_bar_and_new_bar": live_bars if len(live_bars) == 2 else None,
+            "generation_id": self.generation_id,
+        }
+        self.runner_ready = False
+        self._cancel_warmup_timeout()
+        self._warmup_timeout_task = asyncio.create_task(
+            self._warmup_timeout(self.generation_id),
+            name=f"verification-warmup-timeout:{self.session.spec.id}",
+        )
+        if ws is not None:
+            await self.session.ws_manager.send(ws, payload)
+        else:
+            await self._send_to_runners(payload)
+        self._log({
+            "event": "verification_warmup_dispatched",
+            "generation_id": self.generation_id,
+            "pending_bar_timestamp_ms": (
+                int(live_bars[-1][0]) if live_bars else None
+            ),
+        })
+
+    async def _send_to_runners(self, payload: dict[str, Any]) -> None:
+        for ws, role in list(self.session.client_roles.items()):
+            if role == "verification_runner":
+                await self.session.ws_manager.send(ws, payload)
+
+    async def _dispatch_payload_locked(
+        self,
+        ws: WebSocket | None,
+        payload: dict[str, Any],
+    ) -> None:
+        timestamp_ms = int(payload["candle_timestamp_ms"])
+        if (
+            self._last_dispatched_timestamp_ms is not None
+            and timestamp_ms <= self._last_dispatched_timestamp_ms
+        ):
+            return
+        event = dict(payload)
+        event["generation_id"] = self.generation_id
+        if ws is not None:
+            await self.session.ws_manager.send(ws, event)
+        else:
+            await self._send_to_runners(event)
+        self._last_dispatched_timestamp_ms = timestamp_ms
+        self._log({
+            "event": "verification_candle_dispatched",
+            "generation_id": self.generation_id,
+            "authoritative_source": event.get("authoritative_source"),
+            "candle_timestamp_ms": timestamp_ms,
+            "confirmed_bar": event["confirmed_bar_and_new_bar"][0],
+            "new_bar": event["confirmed_bar_and_new_bar"][1],
+        })
+
+    async def _replay_backlog(
+        self,
+        ws: WebSocket,
+        *,
+        calculated_through_ms: int | None,
+        pending_bar_timestamp_ms: int | None,
+    ) -> tuple[bool, str]:
+        if calculated_through_ms is None or pending_bar_timestamp_ms is None:
+            return False, "verification warm-up cursor is missing"
+        pending = [
+            payload
+            for timestamp_ms, payload in sorted(self._candle_backlog.items())
+            if timestamp_ms > calculated_through_ms
+        ]
+        expected_timestamp_ms = pending_bar_timestamp_ms
+        for payload in pending:
+            try:
+                timestamp_ms = int(payload["candle_timestamp_ms"])
+                next_timestamp_ms = int(payload["confirmed_bar_and_new_bar"][1][0])
+            except (KeyError, IndexError, TypeError, ValueError):
+                return False, "verification candle backlog is invalid"
+            if timestamp_ms != expected_timestamp_ms:
+                return False, "verification candle backlog has a gap after warm-up"
+            expected_timestamp_ms = next_timestamp_ms
+
+        async with self._protocol_lock:
+            self._last_dispatched_timestamp_ms = calculated_through_ms
+            for payload in pending:
+                await self._dispatch_payload_locked(ws, payload)
+        return True, ""
+
+    async def handle_candle(self, payload: dict[str, Any]) -> None:
+        try:
+            timestamp_ms = int(payload["candle_timestamp_ms"])
+        except (KeyError, TypeError, ValueError):
+            return
+        event = {
+            "type": "verification_run_ready",
+            "authoritative_source": payload.get("authoritative_source"),
+            "candle_timestamp_ms": timestamp_ms,
+            "confirmed_bar_and_new_bar": [
+                payload.get("confirmed_bar"),
+                payload.get("new_bar"),
+            ],
+        }
+        self._candle_backlog[timestamp_ms] = event
+        self._latest_authoritative_timestamp_ms = max(
+            timestamp_ms,
+            self._latest_authoritative_timestamp_ms or timestamp_ms,
+        )
+        while len(self._candle_backlog) > _MAX_CANDLE_BACKLOG:
+            self._candle_backlog.pop(min(self._candle_backlog))
+
+        if not self.runner_ready or self.runner_count <= 0:
+            self._log({
+                "event": "verification_candle_queued",
+                "reason": "verification runner is disconnected or not ready",
+                "generation_id": self.generation_id,
+                "candle_timestamp_ms": timestamp_ms,
+            })
+            return
+        async with self._protocol_lock:
+            await self._dispatch_payload_locked(None, event)
+
+    def _store_result(self, event: dict[str, Any], timestamp_ms: int) -> None:
+        target = (
+            self._primary_results
+            if event.get("type") == "primary_result"
+            else self._finalized_results
+        )
+        target[timestamp_ms] = dict(event)
+        while len(target) > _MAX_RESULTS:
+            target.pop(next(iter(target)))
+        if event.get("type") == "primary_result":
+            self.session.feed.record_verification_primary_result(event)
+        self._log({
+            "event": event.get("type"),
+            "generation_id": event.get("generation_id"),
+            "candle_timestamp_ms": timestamp_ms,
+            "confirmed_bar": event.get("confirmed_bar"),
+            "intents": event.get("intents") or [],
+            "plot_values": event.get("plot_values"),
+            "source_hashes": event.get("source_hashes") or {},
+            "result_status": event.get("result_status"),
+            "reason": event.get("reason"),
+        })
+
+    def _compare_timestamp(self, timestamp_ms: int, generation_id: str) -> None:
+        primary = self._primary_results.get(timestamp_ms)
+        finalized = self._finalized_results.get(timestamp_ms)
+        if primary is None or finalized is None:
+            return
+        fingerprint, comparison = compare_results(
+            primary,
+            finalized,
+            generation_id=generation_id,
+            timestamp_ms=timestamp_ms,
+        )
+        if fingerprint in self._comparison_fingerprints:
+            return
+        self._comparison_fingerprints.add(fingerprint)
+        self._log(comparison)
+
+    def _resolve_initial_primary_pending(
+        self,
+        event: dict[str, Any],
+        timestamp_ms: int,
+    ) -> None:
+        pending_timestamp_ms = self._initial_pending_timestamp_ms
+        if (
+            self._initial_primary_pending_resolved
+            or pending_timestamp_ms is None
+            or timestamp_ms < pending_timestamp_ms
+        ):
+            return
+        self._initial_primary_pending_resolved = True
+        if timestamp_ms == pending_timestamp_ms:
+            return
+        if pending_timestamp_ms in self._primary_results:
+            return
+
+        synthetic = {
+            "type": "primary_result",
+            "generation_id": self.generation_id,
+            "candle_timestamp_ms": pending_timestamp_ms,
+            "intents": [],
+            "plot_values": None,
+            "source_hashes": event.get("source_hashes") or {},
+            "result_status": "not_calculated",
+            "reason": "startup_partial_bar_skipped",
+        }
+        self._store_result(synthetic, pending_timestamp_ms)
+        self._compare_timestamp(pending_timestamp_ms, self.generation_id)
+
+    async def record_result(self, event: dict[str, Any]) -> None:
+        generation_id = str(event.get("generation_id") or "")
+        if generation_id != self.generation_id:
+            return
+        try:
+            timestamp_ms = int(event["candle_timestamp_ms"])
+        except (KeyError, TypeError, ValueError):
+            return
+        self._store_result(event, timestamp_ms)
+        if event.get("type") == "primary_result":
+            self._resolve_initial_primary_pending(event, timestamp_ms)
+        self._compare_timestamp(timestamp_ms, generation_id)
+
+    def _log(self, event: dict[str, Any]) -> None:
+        feed = self.session.feed.spec
+        log_session_diagnostic(
+            self.session.paths.plot_path.parent,
+            self.session.spec.id,
+            event,
+            feed={
+                "id": feed.id,
+                "provider": feed.provider,
+                "exchange": feed.exchange,
+                "symbol": feed.symbol,
+                "timeframe": feed.timeframe,
+                "market_type": feed.market_type,
+            },
+        )

--- a/data_service/verification/delivery.py
+++ b/data_service/verification/delivery.py
@@ -1,0 +1,502 @@
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import re
+import sqlite3
+import time
+from contextlib import closing
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Callable
+
+import requests
+
+try:
+    from ..config import (
+        default_telegram_chat_id,
+        default_telegram_token,
+        default_webhook_url,
+    )
+    from ..manual_alerts import post_telegram_message, webhook_request_timeout
+    from ..prerun_scheduler import timeframe_seconds
+except ImportError:
+    from config import (
+        default_telegram_chat_id,
+        default_telegram_token,
+        default_webhook_url,
+    )
+    from manual_alerts import post_telegram_message, webhook_request_timeout
+    from prerun_scheduler import timeframe_seconds
+
+
+_WEBHOOK_RETRY_DELAYS = (1.0, 2.0, 4.0)
+_QUEUE_LIMIT = 256
+
+
+@dataclass(frozen=True)
+class VerificationDeliveryRequest:
+    session_id: str
+    script_title: str
+    exchange: str
+    symbol: str
+    timeframe: str
+    candle_timestamp_ms: int
+    discrepancy: str
+    order_signal: dict[str, Any]
+    primary_bar: Any
+    finalized_bar: Any
+    bar_difference: dict[str, Any]
+    authoritative_source: str
+    notification_toggles: dict[str, bool]
+    webhook_config: dict[str, Any]
+    on_result: Callable[[dict[str, Any]], None] | None = None
+
+
+def verification_event_id(request: VerificationDeliveryRequest) -> str:
+    signal = request.order_signal
+    identity = {
+        "session_id": request.session_id,
+        "candle_timestamp_ms": request.candle_timestamp_ms,
+        "discrepancy": request.discrepancy,
+        "action": signal.get("action") or "",
+        "order_id": signal.get("order_id") or "",
+        "exit_id": signal.get("exit_id") or "",
+        "occurrence_index": int(signal.get("occurrence_index") or 0),
+    }
+    encoded = json.dumps(
+        identity,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _strategy_webhook_payload(alert_message: Any) -> Any:
+    if not isinstance(alert_message, str) or not alert_message.strip():
+        raise ValueError("original alert_message is empty")
+    normalized = re.sub(
+        r'"message"\s*:\s*(?![{["0-9])([A-Za-z][A-Za-z0-9 ]*)',
+        r'"message": "\1"',
+        alert_message,
+    )
+    parsed = json.loads(normalized)
+    if not isinstance(parsed, dict) or "message" not in parsed:
+        raise ValueError("original alert_message has no message field")
+    payload = parsed.get("message")
+    if payload == "" or payload is None:
+        raise ValueError("original alert_message payload is empty")
+    return payload
+
+
+def _short(value: Any, limit: int = 1200) -> str:
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True)
+        except Exception:
+            text = str(value)
+    text = " ".join(text.split())
+    return text if len(text) <= limit else text[:limit - 3] + "..."
+
+
+def _format_timestamp(timestamp_ms: int) -> str:
+    return datetime.fromtimestamp(timestamp_ms / 1000, tz=UTC).strftime(
+        "%Y-%m-%d %H:%M:%S UTC"
+    )
+
+
+def _format_bar(bar: Any) -> str:
+    if not isinstance(bar, (list, tuple)) or len(bar) < 6:
+        return "unavailable"
+    return (
+        f"O={bar[1]} H={bar[2]} L={bar[3]} "
+        f"C={bar[4]} V={bar[5]}"
+    )
+
+
+def _format_difference(difference: dict[str, Any]) -> str:
+    if not difference:
+        return "none"
+    parts = []
+    for field, values in difference.items():
+        if not isinstance(values, dict):
+            continue
+        parts.append(
+            f"{field}: {values.get('primary')} -> {values.get('finalized')}"
+        )
+    return ", ".join(parts) or "none"
+
+
+class VerificationDeliveryService:
+    """Deliver verification findings without blocking strategy calculations."""
+
+    def __init__(self, cache_path: Path) -> None:
+        self.cache_path = Path(cache_path)
+        self._queue: asyncio.Queue[VerificationDeliveryRequest] = asyncio.Queue(
+            maxsize=_QUEUE_LIMIT
+        )
+        self._worker: asyncio.Task | None = None
+        self._closed = False
+        self._db_initialized = False
+
+    def enqueue(self, request: VerificationDeliveryRequest) -> bool:
+        if self._closed:
+            return False
+        if self._worker is None or self._worker.done():
+            self._worker = asyncio.create_task(
+                self._run(),
+                name="verification-delivery",
+            )
+        try:
+            self._queue.put_nowait(request)
+            return True
+        except asyncio.QueueFull:
+            self._emit(request, {
+                "event": "verification_delivery_queue_full",
+                "event_id": verification_event_id(request),
+                "discrepancy": request.discrepancy,
+            })
+            return False
+
+    async def close(self) -> None:
+        self._closed = True
+        worker = self._worker
+        self._worker = None
+        if worker is not None and not worker.done():
+            worker.cancel()
+            await asyncio.gather(worker, return_exceptions=True)
+
+    async def _run(self) -> None:
+        while True:
+            request = await self._queue.get()
+            try:
+                result = await asyncio.to_thread(self._deliver, request)
+                self._emit(request, result)
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                self._emit(request, {
+                    "event": "verification_delivery_failed",
+                    "event_id": verification_event_id(request),
+                    "discrepancy": request.discrepancy,
+                    "error_type": type(exc).__name__,
+                    "error": _short(exc, 300),
+                })
+            finally:
+                self._queue.task_done()
+
+    @staticmethod
+    def _emit(
+        request: VerificationDeliveryRequest,
+        event: dict[str, Any],
+    ) -> None:
+        if request.on_result is None:
+            return
+        try:
+            request.on_result(event)
+        except Exception:
+            pass
+
+    def _connect(self) -> sqlite3.Connection:
+        self.cache_path.parent.mkdir(parents=True, exist_ok=True)
+        connection = sqlite3.connect(self.cache_path, timeout=5.0)
+        connection.execute("PRAGMA busy_timeout = 5000")
+        if not self._db_initialized:
+            connection.execute("PRAGMA journal_mode = WAL")
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS verification_deliveries (
+                    event_id TEXT NOT NULL,
+                    channel TEXT NOT NULL,
+                    status TEXT NOT NULL,
+                    attempts INTEGER NOT NULL DEFAULT 0,
+                    last_error TEXT,
+                    created_at REAL NOT NULL,
+                    updated_at REAL NOT NULL,
+                    PRIMARY KEY (event_id, channel)
+                )
+                """
+            )
+            connection.commit()
+            self._db_initialized = True
+        return connection
+
+    def _reserve(self, event_id: str, channel: str) -> bool:
+        now = time.time()
+        with closing(self._connect()) as connection:
+            cursor = connection.execute(
+                """
+                INSERT OR IGNORE INTO verification_deliveries (
+                    event_id, channel, status, attempts, created_at, updated_at
+                ) VALUES (?, ?, 'queued', 0, ?, ?)
+                """,
+                (event_id, channel, now, now),
+            )
+            connection.commit()
+            if cursor.rowcount == 1:
+                return True
+            row = connection.execute(
+                """
+                SELECT status
+                  FROM verification_deliveries
+                 WHERE event_id = ? AND channel = ?
+                """,
+                (event_id, channel),
+            ).fetchone()
+            if row is None or row[0] not in {"queued", "retrying"}:
+                return False
+            connection.execute(
+                """
+                UPDATE verification_deliveries
+                   SET status = 'queued', updated_at = ?
+                 WHERE event_id = ? AND channel = ?
+                """,
+                (now, event_id, channel),
+            )
+            connection.commit()
+            return True
+
+    def _update(
+        self,
+        event_id: str,
+        channel: str,
+        *,
+        status: str,
+        attempts: int,
+        error: str | None = None,
+    ) -> None:
+        with closing(self._connect()) as connection:
+            connection.execute(
+                """
+                UPDATE verification_deliveries
+                   SET status = ?, attempts = ?, last_error = ?, updated_at = ?
+                 WHERE event_id = ? AND channel = ?
+                """,
+                (
+                    status,
+                    attempts,
+                    _short(error, 500) if error else None,
+                    time.time(),
+                    event_id,
+                    channel,
+                ),
+            )
+            connection.commit()
+
+    def _deliver(self, request: VerificationDeliveryRequest) -> dict[str, Any]:
+        event_id = verification_event_id(request)
+        toggles = request.notification_toggles
+        missing = request.discrepancy == "missing"
+        webhook_outcome: dict[str, Any] = {"status": "not_requested", "attempts": 0}
+        telegram_outcome: dict[str, Any] = {"status": "not_requested", "attempts": 0}
+
+        if missing and bool(toggles.get("webhook")):
+            webhook_outcome = self._deliver_webhook(request, event_id)
+
+        if bool(toggles.get("telegram")):
+            telegram_outcome = self._deliver_telegram(
+                request,
+                event_id,
+                webhook_outcome,
+            )
+
+        return {
+            "event": "verification_delivery_completed",
+            "event_id": event_id,
+            "discrepancy": request.discrepancy,
+            "candle_timestamp_ms": request.candle_timestamp_ms,
+            "authoritative_source": request.authoritative_source,
+            "webhook": webhook_outcome,
+            "telegram": telegram_outcome,
+        }
+
+    def _deliver_webhook(
+        self,
+        request: VerificationDeliveryRequest,
+        event_id: str,
+    ) -> dict[str, Any]:
+        if not self._reserve(event_id, "webhook"):
+            return {"status": "duplicate", "attempts": 0}
+
+        url = str(request.webhook_config.get("url") or "").strip()
+        if not url:
+            url = default_webhook_url()
+        try:
+            payload = _strategy_webhook_payload(
+                request.order_signal.get("alert_message")
+            )
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {_short(exc, 300)}"
+            self._update(
+                event_id,
+                "webhook",
+                status="skipped",
+                attempts=0,
+                error=error,
+            )
+            return {"status": "skipped", "attempts": 0, "error": error}
+        try:
+            if not url:
+                raise ValueError("webhook URL is empty")
+            if not url.startswith(("http://", "https://")):
+                raise ValueError("webhook URL must start with http:// or https://")
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {_short(exc, 300)}"
+            self._update(
+                event_id,
+                "webhook",
+                status="failed",
+                attempts=0,
+                error=error,
+            )
+            return {"status": "failed", "attempts": 0, "error": error}
+
+        last_error = ""
+        attempts = 0
+        for attempts in range(1, len(_WEBHOOK_RETRY_DELAYS) + 2):
+            retryable = False
+            try:
+                response = requests.post(
+                    url,
+                    json=payload,
+                    headers={"X-PyneReal-Event-ID": event_id},
+                    timeout=webhook_request_timeout(request.exchange),
+                )
+                status_code = int(response.status_code)
+                if 200 <= status_code < 300:
+                    self._update(
+                        event_id,
+                        "webhook",
+                        status="sent",
+                        attempts=attempts,
+                    )
+                    return {
+                        "status": "sent",
+                        "attempts": attempts,
+                        "http_status": status_code,
+                    }
+                last_error = f"HTTP {status_code}: {_short(response.text, 300)}"
+                retryable = (
+                    status_code in {408, 429}
+                    or status_code >= 500
+                )
+            except (requests.ConnectionError, requests.Timeout) as exc:
+                last_error = f"{type(exc).__name__}: {_short(exc, 300)}"
+                retryable = True
+            except requests.RequestException as exc:
+                last_error = f"{type(exc).__name__}: {_short(exc, 300)}"
+
+            self._update(
+                event_id,
+                "webhook",
+                status="retrying" if retryable and attempts <= 3 else "failed",
+                attempts=attempts,
+                error=last_error,
+            )
+            if not retryable or attempts > len(_WEBHOOK_RETRY_DELAYS):
+                break
+            time.sleep(_WEBHOOK_RETRY_DELAYS[attempts - 1])
+
+        return {"status": "failed", "attempts": attempts, "error": last_error}
+
+    def _deliver_telegram(
+        self,
+        request: VerificationDeliveryRequest,
+        event_id: str,
+        webhook_outcome: dict[str, Any],
+    ) -> dict[str, Any]:
+        if not self._reserve(event_id, "telegram"):
+            return {"status": "duplicate", "attempts": 0}
+
+        token = str(request.webhook_config.get("telegram_token") or "").strip()
+        chat_id = str(request.webhook_config.get("telegram_chat_id") or "").strip()
+        token = token or default_telegram_token()
+        chat_id = chat_id or default_telegram_chat_id()
+        if not token or not chat_id:
+            error = "Telegram credentials are unavailable"
+            self._update(
+                event_id,
+                "telegram",
+                status="failed",
+                attempts=0,
+                error=error,
+            )
+            return {"status": "failed", "attempts": 0, "error": error}
+
+        text = self._telegram_text(request, webhook_outcome)
+        try:
+            response = post_telegram_message(token, chat_id, text)
+            status = int(response.get("status") or 0)
+            self._update(
+                event_id,
+                "telegram",
+                status="sent",
+                attempts=1,
+            )
+            return {"status": "sent", "attempts": 1, "http_status": status}
+        except Exception as exc:
+            error = f"{type(exc).__name__}: {_short(exc, 300)}"
+            self._update(
+                event_id,
+                "telegram",
+                status="failed",
+                attempts=1,
+                error=error,
+            )
+            return {"status": "failed", "attempts": 1, "error": error}
+
+    @staticmethod
+    def _telegram_text(
+        request: VerificationDeliveryRequest,
+        webhook_outcome: dict[str, Any],
+    ) -> str:
+        signal = request.order_signal
+        duration_ms = timeframe_seconds(request.timeframe) * 1000
+        delay_seconds = max(
+            0.0,
+            (time.time() * 1000 - request.candle_timestamp_ms - duration_ms) / 1000,
+        )
+        order = (
+            f"{str(signal.get('action') or '').upper()} "
+            f"order_id={signal.get('order_id') or '-'} "
+            f"exit_id={signal.get('exit_id') or '-'} "
+            f"occurrence={int(signal.get('occurrence_index') or 0) + 1}"
+        )
+        details = (
+            f"Size: {signal.get('size')} | Fill: {signal.get('fill_price')}\n"
+            f"Position: {signal.get('position_size_before')} -> "
+            f"{signal.get('position_size_after')}\n"
+            f"Signal: {_short(signal.get('alert_message') or '(none)')}\n"
+            f"Primary candle: {_format_bar(request.primary_bar)}\n"
+            f"Finalized candle: {_format_bar(request.finalized_bar)}\n"
+            f"Difference: {_format_difference(request.bar_difference)}"
+        )
+        if request.discrepancy == "missing":
+            webhook_status = webhook_outcome.get("status") or "not_requested"
+            webhook_attempts = int(webhook_outcome.get("attempts") or 0)
+            heading = "[Verification] Missed strategy order detected"
+            conclusion = (
+                f"Webhook: {webhook_status} (attempts={webhook_attempts})"
+            )
+        else:
+            heading = "[Verification] Possible false strategy order detected"
+            conclusion = (
+                "No corrective, cancel, or reverse webhook was sent."
+            )
+        return (
+            f"{heading}\n"
+            f"Session: {request.session_id}"
+            f" ({request.script_title or 'No title'})\n"
+            f"Market: {request.exchange} {request.symbol} {request.timeframe}\n"
+            f"Candle: {_format_timestamp(request.candle_timestamp_ms)}\n"
+            f"Verification source: {request.authoritative_source}\n"
+            f"Detected after: {delay_seconds:.1f}s\n"
+            f"Order: {order}\n"
+            f"{details}\n"
+            f"{conclusion}"
+        )

--- a/data_service/verification/protocol.py
+++ b/data_service/verification/protocol.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+import json
+from collections import Counter, defaultdict
+from typing import Any
+
+
+_TRADE_INTENT_TYPES = {"trade_entry", "trade_close"}
+
+
+def intent_key(intent: Any) -> str:
+    return json.dumps(
+        intent,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    )
+
+
+def intent_identity(intent: Any) -> Any:
+    if not isinstance(intent, dict) or intent.get("type") not in _TRADE_INTENT_TYPES:
+        return intent
+    return {
+        "type": intent.get("type"),
+        "time": intent.get("time"),
+        "size": intent.get("size"),
+        "id": intent.get("id") or "",
+        "exit_id": intent.get("exit_id") or "",
+        "comment": intent.get("comment") or "",
+        "occurrence_index": intent.get("occurrence_index", 0),
+    }
+
+
+def intent_identity_key(intent: Any) -> str:
+    return intent_key(intent_identity(intent))
+
+
+def index_intents(intents: list[Any]) -> dict[str, list[Any]]:
+    indexed: dict[str, list[Any]] = defaultdict(list)
+    for intent in intents:
+        indexed[intent_identity_key(intent)].append(intent)
+    return dict(indexed)
+
+
+def expand_intent_difference(
+    difference: Counter[str],
+    indexed: dict[str, list[Any]],
+) -> list[dict[str, Any]]:
+    expanded: list[dict[str, Any]] = []
+    for encoded, count in sorted(difference.items()):
+        values = indexed.get(encoded) or []
+        for value in values[:count]:
+            expanded.append(value if isinstance(value, dict) else {"raw": value})
+        if len(values) >= count:
+            continue
+        try:
+            fallback = json.loads(encoded)
+        except json.JSONDecodeError:
+            fallback = {"raw": encoded}
+        if not isinstance(fallback, dict):
+            fallback = {"raw": fallback}
+        expanded.extend([fallback] * (count - len(values)))
+    return expanded
+
+
+def intent_detail_differences(
+    primary_index: dict[str, list[Any]],
+    finalized_index: dict[str, list[Any]],
+) -> list[dict[str, Any]]:
+    differences: list[dict[str, Any]] = []
+    for identity_key in sorted(primary_index.keys() & finalized_index.keys()):
+        primary_values = primary_index[identity_key]
+        finalized_values = finalized_index[identity_key]
+        for primary, finalized in zip(primary_values, finalized_values):
+            if primary == finalized:
+                continue
+            if not isinstance(primary, dict) or not isinstance(finalized, dict):
+                continue
+            fields = {}
+            for field in sorted(primary.keys() | finalized.keys()):
+                primary_value = primary.get(field)
+                finalized_value = finalized.get(field)
+                if primary_value != finalized_value:
+                    fields[field] = {
+                        "primary": primary_value,
+                        "finalized": finalized_value,
+                    }
+            if fields:
+                differences.append({
+                    "identity": intent_identity(primary),
+                    "fields": fields,
+                })
+    return differences
+
+
+def candle_difference(
+    primary: Any,
+    finalized: Any,
+) -> dict[str, dict[str, Any]]:
+    fields = ("timestamp_ms", "open", "high", "low", "close", "volume")
+    if not isinstance(primary, (list, tuple)):
+        primary = []
+    if not isinstance(finalized, (list, tuple)):
+        finalized = []
+    difference: dict[str, dict[str, Any]] = {}
+    for index, field in enumerate(fields):
+        primary_value = primary[index] if index < len(primary) else None
+        finalized_value = finalized[index] if index < len(finalized) else None
+        if primary_value != finalized_value:
+            difference[field] = {
+                "primary": primary_value,
+                "finalized": finalized_value,
+            }
+    return difference
+
+
+def compare_results(
+    primary: dict[str, Any],
+    finalized: dict[str, Any],
+    *,
+    generation_id: str,
+    timestamp_ms: int,
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    primary_intents = list(primary.get("intents") or [])
+    finalized_intents = list(finalized.get("intents") or [])
+    primary_index = index_intents(primary_intents)
+    finalized_index = index_intents(finalized_intents)
+    primary_counter = Counter({key: len(values) for key, values in primary_index.items()})
+    finalized_counter = Counter({key: len(values) for key, values in finalized_index.items()})
+    detail_differences = intent_detail_differences(primary_index, finalized_index)
+    primary_plot = primary.get("plot_values") or {}
+    finalized_plot = finalized.get("plot_values") or {}
+    primary_hashes = primary.get("source_hashes") or {}
+    finalized_hashes = finalized.get("source_hashes") or {}
+    primary_bar = primary.get("confirmed_bar")
+    finalized_bar = finalized.get("confirmed_bar")
+    bar_difference = candle_difference(primary_bar, finalized_bar)
+    fingerprint = (
+        generation_id,
+        timestamp_ms,
+        tuple(sorted(primary_counter.items())),
+        tuple(sorted(finalized_counter.items())),
+        tuple(sorted(intent_key(item) for item in primary_intents)),
+        tuple(sorted(intent_key(item) for item in finalized_intents)),
+        intent_key(primary_plot),
+        intent_key(finalized_plot),
+        intent_key(primary_hashes),
+        intent_key(finalized_hashes),
+        intent_key(primary_bar),
+        intent_key(finalized_bar),
+        primary.get("result_status"),
+        primary.get("reason"),
+    )
+    missing_from_primary = finalized_counter - primary_counter
+    primary_only = primary_counter - finalized_counter
+    primary_result_available = primary.get("result_status") != "not_calculated"
+    comparison = {
+        "event": "verification_result_comparison",
+        "generation_id": generation_id,
+        "candle_timestamp_ms": timestamp_ms,
+        "matched": (
+            primary_result_available
+            and not missing_from_primary
+            and not primary_only
+            and not detail_differences
+            and primary_plot == finalized_plot
+            and primary_hashes == finalized_hashes
+            and not bar_difference
+        ),
+        "missing_from_primary": expand_intent_difference(
+            missing_from_primary,
+            finalized_index,
+        ),
+        "primary_only": expand_intent_difference(primary_only, primary_index),
+        "signal_intents_matched": not missing_from_primary and not primary_only,
+        "intent_details_matched": not detail_differences,
+        "intent_detail_differences": detail_differences,
+        "plot_values_matched": primary_plot == finalized_plot,
+        "primary_plot_values": primary_plot,
+        "finalized_plot_values": finalized_plot,
+        "source_hashes_matched": primary_hashes == finalized_hashes,
+        "primary_source_hashes": primary_hashes,
+        "finalized_source_hashes": finalized_hashes,
+        "confirmed_bars_matched": not bar_difference,
+        "primary_confirmed_bar": primary_bar,
+        "finalized_confirmed_bar": finalized_bar,
+        "confirmed_bar_difference": bar_difference,
+        "primary_result_status": primary.get("result_status") or "calculated",
+        "primary_result_reason": primary.get("reason"),
+        "primary_result_available": primary_result_available,
+        "supplemental_delivery_enabled": False,
+    }
+    return fingerprint, comparison

--- a/data_service/verification/protocol.py
+++ b/data_service/verification/protocol.py
@@ -6,6 +6,7 @@ from typing import Any
 
 
 _TRADE_INTENT_TYPES = {"trade_entry", "trade_close"}
+_ORDER_SIGNAL_TYPE = "order_signal"
 
 
 def intent_key(intent: Any) -> str:
@@ -19,7 +20,17 @@ def intent_key(intent: Any) -> str:
 
 
 def intent_identity(intent: Any) -> Any:
-    if not isinstance(intent, dict) or intent.get("type") not in _TRADE_INTENT_TYPES:
+    if not isinstance(intent, dict):
+        return intent
+    if intent.get("type") == _ORDER_SIGNAL_TYPE:
+        return {
+            "type": _ORDER_SIGNAL_TYPE,
+            "action": intent.get("action") or "",
+            "order_id": intent.get("order_id") or "",
+            "exit_id": intent.get("exit_id") or "",
+            "occurrence_index": intent.get("occurrence_index", 0),
+        }
+    if intent.get("type") not in _TRADE_INTENT_TYPES:
         return intent
     return {
         "type": intent.get("type"),
@@ -154,6 +165,11 @@ def compare_results(
     )
     missing_from_primary = finalized_counter - primary_counter
     primary_only = primary_counter - finalized_counter
+    missing_intents = expand_intent_difference(
+        missing_from_primary,
+        finalized_index,
+    )
+    primary_only_intents = expand_intent_difference(primary_only, primary_index)
     primary_result_available = primary.get("result_status") != "not_calculated"
     comparison = {
         "event": "verification_result_comparison",
@@ -168,11 +184,16 @@ def compare_results(
             and primary_hashes == finalized_hashes
             and not bar_difference
         ),
-        "missing_from_primary": expand_intent_difference(
-            missing_from_primary,
-            finalized_index,
-        ),
-        "primary_only": expand_intent_difference(primary_only, primary_index),
+        "missing_from_primary": missing_intents,
+        "primary_only": primary_only_intents,
+        "missing_order_signals": [
+            item for item in missing_intents
+            if item.get("type") == _ORDER_SIGNAL_TYPE
+        ],
+        "primary_only_order_signals": [
+            item for item in primary_only_intents
+            if item.get("type") == _ORDER_SIGNAL_TYPE
+        ],
         "signal_intents_matched": not missing_from_primary and not primary_only,
         "intent_details_matched": not detail_differences,
         "intent_detail_differences": detail_differences,

--- a/data_service/verification/source.py
+++ b/data_service/verification/source.py
@@ -1,0 +1,772 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+import math
+import struct
+import time
+from types import MethodType
+from typing import Any, Callable
+
+import ccxt.async_support as ccxt_async
+import ccxt.pro as ccxt_pro
+
+from exchange_clock import release_exchange_clock, retain_exchange_clock
+from market_data_diagnostics import ohlcv_bar_data
+from ohlcv_io import make_ccxt_pro_client
+from prerun_scheduler import timeframe_seconds
+
+
+_MAX_PENDING_CANDLES = 128
+_REST_STABILIZED_EXCHANGES = frozenset({"bitget", "hyperliquid"})
+_REST_FINALIZED_DELAYS_SECONDS = (1.0, 2.0, 3.0, 5.0, 8.0, 11.0)
+_REST_FINALIZED_DEGRADED_RETRY_SECONDS = 5.0
+_REST_FINALIZED_MIN_SAMPLE_INTERVAL_MS = 500
+_REST_FINALIZED_MAX_CONSECUTIVE_ERRORS = 3
+_REST_FINALIZED_LOCKS = {
+    exchange_name: asyncio.Lock()
+    for exchange_name in _REST_STABILIZED_EXCHANGES
+}
+
+
+@dataclass
+class _ReconnectTrace:
+    trace_id: int
+    candle_timestamp_ms: int
+    boundary_timestamp_ms: int
+    last_disconnect_monotonic_ns: int
+    disconnect_count: int = 1
+
+
+async def _safe_close(exchange: Any) -> None:
+    try:
+        await exchange.close()
+    except Exception:
+        pass
+
+
+def _confirmed(value: Any) -> bool:
+    if value is True or value == 1:
+        return True
+    return str(value).strip().lower() in {"1", "true"}
+
+
+def _normalize_bar(bar: Any) -> dict[str, int | float] | None:
+    if isinstance(bar, dict) and "timestamp_ms" in bar:
+        try:
+            return {
+                "timestamp_ms": int(bar["timestamp_ms"]),
+                "open": float(bar["open"]),
+                "high": float(bar["high"]),
+                "low": float(bar["low"]),
+                "close": float(bar["close"]),
+                "volume": float(bar["volume"]),
+            }
+        except (KeyError, TypeError, ValueError, OverflowError):
+            return None
+    return ohlcv_bar_data(bar)
+
+
+def _float32_bar(
+    bar: dict[str, int | float] | None,
+) -> dict[str, int | float] | None:
+    if bar is None:
+        return None
+
+    def as_float32(value: int | float) -> float:
+        return struct.unpack("f", struct.pack("f", float(value)))[0]
+
+    return {
+        "timestamp_ms": int(bar["timestamp_ms"]),
+        "open": as_float32(bar["open"]),
+        "high": as_float32(bar["high"]),
+        "low": as_float32(bar["low"]),
+        "close": as_float32(bar["close"]),
+        "volume": as_float32(bar["volume"]),
+    }
+
+
+class FinalizedCandleProbe:
+    """Produce verifier inputs from exchange-finalized candles.
+
+    Explicit-finalization exchanges use a read-only WebSocket client. Bitget
+    and Hyperliquid use a separate REST client and repeated closed-candle
+    stability checks. Neither source mutates live bars, files, caches, or
+    primary runner events.
+    """
+
+    def __init__(
+        self,
+        *,
+        exchange_name: str,
+        symbol: str,
+        timeframe: str,
+        market_type: str,
+        on_event: Callable[[dict[str, Any]], None],
+        on_authoritative: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
+        self.exchange_name = exchange_name.lower()
+        self.symbol = symbol
+        self.timeframe = timeframe
+        self.market_type = market_type
+        self.on_event = on_event
+        self.on_authoritative = on_authoritative
+        self._timeframe_ms = timeframe_seconds(timeframe) * 1000
+        self._finalized_bars: dict[int, dict[str, int | float]] = {}
+        self._published_timestamps: set[int] = set()
+        self._inferred_latest_bar: dict[str, int | float] | None = None
+        self._connection_attempt = 0
+        self._awaiting_first_message = False
+        self._pending_reconnect_trace: _ReconnectTrace | None = None
+        self._disconnect_trace_sequence = 0
+        self._primary_volumes: dict[int, float | None] = {}
+        self._primary_result_changed = asyncio.Event()
+
+    @property
+    def task_name(self) -> str:
+        if self.exchange_name in _REST_STABILIZED_EXCHANGES:
+            return f"{self.exchange_name}_rest_finalized_candle_probe"
+        return "watch_ohlcv_finalized_candle_probe"
+
+    async def run(self) -> None:
+        if self.exchange_name in _REST_STABILIZED_EXCHANGES:
+            await self.run_rest_stabilized_probe()
+            return
+        await self.run_watch_ohlcv_probe()
+
+    @property
+    def _rest_source_name(self) -> str:
+        return f"{self.exchange_name}_rest_stabilized"
+
+    def _rest_event_name(self, suffix: str) -> str:
+        return f"{self.exchange_name}_rest_finalized_{suffix}"
+
+    def record_primary_result(self, event: dict[str, Any]) -> None:
+        try:
+            timestamp_ms = int(event["candle_timestamp_ms"])
+        except (KeyError, TypeError, ValueError):
+            return
+
+        confirmed_bar = event.get("confirmed_bar")
+        volume: float | None = None
+        if (
+            event.get("result_status") != "not_calculated"
+            and isinstance(confirmed_bar, (list, tuple))
+            and len(confirmed_bar) >= 6
+        ):
+            try:
+                candidate = float(confirmed_bar[5])
+            except (TypeError, ValueError, OverflowError):
+                candidate = math.nan
+            if math.isfinite(candidate) and candidate >= 0.0:
+                volume = candidate
+
+        previous = self._primary_volumes.get(timestamp_ms)
+        if volume is not None:
+            self._primary_volumes[timestamp_ms] = max(
+                volume,
+                previous if previous is not None else volume,
+            )
+        elif timestamp_ms not in self._primary_volumes:
+            self._primary_volumes[timestamp_ms] = None
+        while len(self._primary_volumes) > _MAX_PENDING_CANDLES:
+            self._primary_volumes.pop(min(self._primary_volumes))
+        self._primary_result_changed.set()
+
+    async def _wait_for_primary_volume(
+        self,
+        target_timestamp_ms: int,
+    ) -> float | None:
+        while True:
+            if target_timestamp_ms in self._primary_volumes:
+                return self._primary_volumes[target_timestamp_ms]
+            if any(
+                timestamp_ms > target_timestamp_ms
+                for timestamp_ms in self._primary_volumes
+            ):
+                return None
+            self._primary_result_changed.clear()
+            if (
+                target_timestamp_ms in self._primary_volumes
+                or any(
+                    timestamp_ms > target_timestamp_ms
+                    for timestamp_ms in self._primary_volumes
+                )
+            ):
+                continue
+            await self._primary_result_changed.wait()
+
+    def _publish_authoritative(
+        self,
+        timestamp_ms: int,
+        *,
+        source: str = "watch_ohlcv_confirmed",
+    ) -> None:
+        if (
+            self.on_authoritative is None
+            or timestamp_ms in self._published_timestamps
+        ):
+            return
+        finalized = self._finalized_bars.get(timestamp_ms)
+        if finalized is None:
+            return
+        new_bar = self._fake_new_bar(finalized)
+        self._published_timestamps.add(timestamp_ms)
+        try:
+            self.on_authoritative({
+                "type": "verification_run_ready",
+                "authoritative_source": source,
+                "confirmed_bar": self._raw_bar(finalized),
+                "new_bar": self._raw_bar(new_bar),
+                "candle_timestamp_ms": timestamp_ms,
+            })
+        except Exception:
+            pass
+
+    def _fake_new_bar(
+        self,
+        finalized: dict[str, int | float],
+    ) -> dict[str, int | float]:
+        close = float(finalized["close"])
+        return {
+            "timestamp_ms": int(finalized["timestamp_ms"]) + self._timeframe_ms,
+            "open": close,
+            "high": close,
+            "low": close,
+            "close": close,
+            "volume": 0.0,
+        }
+
+    @staticmethod
+    def _raw_bar(bar: dict[str, int | float]) -> list[int | float]:
+        return [
+            int(bar["timestamp_ms"]),
+            float(bar["open"]),
+            float(bar["high"]),
+            float(bar["low"]),
+            float(bar["close"]),
+            float(bar["volume"]),
+        ]
+
+    def _trim(self) -> None:
+        timestamps = set(self._finalized_bars)
+        if len(timestamps) <= _MAX_PENDING_CANDLES:
+            return
+        for timestamp_ms in sorted(timestamps)[:-_MAX_PENDING_CANDLES]:
+            self._finalized_bars.pop(timestamp_ms, None)
+            self._published_timestamps.discard(timestamp_ms)
+
+    async def run_rest_stabilized_probe(self) -> None:
+        if self.exchange_name not in _REST_STABILIZED_EXCHANGES:
+            raise RuntimeError(
+                "the stabilized REST probe is only available for "
+                "Bitget and Hyperliquid"
+            )
+
+        clock = retain_exchange_clock(self.exchange_name)
+        rest_lock = _REST_FINALIZED_LOCKS[self.exchange_name]
+        source_name = self._rest_source_name
+        exchange: Any | None = None
+        target_timestamp_ms: int | None = None
+        reconnect_delay_seconds = 1.0
+        try:
+            while True:
+                try:
+                    exchange = make_ccxt_pro_client(
+                        ccxt_async,
+                        self.exchange_name,
+                        market_type=self.market_type,
+                        symbol=self.symbol,
+                    )
+                    async with rest_lock:
+                        await exchange.load_markets()
+                    if target_timestamp_ms is None:
+                        now_ms = int(await clock.now_ms())
+                        target_timestamp_ms = (
+                            now_ms // self._timeframe_ms
+                        ) * self._timeframe_ms
+                    self._emit_event({
+                        "event": self._rest_event_name("probe_started"),
+                        "source": source_name,
+                        "next_candle_timestamp_ms": target_timestamp_ms,
+                    })
+                    reconnect_delay_seconds = 1.0
+                    while True:
+                        primary_volume = await self._wait_for_primary_volume(
+                            target_timestamp_ms
+                        )
+                        if primary_volume is None:
+                            self._emit_event({
+                                "event": self._rest_event_name("skipped"),
+                                "source": source_name,
+                                "candle_timestamp_ms": target_timestamp_ms,
+                                "reason": "primary candle was not calculated",
+                            })
+                            target_timestamp_ms += self._timeframe_ms
+                            continue
+                        await self._stabilize_rest_candle(
+                            exchange,
+                            clock,
+                            rest_lock,
+                            target_timestamp_ms,
+                            primary_volume,
+                        )
+                        target_timestamp_ms += self._timeframe_ms
+                except asyncio.CancelledError:
+                    raise
+                except Exception as error:
+                    self._emit_probe_error(source_name, error)
+                    await _safe_close(exchange)
+                    exchange = None
+                    await asyncio.sleep(reconnect_delay_seconds)
+                    reconnect_delay_seconds = min(
+                        reconnect_delay_seconds * 2.0,
+                        30.0,
+                    )
+        finally:
+            await _safe_close(exchange)
+            await release_exchange_clock(self.exchange_name)
+
+    async def _stabilize_rest_candle(
+        self,
+        exchange: Any,
+        clock: Any,
+        rest_lock: asyncio.Lock,
+        target_timestamp_ms: int,
+        primary_volume: float,
+    ) -> None:
+        boundary_timestamp_ms = target_timestamp_ms + self._timeframe_ms
+        source_name = self._rest_source_name
+        previous_bar: dict[str, int | float] | None = None
+        previous_sample_completed_ms: int | None = None
+        attempt = 0
+        degraded = False
+        consecutive_errors = 0
+
+        while True:
+            if attempt < len(_REST_FINALIZED_DELAYS_SECONDS):
+                delay_seconds = _REST_FINALIZED_DELAYS_SECONDS[attempt]
+            else:
+                delay_seconds = (
+                    _REST_FINALIZED_DELAYS_SECONDS[-1]
+                    + (attempt - len(_REST_FINALIZED_DELAYS_SECONDS) + 1)
+                    * _REST_FINALIZED_DEGRADED_RETRY_SECONDS
+                )
+            requested_at_ms = boundary_timestamp_ms + int(delay_seconds * 1000)
+            if previous_sample_completed_ms is not None:
+                requested_at_ms = max(
+                    requested_at_ms,
+                    previous_sample_completed_ms
+                    + _REST_FINALIZED_MIN_SAMPLE_INTERVAL_MS,
+                )
+            await self._sleep_until_exchange_time(clock, requested_at_ms)
+
+            started = time.monotonic()
+            try:
+                async with rest_lock:
+                    rows = await exchange.fetch_ohlcv(
+                        self.symbol,
+                        self.timeframe,
+                        since=target_timestamp_ms,
+                        limit=3,
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception as error:
+                previous_bar = None
+                previous_sample_completed_ms = None
+                consecutive_errors += 1
+                self._emit_event({
+                    "event": self._rest_event_name("probe_error"),
+                    "source": source_name,
+                    "candle_timestamp_ms": target_timestamp_ms,
+                    "boundary_timestamp_ms": boundary_timestamp_ms,
+                    "attempt": attempt + 1,
+                    "requested_boundary_delay_ms": int(delay_seconds * 1000),
+                    "error_type": type(error).__name__,
+                    "error_message": str(error)[:500],
+                    "consecutive_errors": consecutive_errors,
+                })
+                attempt += 1
+                if (
+                    not degraded
+                    and delay_seconds >= _REST_FINALIZED_DELAYS_SECONDS[-1]
+                ):
+                    degraded = True
+                    self._emit_rest_pending(
+                        target_timestamp_ms,
+                        boundary_timestamp_ms,
+                        reason="REST request failed before the candle stabilized",
+                    )
+                if consecutive_errors >= _REST_FINALIZED_MAX_CONSECUTIVE_ERRORS:
+                    raise RuntimeError(
+                        f"{self.exchange_name} finalized-candle REST client failed "
+                        f"{consecutive_errors} consecutive requests"
+                    ) from error
+                continue
+
+            completed_at_ms = await clock.now_ms()
+            consecutive_errors = 0
+            normalized = [
+                bar
+                for bar in (
+                    _float32_bar(_normalize_bar(row)) for row in rows or []
+                )
+                if bar is not None
+            ]
+            target_bar = next(
+                (
+                    bar
+                    for bar in normalized
+                    if int(bar["timestamp_ms"]) == target_timestamp_ms
+                ),
+                None,
+            )
+            newer_candle_present = any(
+                int(bar["timestamp_ms"]) >= boundary_timestamp_ms
+                for bar in normalized
+            )
+            stable = (
+                target_bar is not None
+                and newer_candle_present
+                and self._bars_match(previous_bar, target_bar)
+            )
+            rest_volume = (
+                float(target_bar["volume"])
+                if target_bar is not None
+                else None
+            )
+            latest_primary_volume = self._primary_volumes.get(target_timestamp_ms)
+            if latest_primary_volume is not None:
+                primary_volume = max(primary_volume, latest_primary_volume)
+            volume_covers_primary = (
+                rest_volume is not None and rest_volume >= primary_volume
+            )
+            self._emit_event({
+                "event": self._rest_event_name("sample"),
+                "source": source_name,
+                "candle_timestamp_ms": target_timestamp_ms,
+                "boundary_timestamp_ms": boundary_timestamp_ms,
+                "attempt": attempt + 1,
+                "requested_boundary_delay_ms": int(delay_seconds * 1000),
+                "completed_boundary_delay_ms": completed_at_ms - boundary_timestamp_ms,
+                "request_elapsed_ms": (time.monotonic() - started) * 1000,
+                "response_timestamps_ms": [
+                    int(bar["timestamp_ms"]) for bar in normalized
+                ],
+                "newer_candle_present": newer_candle_present,
+                "matches_previous_sample": stable,
+                "primary_volume": primary_volume,
+                "rest_volume_covers_primary": volume_covers_primary,
+                "bar": target_bar,
+            })
+
+            if stable and volume_covers_primary and target_bar is not None:
+                self._record_rest_finalized(target_bar, source=source_name)
+                self._emit_event({
+                    "event": self._rest_event_name("accepted"),
+                    "source": source_name,
+                    "candle_timestamp_ms": target_timestamp_ms,
+                    "boundary_timestamp_ms": boundary_timestamp_ms,
+                    "accepted_boundary_delay_ms": completed_at_ms - boundary_timestamp_ms,
+                    "attempts": attempt + 1,
+                    "recovered_from_pending": degraded,
+                    "primary_volume": primary_volume,
+                    "bar": target_bar,
+                })
+                return
+
+            previous_bar = (
+                target_bar
+                if target_bar is not None and newer_candle_present
+                else None
+            )
+            previous_sample_completed_ms = (
+                completed_at_ms if previous_bar is not None else None
+            )
+            attempt += 1
+            if (
+                not degraded
+                and delay_seconds >= _REST_FINALIZED_DELAYS_SECONDS[-1]
+            ):
+                degraded = True
+                reason = "REST candle did not stabilize by the initial deadline"
+                if stable and not volume_covers_primary:
+                    reason = "REST candle volume remained below Primary volume"
+                self._emit_rest_pending(
+                    target_timestamp_ms,
+                    boundary_timestamp_ms,
+                    reason=reason,
+                )
+
+    @staticmethod
+    async def _sleep_until_exchange_time(clock: Any, target_ms: int) -> None:
+        while True:
+            remaining_seconds = (target_ms - await clock.now_ms()) / 1000
+            if remaining_seconds <= 0.0:
+                return
+            await asyncio.sleep(remaining_seconds)
+
+    def _emit_rest_pending(
+        self,
+        candle_timestamp_ms: int,
+        boundary_timestamp_ms: int,
+        *,
+        reason: str,
+    ) -> None:
+        self._emit_event({
+            "event": self._rest_event_name("pending"),
+            "source": self._rest_source_name,
+            "candle_timestamp_ms": candle_timestamp_ms,
+            "boundary_timestamp_ms": boundary_timestamp_ms,
+            "reason": reason,
+        })
+
+    def _record_rest_finalized(
+        self,
+        bar: dict[str, int | float],
+        *,
+        source: str,
+    ) -> None:
+        timestamp_ms = int(bar["timestamp_ms"])
+        if timestamp_ms in self._published_timestamps:
+            return
+        self._finalized_bars[timestamp_ms] = bar
+        self._publish_authoritative(
+            timestamp_ms,
+            source=source,
+        )
+        self._trim()
+
+    async def run_watch_ohlcv_probe(self) -> None:
+        if self.exchange_name in _REST_STABILIZED_EXCHANGES:
+            raise RuntimeError(
+                f"{self.exchange_name} verification must use stabilized REST OHLCV"
+            )
+        while True:
+            exchange = make_ccxt_pro_client(
+                ccxt_pro,
+                self.exchange_name,
+                market_type=self.market_type,
+                symbol=self.symbol,
+            )
+            self._connection_attempt += 1
+            attempt = self._connection_attempt
+            self._awaiting_first_message = True
+            self._emit_event({
+                "event": "finalized_candle_probe_connection_attempt",
+                "source": "watch_ohlcv_confirmed",
+                "connection_attempt": attempt,
+                "reconnecting": self._pending_reconnect_trace is not None,
+                "trace_id": (
+                    self._pending_reconnect_trace.trace_id
+                    if self._pending_reconnect_trace is not None
+                    else None
+                ),
+            })
+            try:
+                self._install_raw_ohlcv_observer(exchange, attempt)
+                self._inferred_latest_bar = None
+                while True:
+                    rows = await exchange.watch_ohlcv(
+                        self.symbol,
+                        self.timeframe,
+                        None,
+                        None,
+                        {},
+                    )
+                    self._observe_inferred_confirmation(rows)
+            except asyncio.CancelledError:
+                await _safe_close(exchange)
+                raise
+            except Exception as error:
+                self._begin_disconnect_trace()
+                self._emit_probe_error("watch_ohlcv_confirmed", error)
+                await _safe_close(exchange)
+                await asyncio.sleep(1.0)
+
+    def _install_raw_ohlcv_observer(self, exchange: Any, attempt: int) -> None:
+        original_handler = exchange.handle_ohlcv
+
+        def handle_ohlcv(instance: Any, client: Any, message: Any) -> Any:
+            try:
+                self._observe_raw_ohlcv_message(instance, message, attempt)
+                for bar in self._explicit_finalized_bars(instance, message):
+                    self._record_ws_finalized(bar)
+            except Exception as error:
+                self._emit_probe_error("watch_ohlcv_raw_handler", error)
+            return original_handler(client, message)
+
+        exchange.handle_ohlcv = MethodType(handle_ohlcv, exchange)
+
+    def _observe_raw_ohlcv_message(
+        self,
+        exchange: Any,
+        message: Any,
+        attempt: int,
+    ) -> None:
+        if self._awaiting_first_message:
+            self._awaiting_first_message = False
+            trace = self._pending_reconnect_trace
+            downtime_ms = None
+            if trace is not None:
+                downtime_ms = (
+                    time.monotonic_ns() - trace.last_disconnect_monotonic_ns
+                ) / 1_000_000
+            self._emit_event({
+                "event": "finalized_candle_probe_first_message",
+                "source": "watch_ohlcv_confirmed",
+                "connection_attempt": attempt,
+                "reconnected": trace is not None,
+                "trace_id": trace.trace_id if trace is not None else None,
+                "candle_timestamp_ms": (
+                    trace.candle_timestamp_ms if trace is not None else None
+                ),
+                "disconnect_to_first_message_ms": downtime_ms,
+                "server_timestamp_ms": self._message_timestamp_ms(message),
+                "action": message.get("action") if isinstance(message, dict) else None,
+            })
+            self._pending_reconnect_trace = None
+
+    @staticmethod
+    def _message_timestamp_ms(message: Any) -> int | None:
+        if not isinstance(message, dict):
+            return None
+        try:
+            return int(message.get("ts"))
+        except (TypeError, ValueError):
+            return None
+
+    def _begin_disconnect_trace(self) -> None:
+        now_ms = int(time.time() * 1000)
+        now_monotonic_ns = time.monotonic_ns()
+        candle_timestamp_ms = (now_ms // self._timeframe_ms) * self._timeframe_ms
+        self._disconnect_trace_sequence += 1
+        trace = _ReconnectTrace(
+            trace_id=self._disconnect_trace_sequence,
+            candle_timestamp_ms=candle_timestamp_ms,
+            boundary_timestamp_ms=candle_timestamp_ms + self._timeframe_ms,
+            last_disconnect_monotonic_ns=now_monotonic_ns,
+        )
+        self._pending_reconnect_trace = trace
+        self._emit_event({
+            "event": "finalized_candle_probe_disconnected",
+            "source": "watch_ohlcv_confirmed",
+            "trace_id": trace.trace_id,
+            "candle_timestamp_ms": trace.candle_timestamp_ms,
+            "boundary_timestamp_ms": trace.boundary_timestamp_ms,
+            "boundary_in_ms": trace.boundary_timestamp_ms - now_ms,
+            "disconnect_count": trace.disconnect_count,
+        })
+
+    @staticmethod
+    def _bars_match(
+        left: dict[str, int | float] | None,
+        right: dict[str, int | float] | None,
+    ) -> bool:
+        if left is None or right is None:
+            return False
+        if int(left["timestamp_ms"]) != int(right["timestamp_ms"]):
+            return False
+        return all(
+            math.isclose(
+                float(left[field_name]),
+                float(right[field_name]),
+                rel_tol=1e-12,
+                abs_tol=1e-12,
+            )
+            for field_name in ("open", "high", "low", "close", "volume")
+        )
+
+    def _explicit_finalized_bars(
+        self,
+        exchange: Any,
+        message: Any,
+    ) -> list[list[Any]]:
+        if not isinstance(message, dict):
+            return []
+        if self.exchange_name == "binance":
+            kline = message.get("k")
+            if not isinstance(kline, dict) or not _confirmed(kline.get("x")):
+                return []
+            return [[
+                exchange.safe_integer(kline, "t"),
+                exchange.safe_float(kline, "o"),
+                exchange.safe_float(kline, "h"),
+                exchange.safe_float(kline, "l"),
+                exchange.safe_float(kline, "c"),
+                exchange.safe_float(kline, "v"),
+            ]]
+
+        if self.exchange_name == "okx":
+            arg = message.get("arg") or {}
+            market_id = arg.get("instId")
+            market = exchange.safe_market(market_id)
+            finalized: list[list[Any]] = []
+            for row in message.get("data") or []:
+                raw_confirm = row[8] if isinstance(row, list) and len(row) > 8 else None
+                if _confirmed(raw_confirm):
+                    finalized.append(exchange.parse_ohlcv(row, market))
+            return finalized
+
+        if self.exchange_name == "bybit":
+            market = exchange.market(self.symbol)
+            finalized = []
+            for row in message.get("data") or []:
+                if not isinstance(row, dict) or not _confirmed(row.get("confirm")):
+                    continue
+                finalized.append(exchange.parse_ws_ohlcv(row, market))
+            return finalized
+
+        return []
+
+    def _observe_inferred_confirmation(self, rows: Any) -> None:
+        normalized = [
+            bar
+            for bar in (_normalize_bar(row) for row in rows or [])
+            if bar is not None
+        ]
+        if not normalized:
+            return
+        latest = max(normalized, key=lambda item: int(item["timestamp_ms"]))
+        previous = self._inferred_latest_bar
+        self._inferred_latest_bar = latest
+        if previous is None:
+            return
+        if int(latest["timestamp_ms"]) <= int(previous["timestamp_ms"]):
+            return
+        previous_timestamp_ms = int(previous["timestamp_ms"])
+        finalized = next(
+            (
+                bar
+                for bar in normalized
+                if int(bar["timestamp_ms"]) == previous_timestamp_ms
+            ),
+            previous,
+        )
+        self._record_ws_finalized(finalized)
+
+    def _record_ws_finalized(self, bar: Any) -> None:
+        normalized = _normalize_bar(bar)
+        if normalized is None:
+            return
+        timestamp_ms = int(normalized["timestamp_ms"])
+        if timestamp_ms in self._finalized_bars:
+            return
+        self._finalized_bars[timestamp_ms] = normalized
+        self._publish_authoritative(timestamp_ms)
+        self._trim()
+
+    def _emit_event(self, event: dict[str, Any]) -> None:
+        try:
+            self.on_event(event)
+        except Exception:
+            pass
+
+    def _emit_probe_error(self, source: str, error: Exception) -> None:
+        self._emit_event({
+            "event": "finalized_candle_probe_error",
+            "source": source,
+            "error_type": type(error).__name__,
+            "error_message": str(error)[:500],
+        })

--- a/pynecore/core/exchange_policy.py
+++ b/pynecore/core/exchange_policy.py
@@ -20,6 +20,11 @@ _FETCH_CURRENT_OPEN_EXCHANGES = {
     "HYPERLIQUID",
 }
 
+_PREVIOUS_CLOSE_OPEN_EXCHANGES = {
+    "BITGET",
+    "BYBIT",
+}
+
 
 def normalize_exchange_name(exchange: str | None) -> str:
     return (exchange or "").upper()
@@ -31,3 +36,7 @@ def tradingview_hides_zero_volume(exchange: str | None) -> bool:
 
 def fetch_current_open_from_exchange(exchange: str | None) -> bool:
     return normalize_exchange_name(exchange) in _FETCH_CURRENT_OPEN_EXCHANGES
+
+
+def previous_close_is_next_open(exchange: str | None) -> bool:
+    return normalize_exchange_name(exchange) in _PREVIOUS_CLOSE_OPEN_EXCHANGES

--- a/pynecore/lib/strategy/__init__.py
+++ b/pynecore/lib/strategy/__init__.py
@@ -385,6 +385,7 @@ class Position:
         'risk_cons_loss_days', 'risk_last_day_index', 'risk_last_day_equity',
         'risk_intraday_filled_orders', 'risk_intraday_start_equity', 'risk_halt_trading',
         'on_entry_callback', 'on_close_callback', 'on_alert_callback', 'on_ai_callback',
+        'on_order_signal_callback',
         '_entry_open_ledger'
     )
 
@@ -465,6 +466,7 @@ class Position:
         self.on_close_callback = None
         self.on_alert_callback = None
         self.on_ai_callback = None
+        self.on_order_signal_callback = None
 
     @property
     def equity(self) -> float | NA[float]:
@@ -584,6 +586,7 @@ class Position:
         :param h: The high price
         :param l: The low price
         """
+        position_size_before = float(self.size)
         # Save the original order size before any modifications
         filled_size = abs(order.size)
 
@@ -886,9 +889,42 @@ class Position:
                 # Use the saved original filled_size from the beginning of this method
                 self._reduce_oca_group(order.oca_name, filled_size)
 
-        self._dispatch_order_notifications(order)
+        self._dispatch_order_notifications(
+            order,
+            filled_size=filled_size,
+            fill_price=price,
+            position_size_before=position_size_before,
+            position_size_after=float(self.size),
+        )
 
-    def _dispatch_order_notifications(self, order: Order) -> None:
+    @staticmethod
+    def _order_signal_action(
+            order: Order,
+            position_size_before: float,
+            position_size_after: float,
+    ) -> str:
+        if order.order_type == _order_type_close:
+            return "close"
+        if order.order_type == _order_type_entry:
+            return "entry"
+        if position_size_before != 0.0:
+            same_direction = position_size_before * position_size_after > 0.0
+            if position_size_after == 0.0 or (
+                    same_direction
+                    and abs(position_size_after) < abs(position_size_before)
+            ):
+                return "close"
+        return "entry"
+
+    def _dispatch_order_notifications(
+            self,
+            order: Order,
+            *,
+            filled_size: float,
+            fill_price: float,
+            position_size_before: float,
+            position_size_after: float,
+    ) -> None:
         if not realtime_trade() and order.alert_message:
             alert(order.alert_message, _dispatch_callback=False)
         elif realtime_trade() and not pre_run():
@@ -896,6 +932,32 @@ class Position:
             # Real time trade 에서는 최종 봉이 확정되고 새로운 봉이 생길때에만
             # alert 및 AI instruction을 전달함.
             if order.bar_index == last_bar_index() - 1:
+                if self.on_order_signal_callback:
+                    try:
+                        self.on_order_signal_callback({
+                            "action": self._order_signal_action(
+                                order,
+                                position_size_before,
+                                position_size_after,
+                            ),
+                            "time": int(lib._time / 1000),
+                            "order_id": order.order_id or "",
+                            "exit_id": order.exit_id or "",
+                            "size": float(filled_size),
+                            "direction": (
+                                "buy" if order.sign > 0.0
+                                else "sell" if order.sign < 0.0
+                                else ""
+                            ),
+                            "comment": order.comment or "",
+                            "alert_message": order.alert_message or "",
+                            "fill_price": float(fill_price),
+                            "order_bar_index": int(order.bar_index),
+                            "position_size_before": position_size_before,
+                            "position_size_after": position_size_after,
+                        })
+                    except Exception as e:
+                        print(f"Error in on_order_signal_callback: {e}")
                 if order.alert_message:
                     alert(order.alert_message, _dispatch_callback=False)
                 if order.alert_message and self.on_alert_callback:

--- a/runner_service/appendable_iter.py
+++ b/runner_service/appendable_iter.py
@@ -81,6 +81,11 @@ class AppendableIterable(Generic[T]):
             self._q[-1] = item
             self._cv.notify()
 
+    def discard_last(self) -> None:
+        with self._cv:
+            if self._q:
+                self._q.pop()
+
     def close(self) -> None:
         """더 이상 아이템을 넣지 않을 때 호출. 반복자는 큐를 모두 비우면 종료합니다."""
         with self._cv:

--- a/runner_service/evaluation_intents.py
+++ b/runner_service/evaluation_intents.py
@@ -7,10 +7,21 @@ from typing import Any
 
 _MAX_RECORDED_TRADE_IDENTITIES = 4096
 _TRADE_INTENT_TYPES = {"trade_entry", "trade_close"}
+_ORDER_SIGNAL_TYPE = "order_signal"
 
 
 def trade_intent_identity(intent: dict[str, Any]) -> str | None:
-    if intent.get("type") not in _TRADE_INTENT_TYPES:
+    intent_type = intent.get("type")
+    if intent_type == _ORDER_SIGNAL_TYPE:
+        identity = {
+            "type": intent_type,
+            "evaluation_candle_time": intent.get("evaluation_candle_time"),
+            "action": intent.get("action") or "",
+            "order_id": intent.get("order_id") or "",
+            "exit_id": intent.get("exit_id") or "",
+        }
+        return json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+    if intent_type not in _TRADE_INTENT_TYPES:
         return None
     identity = {
         "type": intent.get("type"),

--- a/runner_service/evaluation_intents.py
+++ b/runner_service/evaluation_intents.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+from collections import Counter, deque
+from typing import Any
+
+
+_MAX_RECORDED_TRADE_IDENTITIES = 4096
+_TRADE_INTENT_TYPES = {"trade_entry", "trade_close"}
+
+
+def trade_intent_identity(intent: dict[str, Any]) -> str | None:
+    if intent.get("type") not in _TRADE_INTENT_TYPES:
+        return None
+    identity = {
+        "type": intent.get("type"),
+        "time": intent.get("time"),
+        "size": intent.get("size"),
+        "id": intent.get("id") or "",
+        "exit_id": intent.get("exit_id") or "",
+        "comment": intent.get("comment") or "",
+    }
+    return json.dumps(identity, sort_keys=True, separators=(",", ":"), default=str)
+
+
+class EvaluationIntentRecorder:
+    """Collect per-candle comparison intents without changing live event delivery."""
+
+    def __init__(self, max_trade_history: int = _MAX_RECORDED_TRADE_IDENTITIES) -> None:
+        self.max_trade_history = max(1, int(max_trade_history))
+        self._intents: list[dict[str, Any]] = []
+        self._occurrences: Counter[str] = Counter()
+        self._recorded_trade_keys: set[tuple[str, int]] = set()
+        self._recorded_trade_order: deque[tuple[str, int]] = deque()
+
+    def reset(self) -> None:
+        self._intents.clear()
+        self._occurrences.clear()
+        self._recorded_trade_keys.clear()
+        self._recorded_trade_order.clear()
+
+    def begin_candle(self) -> None:
+        self._intents.clear()
+        self._occurrences.clear()
+
+    def record(
+        self,
+        event: dict[str, Any],
+        *,
+        evaluation_candle_time: int,
+        suppress_trade_replays: bool,
+    ) -> bool:
+        payload = dict(event)
+        payload["evaluation_candle_time"] = int(evaluation_candle_time)
+
+        identity = trade_intent_identity(payload)
+        if identity is not None:
+            occurrence = self._occurrences[identity]
+            self._occurrences[identity] += 1
+            payload["occurrence_index"] = occurrence
+            replay_key = (identity, occurrence)
+            if suppress_trade_replays:
+                if replay_key in self._recorded_trade_keys:
+                    return False
+                self._recorded_trade_keys.add(replay_key)
+                self._recorded_trade_order.append(replay_key)
+                while len(self._recorded_trade_order) > self.max_trade_history:
+                    expired = self._recorded_trade_order.popleft()
+                    self._recorded_trade_keys.discard(expired)
+
+        self._intents.append(payload)
+        return True
+
+    def snapshot(self) -> list[dict[str, Any]]:
+        return [dict(intent) for intent in self._intents]

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -304,6 +304,15 @@ def on_close_event(trade, runner=None):
     _record_evaluation_intent(event)
 
 
+def on_order_signal_event(order_signal: dict[str, Any], runner=None) -> None:
+    """Record one comparison intent for one filled strategy order."""
+    if runner is not None and getattr(runner.script, "pre_run", False):
+        return
+    event = dict(order_signal)
+    event["type"] = "order_signal"
+    _record_evaluation_intent(event)
+
+
 def on_plot_event(plot_data):
     """Callback for plot events - stores/updates plot options"""
     title = plot_data['title']
@@ -527,6 +536,10 @@ AppendableIterable[OHLCV], OHLCVReader] | None:
             # Register trade event callbacks
             runner.script.position.on_entry_callback = partial(on_entry_event, runner=runner)
             runner.script.position.on_close_callback = partial(on_close_event, runner=runner)
+            runner.script.position.on_order_signal_callback = partial(
+                on_order_signal_event,
+                runner=runner,
+            )
             runner.script.position.on_alert_callback = partial(on_alert_event, runner=runner)
             runner.script.position.on_ai_callback = partial(on_ai_event, runner=runner)
             # Register plot event callback
@@ -683,6 +696,10 @@ def build_calculation_result(
         "intents": evaluation_intents.snapshot(),
         "plot_values": plot_values,
         "source_hashes": ACTIVE_SOURCE_HASHES,
+        "notification_toggles": {
+            "webhook": bool(WEBHOOK_ENABLED),
+            "telegram": bool(TELEGRAM_ENABLED),
+        },
     }
 
 
@@ -1458,6 +1475,9 @@ async def main():
                         build_result=build_calculation_result,
                         generation_id=generation_id,
                     )
+                )
+                result_payload["authoritative_source"] = msg.get(
+                    "authoritative_source"
                 )
                 VERIFICATION_RESUME_STATE.remember(
                     result_payload,

--- a/runner_service/main.py
+++ b/runner_service/main.py
@@ -20,7 +20,13 @@ import numpy as np
 import websockets
 
 from appendable_iter import AppendableIterable
+from evaluation_intents import EvaluationIntentRecorder
 from strategy_snapshot import build_strategy_snapshot
+from verification import (
+    VerificationContinuityError,
+    VerificationResumeState,
+    calculate_candle as calculate_verification_candle,
+)
 from pynecore.cli.app import app_state
 from pynecore.core.ohlcv_file import OHLCVReader
 from pynecore.core.exchange_policy import normalize_exchange_name, tradingview_hides_zero_volume
@@ -33,6 +39,7 @@ SCRIPT_PATH: Path | None = None
 SCRIPT_HASH_PATH: Path | None = None  # CSV path for persisted script hashes.
 PLOT_PATH: Path | None = None  # per-session plot CSV path (from --plot-path).
 SESSION_ID: str = "default"
+RUNNER_ROLE: str = "primary"
 # Live webhook/telegram toggles for this session (decision 8-1). Updated at
 # startup from args/env and at runtime via the "webhook_config" WS message.
 WEBHOOK_ENABLED: bool = False
@@ -43,6 +50,7 @@ WEBHOOK_URL: str = ""
 TELEGRAM_TOKEN: str = ""
 TELEGRAM_CHAT_ID: str = ""
 SUPPRESS_EXTERNAL_NOTIFICATIONS: bool = False
+ALWAYS_SUPPRESS_EXTERNAL_NOTIFICATIONS: bool = False
 DEFAULT_WEBHOOK_REQUEST_TIMEOUT = (5, 10)
 HYPERLIQUID_WEBHOOK_REQUEST_TIMEOUT = (5, 30)
 TELEGRAM_REQUEST_TIMEOUT = (5, 10)
@@ -55,6 +63,11 @@ trade_event_queue = deque()
 plot_options = {}
 # Event queue for plotchar events
 plotchar_event_queue = deque()
+# Normalized per-candle intents used only for primary/verification comparison.
+evaluation_intents = EvaluationIntentRecorder()
+CURRENT_EVALUATION_TIMESTAMP: int | None = None
+ACTIVE_SOURCE_HASHES: dict[str, str] = {}
+VERIFICATION_RESUME_STATE = VerificationResumeState()
 
 
 def extract_script_title(script_path: Path) -> str:
@@ -235,7 +248,18 @@ def send_webhook_message(webhook_url: str, message: str, *, script_title: str | 
 def clear_local_state() -> None:
     trade_event_queue.clear()
     plotchar_event_queue.clear()
+    evaluation_intents.reset()
     plot_options.clear()
+
+
+def _record_evaluation_intent(event: dict[str, Any]) -> None:
+    if CURRENT_EVALUATION_TIMESTAMP is None:
+        return
+    evaluation_intents.record(
+        event,
+        evaluation_candle_time=CURRENT_EVALUATION_TIMESTAMP,
+        suppress_trade_replays=RUNNER_ROLE == "primary",
+    )
 
 
 def on_entry_event(trade, runner=None):
@@ -259,6 +283,7 @@ def on_entry_event(trade, runner=None):
         "comment": trade.entry_comment if trade.entry_comment else ""
     }
     trade_event_queue.append(event)
+    _record_evaluation_intent(event)
 
 
 def on_close_event(trade, runner=None):
@@ -276,6 +301,7 @@ def on_close_event(trade, runner=None):
         "profit": float(trade.profit)
     }
     trade_event_queue.append(event)
+    _record_evaluation_intent(event)
 
 
 def on_plot_event(plot_data):
@@ -321,10 +347,15 @@ def on_plotchar_event(plotchar_data):
         "size": plotchar_data.get('size')
     }
     plotchar_event_queue.append(event)
+    _record_evaluation_intent(event)
 
 
 def on_alert_event(message: str, runner: ScriptRunner):
     """Callback for alert events - webhook/telegram notifications"""
+    _record_evaluation_intent({
+        "type": "alert",
+        "message": message,
+    })
     if SUPPRESS_EXTERNAL_NOTIFICATIONS:
         return
     script = runner.script
@@ -359,7 +390,7 @@ def on_alert_event(message: str, runner: ScriptRunner):
 
 def on_ai_event(instruction: str, order, bar_time: int, runner: ScriptRunner):
     """Queue one deterministic AI instruction event for a realtime order fill."""
-    if SUPPRESS_EXTERNAL_NOTIFICATIONS:
+    if SUPPRESS_EXTERNAL_NOTIFICATIONS and RUNNER_ROLE == "primary":
         return
     instruction = str(instruction or "").strip()
     if not instruction or getattr(runner.script, "pre_run", False):
@@ -378,7 +409,7 @@ def on_ai_event(instruction: str, order, bar_time: int, runner: ScriptRunner):
     event_id = hashlib.sha256(
         json.dumps(identity, ensure_ascii=False, sort_keys=True).encode("utf-8")
     ).hexdigest()
-    trade_event_queue.append({
+    event = {
         "type": "ai_instruction",
         "event_id": event_id,
         "instruction": instruction,
@@ -387,7 +418,10 @@ def on_ai_event(instruction: str, order, bar_time: int, runner: ScriptRunner):
         "bar_index": identity["bar_index"],
         "order_id": identity["order_id"],
         "comment": str(getattr(order, "comment", "") or ""),
-    })
+    }
+    _record_evaluation_intent(event)
+    if not SUPPRESS_EXTERNAL_NOTIFICATIONS:
+        trade_event_queue.append(event)
 
 
 def hide_zero_volume_bars(exchange: str | None) -> bool:
@@ -623,6 +657,49 @@ class RunnerCtx:
     stream: AppendableIterable[OHLCV] | None
     reader: OHLCVReader | None
     last_new_bar_ts_sec: int
+    generation_id: str = ""
+
+
+def build_calculation_result(
+    *,
+    role: str,
+    generation_id: str,
+    confirmed_ohlcv: OHLCV,
+    plot_values: dict[str, float | int | None] | None,
+) -> dict[str, Any]:
+    confirmed_bar = [
+        int(confirmed_ohlcv.timestamp) * 1000,
+        float(confirmed_ohlcv.open),
+        float(confirmed_ohlcv.high),
+        float(confirmed_ohlcv.low),
+        float(confirmed_ohlcv.close),
+        float(confirmed_ohlcv.volume),
+    ]
+    return {
+        "type": f"{role}_result",
+        "generation_id": generation_id,
+        "candle_timestamp_ms": confirmed_bar[0],
+        "confirmed_bar": confirmed_bar,
+        "intents": evaluation_intents.snapshot(),
+        "plot_values": plot_values,
+        "source_hashes": ACTIVE_SOURCE_HASHES,
+    }
+
+
+async def send_calculation_result(
+    ws,
+    *,
+    role: str,
+    generation_id: str,
+    confirmed_ohlcv: OHLCV,
+    plot_values: dict[str, float | int | None] | None,
+) -> None:
+    await ws.send(json.dumps(build_calculation_result(
+        role=role,
+        generation_id=generation_id,
+        confirmed_ohlcv=confirmed_ohlcv,
+        plot_values=plot_values,
+    )))
 
 
 async def ws_loop():
@@ -630,26 +707,41 @@ async def ws_loop():
         try:
             async with websockets.connect(DATA_WS, ping_interval=None) as ws:
                 try:
-                    await ws.send(json.dumps({"type": "client_hello", "role": "runner",
-                                              "session_id": SESSION_ID}))
+                    role = (
+                        "verification_runner"
+                        if RUNNER_ROLE == "verification"
+                        else "runner"
+                    )
+                    hello = {
+                        "type": "client_hello",
+                        "role": role,
+                        "session_id": SESSION_ID,
+                    }
+                    resume = VERIFICATION_RESUME_STATE.payload(
+                        enabled=RUNNER_ROLE == "verification"
+                    )
+                    if resume is not None:
+                        hello["verification_resume"] = resume
+                    await ws.send(json.dumps(hello))
                 except Exception:
                     pass
-                try:
-                    if SCRIPT_PATH and SCRIPT_PATH.exists():
-                        await ws.send(json.dumps(build_script_info_payload(SCRIPT_PATH)))
-                except Exception as e:
-                    print(f"[runner] Failed to send script_info (connect): {e}")
-                try:
-                    if SCRIPT_PATH and SCRIPT_PATH.exists():
-                        current_hashes = compute_script_hashes(SCRIPT_PATH)
-                        previous_hashes = load_script_hashes(SCRIPT_HASH_PATH)
-                        if current_hashes != previous_hashes:
-                            # Only reset when script contents changed.
-                            await ws.send(json.dumps({"type": "reset_history"}))
-                            clear_local_state()
-                            write_script_hashes(SCRIPT_HASH_PATH, current_hashes)
-                except Exception as e:
-                    print(f"[runner] Failed to send reset_history: {e}")
+                if RUNNER_ROLE == "primary":
+                    try:
+                        if SCRIPT_PATH and SCRIPT_PATH.exists():
+                            await ws.send(json.dumps(build_script_info_payload(SCRIPT_PATH)))
+                    except Exception as e:
+                        print(f"[runner] Failed to send script_info (connect): {e}")
+                    try:
+                        if SCRIPT_PATH and SCRIPT_PATH.exists():
+                            current_hashes = compute_script_hashes(SCRIPT_PATH)
+                            previous_hashes = load_script_hashes(SCRIPT_HASH_PATH)
+                            if current_hashes != previous_hashes:
+                                # Only reset when script contents changed.
+                                await ws.send(json.dumps({"type": "reset_history"}))
+                                clear_local_state()
+                                write_script_hashes(SCRIPT_HASH_PATH, current_hashes)
+                    except Exception as e:
+                        print(f"[runner] Failed to send reset_history: {e}")
 
                 async def keepalive():
                     while True:
@@ -684,6 +776,7 @@ def parse_timeframe_to_ms(tf: str) -> int:
 def parse_runner_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description="PyneReal runner_service")
     p.add_argument("--session-id")
+    p.add_argument("--role", choices=("primary", "verification"), default="primary")
     p.add_argument("--data-service-ws")
     p.add_argument("--provider")
     p.add_argument("--exchange")
@@ -760,11 +853,15 @@ async def main():
     if not script_path.exists():
         raise RuntimeError(f"script not found: {script_path}")
 
-    global SCRIPT_PATH, SCRIPT_HASH_PATH, DATA_WS, PLOT_PATH, SESSION_ID
+    global SCRIPT_PATH, SCRIPT_HASH_PATH, DATA_WS, PLOT_PATH, SESSION_ID, RUNNER_ROLE
     global WEBHOOK_ENABLED, TELEGRAM_ENABLED, WEBHOOK_URL, TELEGRAM_TOKEN, TELEGRAM_CHAT_ID
-    global SUPPRESS_EXTERNAL_NOTIFICATIONS
+    global SUPPRESS_EXTERNAL_NOTIFICATIONS, ALWAYS_SUPPRESS_EXTERNAL_NOTIFICATIONS
+    global CURRENT_EVALUATION_TIMESTAMP, ACTIVE_SOURCE_HASHES
     SCRIPT_PATH = script_path
     SESSION_ID = _resolve(args.session_id, "PYNEREAL_SESSION_ID", None, default="default")
+    RUNNER_ROLE = str(args.role or "primary")
+    ALWAYS_SUPPRESS_EXTERNAL_NOTIFICATIONS = RUNNER_ROLE == "verification"
+    SUPPRESS_EXTERNAL_NOTIFICATIONS = ALWAYS_SUPPRESS_EXTERNAL_NOTIFICATIONS
 
     # Per-session script-hash path (decision: avoid multi-runner contention).
     hash_path = _resolve(args.hash_path, "PYNEREAL_HASH_PATH", None)
@@ -794,7 +891,7 @@ async def main():
 
     from datetime import datetime
     started_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    print(f"[{started_at}] [runner] started | session={SESSION_ID} tf={tf} "
+    print(f"[{started_at}] [runner] started | role={RUNNER_ROLE} session={SESSION_ID} tf={tf} "
           f"script={script_name} ws={DATA_WS}")
 
     # Exit if the spawning hub dies, so a killed/crashed hub never leaves an
@@ -826,6 +923,22 @@ async def main():
 
         mtype = msg.get("type")
 
+        if mtype == "verification_result_ack":
+            VERIFICATION_RESUME_STATE.acknowledge(
+                str(msg.get("generation_id") or ""),
+                msg.get("candle_timestamp_ms"),
+            )
+            continue
+
+        if mtype == "verification_resume_accepted":
+            if (
+                RUNNER_ROLE == "verification"
+                and ctx is not None
+                and str(msg.get("generation_id") or "") == ctx.generation_id
+            ):
+                ready_sent = True
+            continue
+
         # -----------------------------
         # Live per-session webhook toggle (decision 8-1)
         # -----------------------------
@@ -844,7 +957,12 @@ async def main():
         # -----------------------------
         # Pre script run stage
         # -----------------------------
-        if (mtype == "prerun_ready") or (mtype == "prerun_ready_after_history_download"):
+        if mtype in {
+            "prerun_ready",
+            "prerun_ready_after_history_download",
+            "verification_warmup",
+        }:
+            verification_warmup = mtype == "verification_warmup"
             # Send ACK immediately for prerun_ready_after_history_download
             if mtype == "prerun_ready_after_history_download":
                 try:
@@ -859,16 +977,28 @@ async def main():
                 print("[runner] prerun_ready received but file missing:", ohlcv_path, toml_path)
                 continue
 
-            # Prevent the duplicate prerun_ready event
+            # A new verification generation replaces the previous in-memory state.
             if ctx is not None:
-                continue
+                if not verification_warmup:
+                    continue
+                try:
+                    ctx.runner.destroy()
+                    if ctx.stream is not None:
+                        ctx.stream.finish()
+                    if ctx.reader is not None:
+                        ctx.reader.close()
+                except Exception:
+                    pass
+                ctx = None
 
             try:
                 current_hashes = compute_script_hashes(SCRIPT_PATH)
+                ACTIVE_SOURCE_HASHES = dict(current_hashes)
                 previous_hashes = load_script_hashes(SCRIPT_HASH_PATH)
                 if current_hashes != previous_hashes:
-                    pending_full_reemit = True
-                    await ws.send(json.dumps({"type": "script_modified"}))
+                    pending_full_reemit = RUNNER_ROLE == "primary"
+                    if RUNNER_ROLE == "primary":
+                        await ws.send(json.dumps({"type": "script_modified"}))
                     clear_local_state()
                     write_script_hashes(SCRIPT_HASH_PATH, current_hashes)
                 elif (
@@ -888,6 +1018,17 @@ async def main():
             if result is None:
                 from datetime import datetime
                 print(f"[{datetime.now().strftime('%y-%m-%d %H:%M:%S')}] [runner] failed to prepare runner")
+                if verification_warmup:
+                    VERIFICATION_RESUME_STATE.reset()
+                    try:
+                        await ws.send(json.dumps({
+                            "type": "verification_calculation_error",
+                            "generation_id": str(msg.get("generation_id") or ""),
+                            "error_type": "VerificationWarmupError",
+                            "error_message": "failed to prepare verification runner",
+                        }))
+                    except Exception as e:
+                        print(f"[runner] Failed to report verification warm-up error: {e}")
                 continue
             else:
                 runner, stream, reader = result
@@ -912,7 +1053,9 @@ async def main():
                 int(confirmed_bar.timestamp) if confirmed_bar is not None else None
             )
             runner.script.pre_run = True
-            if mtype == "prerun_ready_after_history_download":
+            if verification_warmup:
+                runner.script.pre_run = True
+            elif mtype == "prerun_ready_after_history_download":
                 prerun_range = size
                 runner.script.pre_run = False
             elif pending_full_reemit:
@@ -925,8 +1068,11 @@ async def main():
                 # run_ready, so no spurious last-bar alert fires (its fill bar isn't stepped).
                 runner.script.pre_run = False
             SUPPRESS_EXTERNAL_NOTIFICATIONS = bool(
-                mtype == "prerun_ready_after_history_download"
-                and msg.get("history_resync")
+                ALWAYS_SUPPRESS_EXTERNAL_NOTIFICATIONS
+                or (
+                    mtype == "prerun_ready_after_history_download"
+                    and msg.get("history_resync")
+                )
             )
             try:
                 prerun_plot_values = await asyncio.to_thread(
@@ -936,10 +1082,51 @@ async def main():
                     confirmed_bar_time,
                 )
             finally:
-                SUPPRESS_EXTERNAL_NOTIFICATIONS = False
+                SUPPRESS_EXTERNAL_NOTIFICATIONS = ALWAYS_SUPPRESS_EXTERNAL_NOTIFICATIONS
             if runner.plot_writer:
                 runner.plot_writer.flush()
             pending_full_reemit = False
+
+            if verification_warmup:
+                confirmed_bar_and_new_bar = msg.get("confirmed_bar_and_new_bar")
+                if (
+                    isinstance(confirmed_bar_and_new_bar, list)
+                    and len(confirmed_bar_and_new_bar) == 2
+                ):
+                    last_new_ts_sec = int(confirmed_bar_and_new_bar[1][0] / 1000)
+                else:
+                    last_new_ts_sec = int(reader.end_timestamp or 0)
+                ctx = RunnerCtx(
+                    runner=runner,
+                    stream=stream,
+                    reader=reader,
+                    last_new_bar_ts_sec=last_new_ts_sec,
+                    generation_id=str(msg.get("generation_id") or ""),
+                )
+                VERIFICATION_RESUME_STATE.reset(
+                    generation_id=ctx.generation_id,
+                    last_processed_timestamp_ms=(
+                        int(confirmed_bar_time) * 1000
+                        if confirmed_bar_time is not None
+                        else None
+                    ),
+                    pending_bar_timestamp_ms=last_new_ts_sec * 1000,
+                    source_hashes=ACTIVE_SOURCE_HASHES,
+                )
+                trade_event_queue.clear()
+                plotchar_event_queue.clear()
+                try:
+                    await ws.send(json.dumps({
+                        "type": "verification_runner_ready",
+                        "generation_id": str(msg.get("generation_id") or ""),
+                        "calculated_through": confirmed_bar_time,
+                        "pending_bar_timestamp_ms": last_new_ts_sec * 1000,
+                        "source_hashes": ACTIVE_SOURCE_HASHES,
+                    }))
+                    ready_sent = True
+                except Exception as e:
+                    print(f"[runner] Failed to send verification_runner_ready: {e}")
+                continue
 
             # The re-sync plot.csv and historical markers are complete. Reload chart
             # pages now so an earlier runner-connected reload cannot leave stale data.
@@ -1064,6 +1251,9 @@ async def main():
 
             confirmed_ohlcv = bar_list_to_ohlcv(confirmed_bar)
             new_ohlcv = bar_list_to_ohlcv(new_bar)
+            evaluation_intents.begin_candle()
+            CURRENT_EVALUATION_TIMESTAMP = int(confirmed_ohlcv.timestamp)
+            confirmed_plot_values = None
             hide_zero_volume = hide_zero_volume_bars(getattr(ctx.runner.syminfo, "prefix", None))
             # confirmed_visible decides whether this just-closed candle should run one strategy step.
             # new_visible decides whether the newly opened candle should be kept as the next open bar.
@@ -1133,7 +1323,6 @@ async def main():
 
                 # Calculate the last confirmed bar
                 ctx.runner.script.pre_run = False
-                confirmed_plot_values = None
                 while True:
                     step_res = ctx.runner.step()
                     if step_res is None:
@@ -1210,12 +1399,115 @@ async def main():
                         ),
                     )
 
+            verification_generation_id = str(
+                msg.get("verification_generation_id") or ""
+            )
+            if verification_generation_id:
+                try:
+                    await send_calculation_result(
+                        ws,
+                        role="primary",
+                        generation_id=verification_generation_id,
+                        confirmed_ohlcv=confirmed_ohlcv,
+                        plot_values=confirmed_plot_values,
+                    )
+                except Exception as e:
+                    print(f"[runner] Failed to send primary_result: {e}")
+            CURRENT_EVALUATION_TIMESTAMP = None
+
             # Remove the script_module using destroy() (required). If you don't remove it,
             # the ScriptRunner will reuse the previous candle data even when reloading the script.
             ctx.runner.destroy()
             ctx.stream = None
             ctx.reader.close()
             ctx = None
+
+        elif mtype == "verification_run_ready":
+            if RUNNER_ROLE != "verification" or ctx is None:
+                continue
+            generation_id = str(msg.get("generation_id") or "")
+            if generation_id != ctx.generation_id:
+                continue
+
+            confirmed_bar_and_new_bar = msg.get("confirmed_bar_and_new_bar")
+            if (
+                not isinstance(confirmed_bar_and_new_bar, list)
+                or len(confirmed_bar_and_new_bar) != 2
+            ):
+                continue
+            try:
+                evaluation_timestamp = int(
+                    confirmed_bar_and_new_bar[0][0] / 1000
+                )
+            except (IndexError, TypeError, ValueError):
+                continue
+            evaluation_intents.begin_candle()
+            trade_event_queue.clear()
+            plotchar_event_queue.clear()
+            CURRENT_EVALUATION_TIMESTAMP = evaluation_timestamp
+
+            try:
+                result_payload, confirmed_ohlcv, new_ohlcv = (
+                    calculate_verification_candle(
+                        ctx,
+                        confirmed_bar_and_new_bar,
+                        bar_list_to_ohlcv=bar_list_to_ohlcv,
+                        hide_zero_volume_bars=hide_zero_volume_bars,
+                        is_visible_ohlcv=is_visible_ohlcv,
+                        plot_values_from_step=_plot_values_from_step,
+                        build_result=build_calculation_result,
+                        generation_id=generation_id,
+                    )
+                )
+                VERIFICATION_RESUME_STATE.remember(
+                    result_payload,
+                    pending_bar_timestamp_ms=int(new_ohlcv.timestamp) * 1000,
+                )
+            except Exception as e:
+                if isinstance(e, VerificationContinuityError):
+                    error_payload = {
+                        "type": "verification_continuity_error",
+                        "generation_id": generation_id,
+                        "expected_timestamp_ms": e.expected_timestamp_ms,
+                        "received_timestamp_ms": e.received_timestamp_ms,
+                    }
+                else:
+                    error_payload = {
+                        "type": "verification_calculation_error",
+                        "generation_id": generation_id,
+                        "candle_timestamp_ms": evaluation_timestamp * 1000,
+                        "error_type": type(e).__name__,
+                        "error_message": str(e)[:500],
+                    }
+                try:
+                    ctx.runner.destroy()
+                    if ctx.stream is not None:
+                        ctx.stream.finish()
+                    if ctx.reader is not None:
+                        ctx.reader.close()
+                except Exception:
+                    pass
+                ctx = None
+                ready_sent = False
+                VERIFICATION_RESUME_STATE.reset()
+                try:
+                    await ws.send(json.dumps(error_payload))
+                except Exception as send_error:
+                    print(
+                        "[runner] Failed to send verification calculation error: "
+                        f"{send_error}"
+                    )
+            else:
+                try:
+                    await ws.send(json.dumps(result_payload))
+                except Exception as e:
+                    # The calculation state and unacknowledged result are retained.
+                    # They are advertised in client_hello after reconnect.
+                    print(f"[runner] Failed to send verification_result: {e}")
+            finally:
+                CURRENT_EVALUATION_TIMESTAMP = None
+                trade_event_queue.clear()
+                plotchar_event_queue.clear()
 
         else:
             continue

--- a/runner_service/verification.py
+++ b/runner_service/verification.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+from pynecore import lib
+from pynecore.core.script_runner import _set_lib_properties
+from pynecore.lib.request import get_security_ctx
+from pynecore.types.ohlcv import OHLCV
+
+
+_MAX_PENDING_RESULTS = 128
+
+
+@dataclass
+class VerificationResumeState:
+    generation_id: str = ""
+    last_processed_timestamp_ms: int | None = None
+    pending_bar_timestamp_ms: int | None = None
+    source_hashes: dict[str, str] = field(default_factory=dict)
+    pending_results: dict[int, dict[str, Any]] = field(default_factory=dict)
+    complete: bool = True
+
+    def payload(self, *, enabled: bool) -> dict[str, Any] | None:
+        if not enabled or not self.generation_id:
+            return None
+        return {
+            "generation_id": self.generation_id,
+            "last_processed_timestamp_ms": self.last_processed_timestamp_ms,
+            "pending_bar_timestamp_ms": self.pending_bar_timestamp_ms,
+            "source_hashes": dict(self.source_hashes),
+            "pending_results": list(self.pending_results.values()),
+            "complete": self.complete,
+        }
+
+    def reset(
+        self,
+        *,
+        generation_id: str = "",
+        last_processed_timestamp_ms: int | None = None,
+        pending_bar_timestamp_ms: int | None = None,
+        source_hashes: dict[str, str] | None = None,
+    ) -> None:
+        self.generation_id = generation_id
+        self.last_processed_timestamp_ms = last_processed_timestamp_ms
+        self.pending_bar_timestamp_ms = pending_bar_timestamp_ms
+        self.source_hashes = dict(source_hashes or {})
+        self.pending_results.clear()
+        self.complete = True
+
+    def remember(
+        self,
+        payload: dict[str, Any],
+        *,
+        pending_bar_timestamp_ms: int,
+    ) -> None:
+        timestamp_ms = int(payload["candle_timestamp_ms"])
+        self.last_processed_timestamp_ms = timestamp_ms
+        self.pending_bar_timestamp_ms = int(pending_bar_timestamp_ms)
+        self.pending_results[timestamp_ms] = dict(payload)
+        while len(self.pending_results) > _MAX_PENDING_RESULTS:
+            self.pending_results.pop(next(iter(self.pending_results)))
+            self.complete = False
+
+    def acknowledge(self, generation_id: str, candle_timestamp_ms: Any) -> None:
+        if generation_id != self.generation_id:
+            return
+        try:
+            timestamp_ms = int(candle_timestamp_ms)
+        except (TypeError, ValueError):
+            return
+        self.pending_results.pop(timestamp_ms, None)
+
+
+class VerificationContinuityError(RuntimeError):
+    def __init__(self, expected_timestamp_ms: int, received_timestamp_ms: int) -> None:
+        super().__init__(
+            "verification candle continuity mismatch: "
+            f"expected={expected_timestamp_ms} received={received_timestamp_ms}"
+        )
+        self.expected_timestamp_ms = expected_timestamp_ms
+        self.received_timestamp_ms = received_timestamp_ms
+
+
+def calculate_candle(
+    ctx: Any,
+    confirmed_bar_and_new_bar: list[Any],
+    *,
+    bar_list_to_ohlcv: Callable[[list[Any]], OHLCV],
+    hide_zero_volume_bars: Callable[[str | None], bool],
+    is_visible_ohlcv: Callable[..., bool],
+    plot_values_from_step: Callable[
+        [tuple[Any, ...] | None, int | None],
+        dict[str, float | int | None] | None,
+    ],
+    build_result: Callable[..., dict[str, Any]],
+    generation_id: str,
+) -> tuple[dict[str, Any], OHLCV, OHLCV]:
+    confirmed_ohlcv = bar_list_to_ohlcv(confirmed_bar_and_new_bar[0])
+    new_ohlcv = bar_list_to_ohlcv(confirmed_bar_and_new_bar[1])
+    expected_timestamp = int(ctx.last_new_bar_ts_sec)
+    if int(confirmed_ohlcv.timestamp) != expected_timestamp:
+        raise VerificationContinuityError(
+            expected_timestamp * 1000,
+            int(confirmed_ohlcv.timestamp) * 1000,
+        )
+
+    hide_zero_volume = hide_zero_volume_bars(
+        getattr(ctx.runner.syminfo, "prefix", None)
+    )
+    confirmed_visible = is_visible_ohlcv(
+        confirmed_ohlcv,
+        hide_zero_volume=hide_zero_volume,
+    )
+    new_visible = is_visible_ohlcv(
+        new_ohlcv,
+        hide_zero_volume=hide_zero_volume,
+    )
+    confirmed_plot_values = None
+
+    if confirmed_visible:
+        pending = ctx.stream.q
+        if pending:
+            pending_timestamp = int(pending[-1].timestamp)
+            if pending_timestamp != int(confirmed_ohlcv.timestamp):
+                raise RuntimeError(
+                    "verification pending candle mismatch: "
+                    f"expected={confirmed_ohlcv.timestamp} "
+                    f"actual={pending_timestamp}"
+                )
+            ctx.stream.replace_last(confirmed_ohlcv)
+        else:
+            ctx.stream.append(confirmed_ohlcv)
+
+        # run_iter() increments bar_index before evaluating the queued candle.
+        # While paused here, runner.bar_index still points to the prior candle.
+        confirmed_bar_index = int(ctx.runner.bar_index) + 1
+        if new_visible:
+            ctx.stream.append(new_ohlcv)
+
+        ctx.runner.last_bar_index = confirmed_bar_index + (1 if new_visible else 0)
+        # The realtime gate treats the evaluated candle as last_bar_index - 1,
+        # including exchanges whose zero-volume next candle remains hidden.
+        ctx.runner.script.last_bar_index = confirmed_bar_index + 1
+
+        security_ctx = get_security_ctx()
+        if security_ctx is not None:
+            security_ctx.update_base_bar(confirmed_ohlcv, confirmed_bar_index)
+            if new_visible:
+                security_ctx.update_base_bar(new_ohlcv, confirmed_bar_index + 1)
+
+        ctx.runner.script.pre_run = False
+        step_res = ctx.runner.step()
+        if step_res is None:
+            raise RuntimeError("verification runner produced no candle")
+        step_candle = step_res[0]
+        if int(step_candle.timestamp) != int(confirmed_ohlcv.timestamp):
+            raise RuntimeError(
+                "verification runner stepped unexpected candle: "
+                f"expected={confirmed_ohlcv.timestamp} "
+                f"actual={step_candle.timestamp}"
+            )
+        confirmed_plot_values = plot_values_from_step(
+            step_res,
+            int(confirmed_ohlcv.timestamp),
+        )
+
+        # Orders created on the confirmed candle fill on the synthetic next bar
+        # without executing that new candle's strategy body.
+        if ctx.runner.script.position is not None:
+            _set_lib_properties(
+                new_ohlcv,
+                confirmed_bar_index + 1,
+                ctx.runner.tz,
+                lib,
+            )
+            ctx.runner.script.position.process_orders()
+    else:
+        pending = ctx.stream.q
+        if pending and int(pending[-1].timestamp) == int(confirmed_ohlcv.timestamp):
+            ctx.stream.discard_last()
+        if new_visible:
+            ctx.stream.append(new_ohlcv)
+
+    ctx.last_new_bar_ts_sec = int(new_ohlcv.timestamp)
+    result = build_result(
+        role="verification",
+        generation_id=generation_id,
+        confirmed_ohlcv=confirmed_ohlcv,
+        plot_values=confirmed_plot_values,
+    )
+    return result, confirmed_ohlcv, new_ohlcv


### PR DESCRIPTION
## 변경 내용
- Primary 러너와 독립된 확정봉 검증 러너를 세션별로 구동하고 OHLCV, 주문 신호, plot 결과 및 소스 해시를 비교합니다.
- 거래소별 확정봉 소스를 사용하며 연속성 오류, 스크립트 변경, 데이터 복구 및 프로세스 장애 시 검증 러너를 자동 복구합니다.
- 주기 REST 갱신에서 직전 확정봉의 거래량이 역행하지 않도록 보호합니다.
- Primary에서 누락된 주문 신호는 당시 알림 설정에 따라 웹훅과 텔레그램으로 보완 전송하고, Primary에만 존재하는 오신호 가능성은 텔레그램으로 알립니다.
- 보완 전송을 비동기 큐로 분리하고 SQLite 이벤트 원장과 고정 이벤트 ID로 채널별 중복 전송을 방지합니다.
- 대시보드에서 검증 러너 상태를 확인하고 수동 재시작할 수 있으며, 최근 누락 또는 오신호 가능성 1건을 표시합니다.

## 운영 동작
- Primary 확정봉 계산 경로에서는 비교 자료만 기록하며 네트워크 및 SQLite I/O는 수행하지 않습니다.
- 검증 러너는 Primary 러너가 실행 중일 때만 동작하고 기존 러너 재시작 및 Update 복구 흐름에 함께 연결됩니다.
- 보완 전송 결과와 상세 비교 자료는 세션별 진단 JSONL에 기록되며, 전송 원장은 실제 전송 대상이 발생할 때 생성됩니다.
- 최근 발견 항목은 러너 상태와 분리해 표시하며 data_service 재시작 또는 스크립트 재설정 시 초기화됩니다.